### PR TITLE
Move `unused_qualifications` to the lints table.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ exclude = ["/.github/", "/doc/", ".gitignore"]
 clippy.doc_markdown = "warn"
 clippy.semicolon_if_nothing_returned = "warn"
 clippy.trivially_copy_pass_by_ref = "warn"
+rust.unused_qualifications = "warn"
 
 [lints]
 workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ members = [
 [workspace.package]
 edition = "2021"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml and with the relevant README.md files.
-# TODO: When this hits 1.74, move lint configuration into this file via a lints table.
 rust-version = "1.70"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/parley"

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -3,7 +3,6 @@
 
 //! Font enumeration and fallback.
 
-#![warn(unused_qualifications)]
 // TODO: Remove this dead code allowance and hide the offending code behind the std feature gate.
 #![cfg_attr(not(feature = "std"), allow(dead_code))]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 
 //! Rich text layout.
 
-#![warn(unused_qualifications)]
 // TODO: Remove this dead code allowance and hide the offending code behind the std feature gate.
 #![cfg_attr(not(feature = "std"), allow(dead_code))]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]


### PR DESCRIPTION
We don't need to wait for MSRV support to use the lints table. The MSRV `cargo check` commands won't fail, they'll just warn that there is an unused manifest key but the CI will still pass. The stable toolchain will do the actual linting.

This won't be a problem for projects higher up the stack either, as Cargo doesn't complain about unused manifest keys of dependencies.