### PR TITLE
Convert dependency status images to crate based.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Latest published parley version.](https://img.shields.io/crates/v/parley.svg)](https://crates.io/crates/parley)
 [![Documentation build status.](https://img.shields.io/docsrs/parley.svg)](https://docs.rs/parley)
-[![Dependency staleness status.](https://deps.rs/repo/github/linebender/parley/status.svg)](https://deps.rs/repo/github/linebender/parley)
+[![Dependency staleness status.](https://deps.rs/crate/parley/latest/status.svg)](https://deps.rs/crate/parley)
 [![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23text-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/205635-text)
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 

--- a/fontique/README.md
+++ b/fontique/README.md
@@ -6,7 +6,7 @@
 
 [![Latest published fontique version.](https://img.shields.io/crates/v/fontique.svg)](https://crates.io/crates/fontique)
 [![Documentation build status.](https://img.shields.io/docsrs/fontique.svg)](https://docs.rs/fontique)
-[![Dependency staleness status.](https://deps.rs/repo/github/linebender/fontique/status.svg)](https://deps.rs/repo/github/linebender/fontique)
+[![Dependency staleness status.](https://deps.rs/crate/fontique/latest/status.svg)](https://deps.rs/crate/fontique)
 [![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23text-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/205635-text)
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 


### PR DESCRIPTION
The `fontique` dependency status image was wrong because it was pointing to a non-existent repo. While the `parley` one was showing an out-of-date dependency that was actually `fontique`'s dependency.

This PR converts these images to be crate based instead, like this:

[![Dependency staleness status.](https://deps.rs/crate/vello/latest/status.svg)](https://deps.rs/crate/vello)