### PR TITLE
Search correct paths for fonts on Apple platforms.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,7 +119,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -117,7 +132,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "libc",
 ]
@@ -228,6 +243,8 @@ dependencies = [
  "icu_locid",
  "icu_properties",
  "memmap2",
+ "objc2",
+ "objc2-foundation",
  "peniko",
  "roxmltree",
  "skrifa",
@@ -450,6 +467,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,7 +532,7 @@ version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -38,6 +38,8 @@ wio = "0.2.2"
 [target.'cfg(target_vendor="apple")'.dependencies]
 core-text = "20.1.0"
 core-foundation = "0.9.4"
+objc2 = { version = "0.5.2" }
+objc2-foundation = { version = "0.2.2", features = ["NSArray", "NSEnumerator", "NSPathUtilities", "NSString"] }
 
 [target.'cfg(not(any(target_vendor="apple", target_family="windows")))'.dependencies]
 fontconfig-cache-parser = "0.2.0"

--- a/fontique/src/backend/coretext.rs
+++ b/fontique/src/backend/coretext.rs
@@ -6,6 +6,10 @@ use super::{
 };
 use alloc::sync::Arc;
 use hashbrown::HashMap;
+use objc2::runtime::Bool;
+use objc2_foundation::{
+    NSSearchPathDirectory, NSSearchPathDomainMask, NSSearchPathForDirectoriesInDomains,
+};
 use {
     core_foundation::{
         base::{CFRange, TCFType},
@@ -37,7 +41,17 @@ pub struct SystemFonts {
 
 impl SystemFonts {
     pub fn new() -> Self {
-        let scanned = scan::ScannedCollection::from_paths(Some("/System/Library/Fonts"), 8);
+        let paths = unsafe {
+            NSSearchPathForDirectoriesInDomains(
+                NSSearchPathDirectory::NSLibraryDirectory,
+                NSSearchPathDomainMask::NSAllDomainsMask,
+                Bool::YES,
+            )
+            .as_ref()
+            .iter()
+            .map(|p| format!("{p}/Fonts/"))
+        };
+        let scanned = scan::ScannedCollection::from_paths(paths, 8);
         let name_map = scanned.family_names;
         let mut generic_families = GenericFamilyMap::default();
         for (family, names) in DEFAULT_GENERIC_FAMILIES {


### PR DESCRIPTION
Use the Foundation API to get the list of "Library" directories and look in each of them for a "Fonts" directory.

This handles the need to search a variety of paths on macOS to find fonts in the various standard locations like "~/Library/Fonts", "/System/Library/Fonts", "/Library/Fonts", "/Network/Library/Fonts", etc.

Fixes #50.