### PR TITLE
fontique: Fix fontconfig->opentype extra black weight map

### DIFF
--- a/fontique/src/backend/fontconfig/cache.rs
+++ b/fontique/src/backend/fontconfig/cache.rs
@@ -42,7 +42,7 @@ impl Weight {
             (700, 200),
             (800, 205),
             (900, 210),
-            (1000, 215),
+            (950, 215),
         ];
         for (i, (ot, fc)) in MAP.iter().skip(1).enumerate() {
             if weight == *fc {
@@ -58,7 +58,7 @@ impl Weight {
                 return Self::new(ot_a + (ot_b - ot_a) * t);
             }
         }
-        Self::new(1000.0)
+        Weight::EXTRA_BLACK
     }
 }
 


### PR DESCRIPTION
OpenType extra black is usually 950. If my understanding is correct, Fontique should map fontconfig's extra black to 950, not 1000.

See also `fontique::Weight::EXTRA_BLACK`

https://github.com/linebender/parley/blob/0f2608cc562d7c2eef0f34819aeb15166d542b67/fontique/src/attributes.rs#L211-L212