### PR TITLE
[deps] Revert fontique dep `roxmltree` to 0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,9 +426,12 @@ dependencies = [
 
 [[package]]
 name = "roxmltree"
-version = "0.19.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
+checksum = "862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302"
+dependencies = [
+ "xmlparser",
+]
 
 [[package]]
 name = "serde"
@@ -590,6 +593,12 @@ name = "writeable"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad7bb64b8ef9c0aa27b6da38b452b0ee9fd82beaf276a87dd796fb55cbae14e"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yazi"

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -45,4 +45,4 @@ anyhow = "1.0.82"
 bytemuck = { version = "1.15.0", features = ["derive"] }
 fontconfig-cache-parser = "0.2.0"
 thiserror = "1.0.58"
-roxmltree = "0.19.0"
+roxmltree = "0.18.1" # Beware! Updating this to 0.19 broke masonry tests.


### PR DESCRIPTION
The update to 0.19.0 broke the masonry tests in the xilem repo on Ubuntu.