### PR TITLE
Don't track variations at default location

### DIFF
--- a/src/layout/data.rs
+++ b/src/layout/data.rs
@@ -245,7 +245,10 @@ impl<B: Brush> LayoutData<B> {
         let metrics = shaper.metrics();
         let cluster_range = self.clusters.len()..self.clusters.len();
         let coords_start = self.coords.len();
-        self.coords.extend_from_slice(shaper.normalized_coords());
+        let coords = shaper.normalized_coords();
+        if coords.iter().any(|coord| *coord != 0) {
+            self.coords.extend_from_slice(coords);
+        }
         let coords_end = self.coords.len();
         let mut run = RunData {
             font_index,


### PR DESCRIPTION
For variable fonts, when all normalized coordinates are equal to 0, that is equivalent to the default location in variation space and all variation processing can be disabled.

Detect this when pushing a new shaped run and don't store the unnecessary coordinates.

This "fixes" a current performance problem in vello where glyphs from variable fonts are not cached. This effectively forces variable glyphs at the default location to be treated as non-variable allowing them to be cached.