### PR TITLE
Add automatic CI support for packages without the `std` feature.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,7 @@ env:
   RUST_MIN_VER: "1.70"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  PRIMARY_PKGS: "-p parley -p fontique"
-  # List of packages that are not published on crates.io (examples, etc)
-  EXAMPLE_PKGS: "-p tiny_skia_render"
+  RUST_MIN_VER_PKGS: "-p parley -p fontique"
   # List of features that depend on the standard library and will be excluded from no_std checks.
   FEATURES_DEPENDING_ON_STD: "std,default,system"
 
@@ -106,16 +104,13 @@ jobs:
 
       # TODO: Add --target x86_64-unknown-none to the no_std check once we solve the compilation issues with it
       - name: cargo clippy (no_std)
-        run: cargo hack clippy ${{ env.PRIMARY_PKGS }} --locked --optional-deps --each-feature --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} -- -D warnings
+        run: cargo hack clippy --workspace --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} -- -D warnings
 
       - name: cargo clippy
-        run: cargo hack clippy ${{ env.PRIMARY_PKGS }} --locked --optional-deps --each-feature --features std -- -D warnings
+        run: cargo hack clippy --workspace --locked --optional-deps --each-feature --ignore-unknown-features --features std -- -D warnings
 
       - name: cargo clippy (auxiliary)
-        run: cargo hack clippy ${{ env.PRIMARY_PKGS }} --locked --optional-deps --each-feature --features std --tests --benches --examples -- -D warnings
-
-      - name: cargo clippy (examples)
-        run: cargo hack clippy ${{ env.EXAMPLE_PKGS }} --locked --optional-deps --each-feature -- -D warnings
+        run: cargo hack clippy --workspace --locked --optional-deps --each-feature --ignore-unknown-features --features std --tests --benches --examples -- -D warnings
 
   clippy-stable-android:
     name: cargo clippy (android)
@@ -142,13 +137,10 @@ jobs:
           tool: cargo-hack
 
       - name: cargo clippy
-        run: cargo hack clippy ${{ env.PRIMARY_PKGS }} --locked --target ${{ matrix.target }} --optional-deps --each-feature --features std -- -D warnings
+        run: cargo hack clippy --workspace --locked --target ${{ matrix.target }} --optional-deps --each-feature --ignore-unknown-features --features std -- -D warnings
 
       - name: cargo clippy (auxiliary)
-        run: cargo hack clippy ${{ env.PRIMARY_PKGS }} --locked --target ${{ matrix.target }} --optional-deps --each-feature --features std --tests --benches --examples -- -D warnings
-
-      - name: cargo clippy (examples)
-        run: cargo hack clippy ${{ env.EXAMPLE_PKGS }} --locked --target ${{ matrix.target }} --optional-deps --each-feature -- -D warnings
+        run: cargo hack clippy --workspace --locked --target ${{ matrix.target }} --optional-deps --each-feature --ignore-unknown-features --features std --tests --benches --examples -- -D warnings
 
   test-stable:
     name: cargo test
@@ -168,7 +160,7 @@ jobs:
           toolchain: ${{ env.RUST_STABLE_VER }}
 
       - name: cargo test
-        run: cargo test ${{ env.PRIMARY_PKGS }} --locked --all-features
+        run: cargo test --workspace --locked --all-features
 
   check-msrv:
     name: cargo check (msrv)
@@ -194,10 +186,10 @@ jobs:
 
       # TODO: Add --target x86_64-unknown-none to the no_std check once we solve the compilation issues with it
       - name: cargo check (no_std)
-        run: cargo hack check ${{ env.PRIMARY_PKGS }} --locked --optional-deps --each-feature --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }}
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }}
 
       - name: cargo check
-        run: cargo hack check ${{ env.PRIMARY_PKGS }} --locked --optional-deps --each-feature --features std
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features std
 
   check-msrv-android:
     name: cargo check (msrv) (android)
@@ -223,7 +215,7 @@ jobs:
           tool: cargo-hack
 
       - name: cargo check
-        run: cargo hack check ${{ env.PRIMARY_PKGS }} --locked --target ${{ matrix.target }} --optional-deps --each-feature --features std
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --target ${{ matrix.target }} --optional-deps --each-feature --ignore-unknown-features --features std
 
   doc:
     name: cargo doc
@@ -242,4 +234,4 @@ jobs:
 
       # We test documentation using nightly to match docs.rs. This prevents potential breakages
       - name: cargo doc
-        run: cargo doc ${{ env.PRIMARY_PKGS }} --locked --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
+        run: cargo doc --workspace --locked --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples


### PR DESCRIPTION
With #55 we introduced a package that doesn't have the `std` feature. The CI was adjusted to cope with that.

This PR here improves support for such packages in key ways:
* Automatically support it using the `--ignore-unknown-features` flag.
* Remove the manual listing of `PRIMARY_PKGS` and `EXAMPLE_PKGS` and restore usage of `--workspace` so that the CI will automatically pick up new packages.
* Restores support for "primary packages" that don't need to follow MSRV.