### PR TITLE
Fix cluster index for rtl cursors

### DIFF
--- a/parley/src/layout/cursor.rs
+++ b/parley/src/layout/cursor.rs
@@ -52,17 +52,12 @@ impl Cursor {
             let mut last_edge = line_metrics.offset;
             for (run_index, run) in line.runs().enumerate() {
                 result.path.run_index = run_index;
-                let cluster_range = run.data().cluster_range.clone();
                 for (cluster_index, cluster) in run.visual_clusters().enumerate() {
                     let range = cluster.text_range();
                     result.text_start = range.start;
                     result.text_end = range.end;
                     result.is_rtl = run.is_rtl();
-                    result.path.cluster_index = if result.is_rtl {
-                        cluster_range.end - cluster_index - 1
-                    } else {
-                        cluster_index
-                    };
+                    result.path.cluster_index = run.visual_to_logical(cluster_index).unwrap();
                     if x >= last_edge {
                         let advance = cluster.advance();
                         let next_edge = last_edge + advance;
@@ -122,18 +117,13 @@ impl Cursor {
                     result.offset = last_edge;
                     continue;
                 }
-                let cluster_range = run.data().cluster_range.clone();
                 for (cluster_index, cluster) in run.visual_clusters().enumerate() {
                     let range = cluster.text_range();
                     result.text_start = range.start;
                     result.text_end = range.end;
                     result.offset = last_edge;
                     result.is_rtl = run.is_rtl();
-                    result.path.cluster_index = if result.is_rtl {
-                        cluster_range.end - cluster_index - 1
-                    } else {
-                        cluster_index
-                    };
+                    result.path.cluster_index = run.visual_to_logical(cluster_index).unwrap();
                     let advance = cluster.advance();
                     if range.contains(&position) {
                         if !is_leading || !result.is_inside {

--- a/parley/src/layout/run.rs
+++ b/parley/src/layout/run.rs
@@ -65,12 +65,17 @@ impl<'a, B: Brush> Run<'a, B> {
         self.data.bidi_level & 1 != 0
     }
 
-    /// Returns the number of clusters in the run.
-    pub fn len(&self) -> usize {
+    /// Returns the cluster range for the run.
+    pub fn cluster_range(&self) -> Range<usize> {
         self.line_data
             .map(|d| &d.cluster_range)
             .unwrap_or(&self.data.cluster_range)
-            .len()
+            .clone()
+    }
+
+    /// Returns the number of clusters in the run.
+    pub fn len(&self) -> usize {
+        self.cluster_range().len()
     }
 
     /// Returns true if the run is empty.
@@ -93,11 +98,7 @@ impl<'a, B: Brush> Run<'a, B> {
 
     /// Returns an iterator over the clusters in logical order.
     pub fn clusters(&'a self) -> impl Iterator<Item = Cluster<'a, B>> + 'a + Clone {
-        let range = self
-            .line_data
-            .map(|d| &d.cluster_range)
-            .unwrap_or(&self.data.cluster_range)
-            .clone();
+        let range = self.cluster_range();
         Clusters {
             run: self,
             range,
@@ -105,13 +106,25 @@ impl<'a, B: Brush> Run<'a, B> {
         }
     }
 
+    /// Returns the logical cluster index for the specified visual cluster index.
+    pub fn visual_to_logical(&self, visual_index: usize) -> Option<usize> {
+        let num_clusters = self.len();
+        if visual_index >= num_clusters {
+            return None;
+        }
+
+        let logical_index = if self.is_rtl() {
+            num_clusters - 1 - visual_index
+        } else {
+            visual_index
+        };
+
+        Some(logical_index)
+    }
+
     /// Returns an iterator over the clusters in visual order.
     pub fn visual_clusters(&'a self) -> impl Iterator<Item = Cluster<'a, B>> + 'a + Clone {
-        let range = self
-            .line_data
-            .map(|d| &d.cluster_range)
-            .unwrap_or(&self.data.cluster_range)
-            .clone();
+        let range = self.cluster_range();
         Clusters {
             run: self,
             range,

--- a/parley/src/layout/run.rs
+++ b/parley/src/layout/run.rs
@@ -131,10 +131,6 @@ impl<'a, B: Brush> Run<'a, B> {
             rev: self.is_rtl(),
         }
     }
-
-    pub(crate) fn data(&self) -> &'a RunData {
-        self.data
-    }
 }
 
 struct Clusters<'a, B: Brush> {


### PR DESCRIPTION
The `cluster_index` field of `CursorPath` is used for relative indexing within cluster range of the corresponding `Run`.
For RTL runs the logical `cluster_index` is calculated incorrectly from the visual cluster index as it uses the global cluster range as reference.

This can be reproduced with the `We will لقاء في 09:35 في ال 🏖️` snippet., where `cluster_index` for cursors within RTL segments may reach values of 20 and higher, while the the individual runs only span a few clusters.