### PR TITLE
fontique: README can link to own copy of LICENSE.

### DIFF
--- a/fontique/README.md
+++ b/fontique/README.md
@@ -46,8 +46,8 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](../LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 


### PR DESCRIPTION
Since the `fontique` directory contains a copy of the LICENSE files, it can link to them rather than up a directory.