### PR TITLE
fontique: Make an explicit feature for `unicode_script`.

### DIFF
--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -17,6 +17,7 @@ default = ["system"]
 std = ["skrifa/std", "peniko/std", "dep:memmap2"]
 libm = ["skrifa/libm", "peniko/libm", "dep:core_maths"]
 icu_properties = ["dep:icu_properties"]
+unicode_script = ["dep:unicode-script"]
 # Enables support for system font backends
 system = ["std"]
 

--- a/fontique/src/script.rs
+++ b/fontique/src/script.rs
@@ -32,7 +32,7 @@ impl Script {
     }
 
     /// Returns the associated [`unicode_script::Script`] value.
-    #[cfg(feature = "unicode-script")]
+    #[cfg(feature = "unicode_script")]
     pub fn unicode_script(self) -> Option<unicode_script::Script> {
         unicode_script::Script::from_short_name(core::str::from_utf8(&self.0).ok()?)
     }
@@ -80,7 +80,7 @@ impl From<icu_properties::Script> for Script {
     }
 }
 
-#[cfg(feature = "unicode-script")]
+#[cfg(feature = "unicode_script")]
 impl From<unicode_script::Script> for Script {
     fn from(value: unicode_script::Script) -> Self {
         Self(value.short_name().as_bytes().try_into().unwrap_or_default())


### PR DESCRIPTION
Despite the crate name using a hyphen, the feature uses an underscore to make it match the other Linebender crate features.