### PR TITLE
Add note about MSRV compile failure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ This version of Parley has been verified to compile with **Rust 1.70** and later
 Future versions of Parley might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
 
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some of Parley's dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+</details>
+
 ## Community
 
 Discussion of Parley development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#text stream](https://xi.zulipchat.com/#narrow/stream/205635-text).


### PR DESCRIPTION
This PR adds the note about how to deal with MSRV compilation failures. I optimistically didn't add it in #33 because the Rust toolchain can give basically the same instructions:

```sh
error: package `peniko v0.1.0` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.67.1
Either upgrade to rustc 1.70 or newer, or use
cargo update -p peniko@0.1.0 --precise ver
where `ver` is the latest version of `peniko` supporting rustc 1.67.1
```

However this nice error message is only given if `rust-version` is correctly specified by the dependency. In other cases it will be some much more obscure error about the specific code that can't be handled.

Given that we hide these instructions behind `<details/>` it won't cause too much noise and can be helpful in those obscure error scenarios.