### PR TITLE
fontique: Enable builds for iOS and other Apple targets.

### DIFF
--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -35,10 +35,10 @@ dwrote = "0.11.0"
 winapi = { version = "0.3.9", features = ["dwrite", "dwrite_1", "dwrite_3", "winnt", "unknwnbase", "libloaderapi", "winnls"] }
 wio = "0.2.2"
 
-[target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
+[target.'cfg(target_vendor="apple")'.dependencies]
 core-text = "20.1.0"
 core-foundation = "0.9.4"
 
-[target.'cfg(not(any(target_os="macos", target_os="ios", target_family="windows")))'.dependencies]
+[target.'cfg(not(any(target_vendor="apple", target_family="windows")))'.dependencies]
 fontconfig-cache-parser = "0.2.0"
 roxmltree = "0.19.0"

--- a/fontique/src/backend/mod.rs
+++ b/fontique/src/backend/mod.rs
@@ -7,7 +7,7 @@
 #[path = "dwrite.rs"]
 mod system;
 
-#[cfg(all(feature = "system", target_os = "macos"))]
+#[cfg(all(feature = "system", target_vendor = "apple"))]
 #[path = "coretext.rs"]
 mod system;
 


### PR DESCRIPTION
Backend selection for iOS wasn't hooked up.

Also added support for tvOS as it is the same as iOS here.