### PR TITLE
lints: Enable `warn(unused_qualifications)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
 [workspace.package]
 edition = "2021"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml and with the relevant README.md files.
+# TODO: When this hits 1.74, move lint configuration into this file via a lints table.
 rust-version = "1.70"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/parley"

--- a/fontique/src/backend/fontconfig/config.rs
+++ b/fontique/src/backend/fontconfig/config.rs
@@ -175,10 +175,7 @@ fn include_config(path: &Path, sink: &mut impl ParserSink) -> std::io::Result<()
     Ok(())
 }
 
-fn resolve_dir(
-    node: Node,
-    config_file_path: impl AsRef<std::path::Path>,
-) -> Option<std::path::PathBuf> {
+fn resolve_dir(node: Node, config_file_path: impl AsRef<Path>) -> Option<std::path::PathBuf> {
     let dir_path = node.text()?;
     let (xdg_env, xdg_fallback) = match node.tag_name().name() {
         "include" => ("XDG_CONFIG_HOME", "~/.config"),

--- a/fontique/src/font.rs
+++ b/fontique/src/font.rs
@@ -170,7 +170,7 @@ impl FontInfo {
     pub(crate) fn from_font_ref(font: &FontRef, source: SourceInfo, index: u32) -> Option<Self> {
         let (stretch, style, weight) = read_attributes(font);
         let (axes, attr_axes) = if let Ok(fvar_axes) = font.fvar().and_then(|fvar| fvar.axes()) {
-            let mut axes = smallvec::SmallVec::<[AxisInfo; 1]>::with_capacity(fvar_axes.len());
+            let mut axes = SmallVec::<[AxisInfo; 1]>::with_capacity(fvar_axes.len());
             let mut attrs_axes = 0u8;
             for fvar_axis in fvar_axes {
                 let axis = AxisInfo {

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Font enumeration and fallback.
 
+#![warn(unused_qualifications)]
 // TODO: Remove this dead code allowance and hide the offending code behind the std feature gate.
 #![cfg_attr(not(feature = "std"), allow(dead_code))]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]

--- a/fontique/src/script.rs
+++ b/fontique/src/script.rs
@@ -43,7 +43,7 @@ impl fmt::Debug for Script {
     }
 }
 
-impl core::fmt::Display for Script {
+impl fmt::Display for Script {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", core::str::from_utf8(&self.0).unwrap_or_default())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Rich text layout.
 
+#![warn(unused_qualifications)]
 // TODO: Remove this dead code allowance and hide the offending code behind the std feature gate.
 #![cfg_attr(not(feature = "std"), allow(dead_code))]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -12,7 +12,7 @@ use crate::util::nearly_eq;
 use crate::Font;
 #[cfg(feature = "std")]
 use fontique::QueryFamily;
-use fontique::{self, Attributes, Query, QueryFont};
+use fontique::{self, Query, QueryFont};
 use swash::shape::*;
 #[cfg(feature = "std")]
 use swash::text::cluster::{CharCluster, CharInfo, Token};
@@ -166,7 +166,7 @@ struct FontSelector<'a, 'b, B: Brush> {
     rcx: &'a ResolveContext,
     styles: &'a [RangedStyle<B>],
     style_index: u16,
-    attrs: Attributes,
+    attrs: fontique::Attributes,
     variations: &'a [FontVariation],
     features: &'a [FontFeature],
 }


### PR DESCRIPTION
This helps point out where the code can be more concistent with an identifier already being in scope and not needing qualifications.