### PR TITLE
fontique: Clear weight, style and stretch when parsing the fontconfig cache

### DIFF
--- a/fontique/src/backend/fontconfig/cache.rs
+++ b/fontique/src/backend/fontconfig/cache.rs
@@ -79,6 +79,9 @@ impl CachedFont {
         self.path.clear();
         self.index = 0;
         self.coverage.clear();
+        self.weight = Weight::default();
+        self.style = Style::default();
+        self.stretch = Stretch::default();
     }
 }
 


### PR DESCRIPTION
The fonts do not always have these pattern elements defined, and then the value of the previous font was wrongly used. Clearing the values, fixes that and ensures that the default values are used.  For a more detailed description see https://github.com/linebender/parley/issues/92#issuecomment-2282674729

* Fixes https://github.com/linebender/parley/issues/93 
* Fixes https://github.com/linebender/parley/issues/95
* Fixes https://github.com/linebender/parley/issues/96 