### PR TITLE
Tree style builder

### DIFF
--- a/examples/tiny_skia_render/src/main.rs
+++ b/examples/tiny_skia_render/src/main.rs
@@ -72,7 +72,7 @@ fn main() {
     });
 
     // Build the builder into a Layout
-    let mut layout: Layout<PenikoColor> = builder.build();
+    let mut layout: Layout<PenikoColor> = builder.build(&text);
 
     // Perform layout (including bidi resolution and shaping) with start alignment
     layout.break_all_lines(max_advance);

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -57,7 +57,7 @@ impl Editor {
         builder.push_default(&parley::style::StyleProperty::FontStack(
             parley::style::FontStack::Source("system-ui"),
         ));
-        builder.build_into(&mut self.layout);
+        builder.build_into(&mut self.layout, &self.buffer);
         self.layout.break_all_lines(Some(width - INSET * 2.0));
         self.layout
             .align(Some(width - INSET * 2.0), parley::layout::Alignment::Start);

--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -1,0 +1,197 @@
+// Copyright 2021 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Context for layout.
+
+use super::context::*;
+use super::style::*;
+use super::FontContext;
+
+#[cfg(feature = "std")]
+use super::layout::Layout;
+
+use core::ops::RangeBounds;
+
+use crate::inline_box::InlineBox;
+
+/// Builder for constructing a text layout with ranged attributes.
+pub struct RangedBuilder<'a, B: Brush> {
+    pub(crate) scale: f32,
+    pub(crate) lcx: &'a mut LayoutContext<B>,
+    pub(crate) fcx: &'a mut FontContext,
+}
+
+impl<'a, B: Brush> RangedBuilder<'a, B> {
+    pub fn push_default(&mut self, property: &StyleProperty<B>) {
+        let resolved = self
+            .lcx
+            .rcx
+            .resolve_property(self.fcx, property, self.scale);
+        self.lcx.ranged_style_builder.push_default(resolved);
+    }
+
+    pub fn push(&mut self, property: &StyleProperty<B>, range: impl RangeBounds<usize>) {
+        let resolved = self
+            .lcx
+            .rcx
+            .resolve_property(self.fcx, property, self.scale);
+        self.lcx.ranged_style_builder.push(resolved, range);
+    }
+
+    pub fn push_inline_box(&mut self, inline_box: InlineBox) {
+        self.lcx.inline_boxes.push(inline_box);
+    }
+
+    #[cfg(feature = "std")]
+    pub fn build_into(&mut self, layout: &mut Layout<B>, text: impl AsRef<str>) {
+        // Apply RangedStyleBuilder styles to LayoutContext
+        self.lcx.ranged_style_builder.finish(&mut self.lcx.styles);
+
+        // Call generic layout builder method
+        build_into_layout(layout, self.scale, text.as_ref(), self.lcx, self.fcx);
+    }
+
+    #[cfg(feature = "std")]
+    pub fn build(&mut self, text: impl AsRef<str>) -> Layout<B> {
+        let mut layout = Layout::default();
+        self.build_into(&mut layout, text);
+        layout
+    }
+}
+
+/// Builder for constructing a text layout with a tree of attributes.
+pub struct TreeBuilder<'a, B: Brush> {
+    pub(crate) scale: f32,
+    pub(crate) lcx: &'a mut LayoutContext<B>,
+    pub(crate) fcx: &'a mut FontContext,
+}
+
+impl<'a, B: Brush> TreeBuilder<'a, B> {
+    pub fn push_style_span(&mut self, style: TextStyle<B>) {
+        let resolved = self
+            .lcx
+            .rcx
+            .resolve_entire_style_set(self.fcx, &style, self.scale);
+        self.lcx.tree_style_builder.push_style_span(resolved);
+    }
+
+    pub fn push_style_modification_span<'s, 'iter>(
+        &mut self,
+        properties: impl IntoIterator<Item = &'iter StyleProperty<'s, B>>,
+    ) where
+        's: 'iter,
+        B: 'iter,
+    {
+        self.lcx.tree_style_builder.push_style_modification_span(
+            properties
+                .into_iter()
+                .map(|p| self.lcx.rcx.resolve_property(self.fcx, p, self.scale)),
+        );
+    }
+
+    pub fn pop_style_span(&mut self) {
+        self.lcx.tree_style_builder.pop_style_span();
+    }
+
+    pub fn push_text(&mut self, text: &str) {
+        self.lcx.tree_style_builder.push_text(text);
+    }
+
+    pub fn push_inline_box(&mut self, mut inline_box: InlineBox) {
+        self.lcx.tree_style_builder.push_uncommitted_text(false);
+        // TODO: arrange type better here to factor out the index
+        inline_box.index = self.lcx.tree_style_builder.current_text_len();
+        self.lcx.inline_boxes.push(inline_box);
+    }
+
+    pub fn set_white_space_mode(&mut self, white_space_collapse: WhiteSpaceCollapse) {
+        self.lcx
+            .tree_style_builder
+            .set_white_space_mode(white_space_collapse);
+    }
+
+    #[cfg(feature = "std")]
+    pub fn build_into(&mut self, layout: &mut Layout<B>) -> String {
+        // Apply TreeStyleBuilder styles to LayoutContext
+        let text = self.lcx.tree_style_builder.finish(&mut self.lcx.styles);
+
+        self.lcx.analyze_text(&text);
+
+        // Call generic layout builder method
+        build_into_layout(layout, self.scale, &text, self.lcx, self.fcx);
+
+        text
+    }
+
+    #[cfg(feature = "std")]
+    pub fn build(&mut self) -> (Layout<B>, String) {
+        let mut layout = Layout::default();
+        let text = self.build_into(&mut layout);
+        (layout, text)
+    }
+}
+
+#[cfg(feature = "std")]
+fn build_into_layout<B: Brush>(
+    layout: &mut Layout<B>,
+    scale: f32,
+    text: &str,
+    lcx: &mut LayoutContext<B>,
+    fcx: &mut FontContext,
+) {
+    layout.data.clear();
+    layout.data.scale = scale;
+    layout.data.has_bidi = !lcx.bidi.levels().is_empty();
+    layout.data.base_level = lcx.bidi.base_level();
+    layout.data.text_len = text.len();
+
+    // println!("BUILD INTO ({})", text.len());
+    // for span in &lcx.styles {
+    //     let stack = lcx.rcx.stack(span.style.font_stack);
+    //     println!(
+    //         "{:?} weight:{}, family: {:?}",
+    //         span.range, span.style.font_weight, stack
+    //     );
+    // }
+
+    let mut char_index = 0;
+    for (i, style) in lcx.styles.iter().enumerate() {
+        for _ in text[style.range.clone()].chars() {
+            lcx.info[char_index].1 = i as u16;
+            char_index += 1;
+        }
+    }
+
+    // Copy the visual styles into the layout
+    layout
+        .data
+        .styles
+        .extend(lcx.styles.iter().map(|s| s.style.as_layout_style()));
+
+    // Sort the inline boxes as subsequent code assumes that they are in text index order.
+    // Note: It's important that this is a stable sort to allow users to control the order of contiguous inline boxes
+    lcx.inline_boxes.sort_by_key(|b| b.index);
+
+    // dbg!(&lcx.inline_boxes);
+
+    {
+        let query = fcx.collection.query(&mut fcx.source_cache);
+        super::shape::shape_text(
+            &lcx.rcx,
+            query,
+            &lcx.styles,
+            &lcx.inline_boxes,
+            &lcx.info,
+            lcx.bidi.levels(),
+            &mut lcx.scx,
+            text,
+            layout,
+        );
+    }
+
+    // Move inline boxes into the layout
+    layout.data.inline_boxes.clear();
+    core::mem::swap(&mut layout.data.inline_boxes, &mut lcx.inline_boxes);
+
+    layout.data.finish();
+}

--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -145,15 +145,6 @@ fn build_into_layout<B: Brush>(
     layout.data.base_level = lcx.bidi.base_level();
     layout.data.text_len = text.len();
 
-    // println!("BUILD INTO ({})", text.len());
-    // for span in &lcx.styles {
-    //     let stack = lcx.rcx.stack(span.style.font_stack);
-    //     println!(
-    //         "{:?} weight:{}, family: {:?}",
-    //         span.range, span.style.font_weight, stack
-    //     );
-    // }
-
     let mut char_index = 0;
     for (i, style) in lcx.styles.iter().enumerate() {
         for _ in text[style.range.clone()].chars() {
@@ -171,8 +162,6 @@ fn build_into_layout<B: Brush>(
     // Sort the inline boxes as subsequent code assumes that they are in text index order.
     // Note: It's important that this is a stable sort to allow users to control the order of contiguous inline boxes
     lcx.inline_boxes.sort_by_key(|b| b.index);
-
-    // dbg!(&lcx.inline_boxes);
 
     {
         let query = fcx.collection.query(&mut fcx.source_cache);

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -23,6 +23,7 @@ mod shape;
 mod swash_convert;
 mod util;
 
+pub mod builder;
 pub mod context;
 pub mod layout;
 pub mod style;

--- a/parley/src/resolve/range.rs
+++ b/parley/src/resolve/range.rs
@@ -124,23 +124,15 @@ impl<B: Brush> RangedStyleBuilder<B> {
             }
         }
         styles.truncate(styles.len() - merged_count);
+
+        // for span in styles.iter() {
+        //     println!("{:?} weight:{}", span.range, span.style.font_weight);
+        // }
+
         self.properties.clear();
         self.default_style = ResolvedStyle::default();
         self.len = !0;
     }
-}
-
-/// Style with an associated range.
-#[derive(Clone)]
-pub struct RangedStyle<B: Brush> {
-    pub style: ResolvedStyle<B>,
-    pub range: Range<usize>,
-}
-
-#[derive(Clone)]
-struct RangedProperty<B: Brush> {
-    property: ResolvedProperty<B>,
-    range: Range<usize>,
 }
 
 #[derive(Default)]

--- a/parley/src/resolve/range.rs
+++ b/parley/src/resolve/range.rs
@@ -125,10 +125,6 @@ impl<B: Brush> RangedStyleBuilder<B> {
         }
         styles.truncate(styles.len() - merged_count);
 
-        // for span in styles.iter() {
-        //     println!("{:?} weight:{}", span.range, span.style.font_weight);
-        // }
-
         self.properties.clear();
         self.default_style = ResolvedStyle::default();
         self.len = !0;

--- a/parley/src/resolve/tree.rs
+++ b/parley/src/resolve/tree.rs
@@ -172,17 +172,6 @@ impl<B: Brush> TreeStyleBuilder<B> {
 
         self.push_uncommitted_text(true);
 
-        // println!("FINISH TREE");
-        // dbg!(self.total_text_len);
-        // dbg!(&self.tree);
-        // for span in &self.flatted_styles {
-        //     println!("{:?} weight:{}", span.range, span.style.font_weight);
-        // }
-        // dbg!(&self.flatted_styles);
-
-        // println!("TEXT");
-        // dbg!(&self.text);
-
         styles.clear();
         styles.extend_from_slice(&self.flatted_styles);
 

--- a/parley/src/resolve/tree.rs
+++ b/parley/src/resolve/tree.rs
@@ -2,3 +2,190 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Hierarchical tree based style application.
+use alloc::borrow::Cow;
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+
+use crate::style::WhiteSpaceCollapse;
+
+use super::*;
+
+#[derive(Debug, Clone)]
+struct StyleTreeNode<B: Brush> {
+    parent: Option<usize>,
+    style: ResolvedStyle<B>,
+}
+
+/// Builder for constructing a tree of styles
+#[derive(Clone)]
+pub struct TreeStyleBuilder<B: Brush> {
+    tree: Vec<StyleTreeNode<B>>,
+    flatted_styles: Vec<RangedStyle<B>>,
+    white_space_collapse: WhiteSpaceCollapse,
+    text: String,
+    uncommitted_text: String,
+    current_span: usize,
+    is_span_first: bool,
+}
+
+impl<B: Brush> TreeStyleBuilder<B> {
+    fn current_style(&self) -> ResolvedStyle<B> {
+        self.tree[self.current_span].style.clone()
+    }
+}
+
+impl<B: Brush> Default for TreeStyleBuilder<B> {
+    fn default() -> Self {
+        Self {
+            tree: Vec::new(),
+            flatted_styles: Vec::new(),
+            white_space_collapse: WhiteSpaceCollapse::Preserve,
+            text: String::new(),
+            uncommitted_text: String::new(),
+            current_span: usize::MAX,
+            is_span_first: false,
+        }
+    }
+}
+
+impl<B: Brush> TreeStyleBuilder<B> {
+    /// Prepares the builder for accepting a style tree for text of the specified length.
+    pub fn begin(&mut self, root_style: ResolvedStyle<B>) {
+        self.tree.clear();
+        self.flatted_styles.clear();
+        self.white_space_collapse = WhiteSpaceCollapse::Preserve;
+        self.text.clear();
+        self.uncommitted_text.clear();
+
+        self.tree.push(StyleTreeNode {
+            parent: None,
+            style: root_style,
+        });
+        self.current_span = 0;
+        self.is_span_first = true;
+    }
+
+    pub fn set_white_space_mode(&mut self, white_space_collapse: WhiteSpaceCollapse) {
+        self.white_space_collapse = white_space_collapse;
+    }
+
+    pub fn push_uncommitted_text(&mut self, is_span_last: bool) {
+        let span_text: Cow<str> = match self.white_space_collapse {
+            WhiteSpaceCollapse::Preserve => Cow::from(&self.uncommitted_text),
+            WhiteSpaceCollapse::Collapse => {
+                let mut span_text = self.uncommitted_text.as_str();
+
+                if self.is_span_first {
+                    span_text = span_text.trim_start();
+                }
+                if is_span_last {
+                    span_text = span_text.trim_end();
+                }
+
+                // Collapse spaces
+                let mut last_char_whitespace = false;
+                let span_text: String = span_text
+                    .chars()
+                    .filter_map(|c: char| {
+                        let this_char_whitespace = c.is_ascii_whitespace();
+                        let prev_char_whitespace = last_char_whitespace;
+                        last_char_whitespace = this_char_whitespace;
+
+                        if this_char_whitespace {
+                            if prev_char_whitespace {
+                                None
+                            } else {
+                                Some(' ')
+                            }
+                        } else {
+                            Some(c)
+                        }
+                    })
+                    .collect();
+
+                Cow::from(span_text)
+            }
+        };
+        let span_text = span_text.as_ref();
+
+        // Nothing to do if there is no uncommitted text
+        if span_text.is_empty() {
+            // This is for the case of an inline box. This possibly ought to be made more explicit.
+            self.is_span_first = false;
+            return;
+        }
+
+        let range = self.text.len()..(self.text.len() + span_text.len());
+        let style = self.current_style();
+        self.flatted_styles.push(RangedStyle { style, range });
+        self.text.push_str(span_text);
+        self.uncommitted_text.clear();
+        self.is_span_first = false;
+    }
+
+    pub fn current_text_len(&self) -> usize {
+        self.text.len()
+    }
+
+    pub fn push_style_span(&mut self, style: ResolvedStyle<B>) {
+        self.push_uncommitted_text(false);
+
+        self.tree.push(StyleTreeNode {
+            parent: Some(self.current_span),
+            style,
+        });
+        self.current_span = self.tree.len() - 1;
+        self.is_span_first = true;
+    }
+
+    pub fn push_style_modification_span(
+        &mut self,
+        properties: impl Iterator<Item = ResolvedProperty<B>>,
+    ) {
+        let mut style = self.current_style();
+        for prop in properties {
+            style.apply(prop.clone());
+        }
+        self.push_style_span(style);
+    }
+
+    pub fn pop_style_span(&mut self) {
+        self.push_uncommitted_text(true);
+
+        self.current_span = self.tree[self.current_span]
+            .parent
+            .expect("Popped root style");
+    }
+
+    /// Pushes a property that covers the specified range of text.
+    pub fn push_text(&mut self, text: &str) {
+        if !text.is_empty() {
+            self.uncommitted_text.push_str(text);
+        }
+    }
+
+    /// Computes the sequence of ranged styles.
+    pub fn finish(&mut self, styles: &mut Vec<RangedStyle<B>>) -> String {
+        while self.tree[self.current_span].parent.is_some() {
+            self.pop_style_span();
+        }
+
+        self.push_uncommitted_text(true);
+
+        // println!("FINISH TREE");
+        // dbg!(self.total_text_len);
+        // dbg!(&self.tree);
+        // for span in &self.flatted_styles {
+        //     println!("{:?} weight:{}", span.range, span.style.font_weight);
+        // }
+        // dbg!(&self.flatted_styles);
+
+        // println!("TEXT");
+        // dbg!(&self.text);
+
+        styles.clear();
+        styles.extend_from_slice(&self.flatted_styles);
+
+        core::mem::take(&mut self.text)
+    }
+}

--- a/parley/src/shape.rs
+++ b/parley/src/shape.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "std")]
 use super::layout::Layout;
-use super::resolve::range::RangedStyle;
-use super::resolve::{ResolveContext, Resolved};
+use super::resolve::{RangedStyle, ResolveContext, Resolved};
 use super::style::{Brush, FontFeature, FontVariation};
 #[cfg(feature = "std")]
 use crate::util::nearly_eq;

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -12,6 +12,12 @@ pub use font::{
     FontWeight, GenericFamily,
 };
 
+#[derive(Debug, Clone, Copy)]
+pub enum WhiteSpaceCollapse {
+    Collapse,
+    Preserve,
+}
+
 /// Properties that define a style.
 #[derive(Clone, PartialEq, Debug)]
 pub enum StyleProperty<'a, B: Brush> {
@@ -55,4 +61,76 @@ pub enum StyleProperty<'a, B: Brush> {
     WordSpacing(f32),
     /// Extra spacing between letters.
     LetterSpacing(f32),
+}
+
+/// Unresolved styles.
+#[derive(Clone, PartialEq, Debug)]
+pub struct TextStyle<'a, B: Brush> {
+    /// Font family stack.
+    pub font_stack: FontStack<'a>,
+    /// Font size.
+    pub font_size: f32,
+    /// Font stretch.
+    pub font_stretch: FontStretch,
+    /// Font style.
+    pub font_style: FontStyle,
+    /// Font weight.
+    pub font_weight: FontWeight,
+    /// Font variation settings.
+    pub font_variations: FontSettings<'a, FontVariation>,
+    /// Font feature settings.
+    pub font_features: FontSettings<'a, FontFeature>,
+    /// Locale.
+    pub locale: Option<&'a str>,
+    /// Brush for rendering text.
+    pub brush: B,
+    /// Underline decoration.
+    pub has_underline: bool,
+    /// Offset of the underline decoration.
+    pub underline_offset: Option<f32>,
+    /// Size of the underline decoration.
+    pub underline_size: Option<f32>,
+    /// Brush for rendering the underline decoration.
+    pub underline_brush: Option<B>,
+    /// Strikethrough decoration.
+    pub has_strikethrough: bool,
+    /// Offset of the strikethrough decoration.
+    pub strikethrough_offset: Option<f32>,
+    /// Size of the strikethrough decoration.
+    pub strikethrough_size: Option<f32>,
+    /// Brush for rendering the strikethrough decoration.
+    pub strikethrough_brush: Option<B>,
+    /// Line height multiplier.
+    pub line_height: f32,
+    /// Extra spacing between words.
+    pub word_spacing: f32,
+    /// Extra spacing between letters.
+    pub letter_spacing: f32,
+}
+
+impl<'a, B: Brush> Default for TextStyle<'a, B> {
+    fn default() -> Self {
+        TextStyle {
+            font_stack: FontStack::Source("sans-serif"),
+            font_size: 16.0,
+            font_stretch: Default::default(),
+            font_style: Default::default(),
+            font_weight: Default::default(),
+            font_variations: FontSettings::List(&[]),
+            font_features: FontSettings::List(&[]),
+            locale: Default::default(),
+            brush: Default::default(),
+            has_underline: Default::default(),
+            underline_offset: Default::default(),
+            underline_size: Default::default(),
+            underline_brush: Default::default(),
+            has_strikethrough: Default::default(),
+            strikethrough_offset: Default::default(),
+            strikethrough_size: Default::default(),
+            strikethrough_brush: Default::default(),
+            line_height: 1.2,
+            word_spacing: Default::default(),
+            letter_spacing: Default::default(),
+        }
+    }
 }


### PR DESCRIPTION
- Builds on top of https://github.com/linebender/parley/pull/84 which should be merged first to preserve history

## Changes made

- ### Entire unresolved style struct
     - Adds an "unresolved style struct" (`TextStyle`) to `style/mod.rs`
     - The new `TreeBuilder` allows you to directly pass an entire style struct (rather than just "changed styles" relative to a previous node in the tree) as this is easier for integrating with Stylo which already resolves inherited styles. So I have added an "unresolved" version of the style struct to allow this API to still plug into the other parts of Parley's style resolution functionality.
     - Adds a corresponding`resolve_entire_style_set` method to `LayoutContext` to convert `TextStyle` into `ResolvedStyle`.
- ### Moved code
   - Moves the `RangedBuilder` from `context.rs` to a new `builder.rs` module (as there are now two builders, justifying a separate module).
   - Extract most of `RangedBuilder::build_into` into a standalone `build_into_layout` function (`builder.rs`) that can be shared between the ranged and tree builders.
   - Moves the `RangedStyle` and `RangedProperty` types from `resolve/range.rs` to `resolve/mod.rs`. These types are shared between the `RangedBuilder` and the `TreeBuilder`.
- ### Tree builder
   - Adds a `TreeBuilder` (also to `builder.rs`). This mostly delegates to `TreeStyleBuilder`
   - Add a `TreeStyleBuilder` (`resolve/tree.rs`). This is the vast majority of the new code 
   - The `TreeStyleBuilder` implements HTML-style whitespace collapsing (opt-in). This probably ought to become a style rather than being a flag on the style builder.
   - Updated swash example to optionally use the tree builder (depending on command line opt)
