### PR TITLE
Save range of original text in glyph

### DIFF
--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -126,6 +126,7 @@ impl<'a, B: Brush> Cluster<'a, B> {
     pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + 'a + Clone {
         if self.data.glyph_len == 0xFF {
             GlyphIter::Single(Some(Glyph {
+                text_range: self.text_range(),
                 id: self.data.glyph_offset,
                 style_index: self.data.style_index,
                 x: 0.,
@@ -451,7 +452,7 @@ impl<'a> Iterator for GlyphIter<'a> {
         match self {
             Self::Single(glyph) => glyph.take(),
             Self::Slice(iter) => {
-                let glyph = *iter.next()?;
+                let glyph = iter.next()?.clone();
                 Some(glyph)
             }
         }

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -126,12 +126,12 @@ impl<'a, B: Brush> Cluster<'a, B> {
     pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + 'a + Clone {
         if self.data.glyph_len == 0xFF {
             GlyphIter::Single(Some(Glyph {
-                text_range: self.text_range(),
                 id: self.data.glyph_offset,
                 style_index: self.data.style_index,
                 x: 0.,
                 y: 0.,
                 advance: self.data.advance,
+                text_range: self.text_range(),
             }))
         } else {
             let start = self.run.data.glyph_start + self.data.glyph_offset as usize;

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -435,12 +435,12 @@ impl<B: Brush> LayoutData<B> {
                     cluster_data.flags |= ClusterData::DIVERGENT_STYLES;
                 }
                 Glyph {
-                    text_range: source_range.clone(),
                     id: g.id,
                     style_index,
                     x: g.x,
                     y: g.y,
                     advance: g.advance,
+                    text_range: source_range.clone(),
                 }
             }));
             glyph_count += glyph_len;

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -435,6 +435,7 @@ impl<B: Brush> LayoutData<B> {
                     cluster_data.flags |= ClusterData::DIVERGENT_STYLES;
                 }
                 Glyph {
+                    text_range: source_range.clone(),
                     id: g.id,
                     style_index,
                     x: g.x,

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -210,13 +210,14 @@ pub struct Cluster<'a, B: Brush> {
 }
 
 /// Glyph with an offset and advance.
-#[derive(Copy, Clone, Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct Glyph {
     pub id: GlyphId,
     pub style_index: u16,
     pub x: f32,
     pub y: f32,
     pub advance: f32,
+    pub text_range: Range<usize>,
 }
 
 impl Glyph {


### PR DESCRIPTION
Okay, so I tried to look into #109 myself, and it actually was very straighforward (I tested it and it seems to work for my purpose), however:
- I had to make `Glyph` not implement copy, since `Range` doesn't.
- I'm a bit unsure why I had to add the text range in two places instead of one and I'm not sure it's 100% correct, so I would appreciate if someone could check this in detail to make sure I didn't mess up anything (assuming that you are okay with this change in the first place). :p