### PR TITLE
coretext: Get `CFRange` from `core-foundation`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,6 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "core-foundation",
- "core-foundation-sys",
  "core-text",
  "core_maths",
  "dwrote",

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -38,7 +38,6 @@ wio = "0.2.2"
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
 core-text = "20.1.0"
 core-foundation = "0.9.4"
-core-foundation-sys = "0.8.6"
 
 [target.'cfg(not(any(target_os="macos", target_os="ios", target_family="windows")))'.dependencies]
 anyhow = "1.0.82"

--- a/fontique/src/backend/coretext.rs
+++ b/fontique/src/backend/coretext.rs
@@ -8,11 +8,10 @@ use alloc::sync::Arc;
 use hashbrown::HashMap;
 use {
     core_foundation::{
-        base::TCFType,
+        base::{CFRange, TCFType},
         dictionary::CFDictionary,
         string::{CFString, CFStringRef},
     },
-    core_foundation_sys::base::CFRange,
     core_text::{
         font::{self, kCTFontSystemFontType, CTFont, CTFontRef, CTFontUIFontType},
         font_descriptor,


### PR DESCRIPTION
Remove a direct dependency on `core-foundation-sys` by getting `CFRange` from a re-export in `core-foundation`.