### PR TITLE
fontique: Make `icu_properties` optional

### DIFF
--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 default = ["system"]
 std = ["skrifa/std", "peniko/std", "dep:memmap2"]
 libm = ["skrifa/libm", "peniko/libm", "dep:core_maths"]
+icu_properties = ["dep:icu_properties"]
 # Enables support for system font backends
 system = ["std"]
 
@@ -26,7 +27,7 @@ smallvec = "1.13.2"
 memmap2 = { version = "0.9.4", optional = true }
 unicode-script = { version = "0.5.6", optional = true }
 core_maths = { version = "0.1.0", optional = true }
-icu_properties = "1.4.1"
+icu_properties = { version = "1.4.1", optional = true }
 icu_locid = "1.4.0"
 hashbrown = "0.14.5"
 

--- a/fontique/src/script.rs
+++ b/fontique/src/script.rs
@@ -24,6 +24,7 @@ impl Script {
     }
 
     /// Returns the associated [`icu_properties::Script`] value.
+    #[cfg(feature = "icu-properties")]
     pub fn icu_script(self) -> Option<icu_properties::Script> {
         let mapper = icu_properties::Script::name_to_enum_mapper();
         let s = core::str::from_utf8(&self.0).ok()?;
@@ -67,6 +68,7 @@ impl From<&str> for Script {
     }
 }
 
+#[cfg(feature = "icu-properties")]
 impl From<icu_properties::Script> for Script {
     fn from(value: icu_properties::Script) -> Self {
         Self(


### PR DESCRIPTION
This doesn't seem like everyone using `fontique` will need this (or already have it in their dependency graph).

I left this in `default` since that's the current behavior, but I think there's a good case for not doing so.