### PR TITLE
Fontique: parse `-apple-system` and `BlinkMacSystemFont` as system-ui on relevant platforms

### DIFF
--- a/fontique/src/generic.rs
+++ b/fontique/src/generic.rs
@@ -77,6 +77,13 @@ impl GenericFamily {
             "emoji" => Self::Emoji,
             "math" => Self::Math,
             "fangsong" => Self::FangSong,
+
+            // Legacy web compatibility
+            #[cfg(target_vendor = "apple")]
+            "-apple-system" => Self::SystemUi,
+            #[cfg(target_os = "macos")]
+            "BlinkMacSystemFont" => Self::SystemUi,
+
             _ => return None,
         })
     }


### PR DESCRIPTION
This is for web compatibility. I think we're actually not using it in Blitz anymore (as the interaction between stylo parsing things first and how we then parse that into fontique meant that this code path didn't actually get hit). But I thought it might be worth having anyway? (alternatively I won't be too concerned if this gets rejected).