### PR TITLE
parley: add IME support to text editor example

### DIFF
--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -60,6 +60,7 @@ impl<'s> ApplicationHandler for SimpleVelloApp<'s> {
         let window = cached_window
             .take()
             .unwrap_or_else(|| create_winit_window(event_loop));
+        window.set_ime_allowed(true);
 
         // Create a vello Surface
         let size = window.inner_size();
@@ -107,7 +108,7 @@ impl<'s> ApplicationHandler for SimpleVelloApp<'s> {
             _ => return,
         };
 
-        self.editor.handle_event(&event);
+        self.editor.handle_event(&render_state.window, &event);
         render_state.window.request_redraw();
         // render_state
         //     .window

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -406,7 +406,7 @@ impl Editor {
                                 &self.layout,
                                 preedit_start,
                                 Affinity::Downstream,
-                            )
+                            );
                         }
 
                         self.set_ime_cursor_area(window);

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -404,6 +404,8 @@ impl Editor {
                         }
                     }
                     Ime::Preedit(text, compose_cursor) => {
+                        let old_selection = self.selection;
+
                         let preedit_start = if let Some(text_range) = self.preedit_range.take() {
                             self.buffer.replace_range(text_range.clone(), text);
                             text_range.start
@@ -468,7 +470,9 @@ impl Editor {
                             }
                         }
 
-                        self.set_ime_cursor_area(window);
+                        if self.selection != old_selection {
+                            self.set_ime_cursor_area(window);
+                        }
                     }
                     Ime::Disabled => {
                         if let Some(text_range) = self.preedit_range.take() {

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -204,6 +204,10 @@ impl Editor {
         }
     }
 
+    fn ime_is_composing(&self) -> bool {
+        self.preedit_range.is_some()
+    }
+
     pub fn handle_event(&mut self, window: &Window, event: &WindowEvent) {
         match event {
             WindowEvent::Resized(size) => {
@@ -236,12 +240,21 @@ impl Editor {
                 if let PhysicalKey::Code(code) = event.physical_key {
                     match code {
                         KeyCode::KeyC if action_mod => {
+                            if self.ime_is_composing() {
+                                return;
+                            }
                             self.handle_clipboard(code);
                         }
                         KeyCode::KeyX if action_mod => {
+                            if self.ime_is_composing() {
+                                return;
+                            }
                             self.handle_clipboard(code);
                         }
                         KeyCode::KeyV if action_mod => {
+                            if self.ime_is_composing() {
+                                return;
+                            }
                             self.handle_clipboard(code);
                         }
                         KeyCode::ArrowLeft => {
@@ -286,6 +299,11 @@ impl Editor {
                             }
                         }
                         KeyCode::Delete => {
+                            // The IME or Winit probably intercepts this event when composing, but
+                            // I'm not sure.
+                            if self.ime_is_composing() {
+                                return;
+                            }
                             let start = if self.selection.is_collapsed() {
                                 let range = self.selection.focus().text_range();
                                 let start = range.start;
@@ -301,6 +319,11 @@ impl Editor {
                             }
                         }
                         KeyCode::Backspace => {
+                            // The IME or Winit probably intercepts this event when composing, but
+                            // I'm not sure.
+                            if self.ime_is_composing() {
+                                return;
+                            }
                             let start = if self.selection.is_collapsed() {
                                 let end = self.selection.focus().text_range().start;
                                 if let Some((start, _)) =
@@ -326,6 +349,9 @@ impl Editor {
                             }
                         }
                         _ => {
+                            if self.ime_is_composing() {
+                                return;
+                            }
                             if let Some(text) = &event.text {
                                 let start = self
                                     .delete_current_selection()

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -442,7 +442,7 @@ impl Editor {
                                         &self.layout,
                                         preedit_start + compose_cursor.0,
                                         Affinity::Downstream,
-                                    )
+                                    );
                                 } else {
                                     self.selection = Selection::from_cursors(
                                         Cursor::from_index(

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -529,11 +529,10 @@ impl Editor {
 
                 let insertion_index = self.selection.insertion_index();
                 self.buffer.insert_str(insertion_index, &text);
-                {
-                    self.compose_state = ComposeState::Preedit {
-                        text_range: insertion_index..insertion_index + text.len(),
-                    };
-                }
+                self.compose_state = ComposeState::Preedit {
+                    text_range: insertion_index..insertion_index + text.len(),
+                };
+
                 // TODO: events that caused the preedit to be moved may also have updated the
                 // layout, in that case we're now updating twice.
                 self.update_layout(self.width, 1.0);

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -50,6 +50,7 @@ pub struct Editor {
 }
 
 /// Shrink the selection by the given amount of bytes by moving the focus towards the anchor.
+#[must_use]
 fn shrink_selection(layout: &Layout, selection: Selection, bytes: usize) -> Selection {
     let mut selection = selection;
     let shrink = bytes.min(selection.text_range().len());

--- a/parley/src/layout/cursor.rs
+++ b/parley/src/layout/cursor.rs
@@ -407,6 +407,15 @@ impl Selection {
         Cursor::from_point(layout, x, y).into()
     }
 
+    /// Creates a selection bounding the given anchor and focus cursors.
+    pub fn from_cursors(anchor: Cursor, focus: Cursor) -> Self {
+        Self {
+            anchor,
+            focus,
+            h_pos: None,
+        }
+    }
+
     /// Creates a new selection bounding the word at the given point.
     pub fn word_from_point<B: Brush>(layout: &Layout<B>, x: f32, y: f32) -> Self {
         let mut anchor = Cursor::from_point(layout, x, y);
@@ -498,16 +507,6 @@ impl Selection {
     #[must_use]
     pub fn extend_to_point<B: Brush>(&self, layout: &Layout<B>, x: f32, y: f32) -> Self {
         let focus = Cursor::from_point(layout, x, y);
-        Self {
-            anchor: self.anchor,
-            focus,
-            h_pos: None,
-        }
-    }
-
-    /// Returns a new selection with the focus extended to the given cursor.
-    #[must_use]
-    pub fn extend_to_cursor(&self, focus: Cursor) -> Self {
         Self {
             anchor: self.anchor,
             focus,

--- a/parley/src/layout/cursor.rs
+++ b/parley/src/layout/cursor.rs
@@ -505,6 +505,16 @@ impl Selection {
         }
     }
 
+    /// Returns a new selection with the focus extended to the given cursor.
+    #[must_use]
+    pub fn extend_to_cursor(&self, focus: Cursor) -> Self {
+        Self {
+            anchor: self.anchor,
+            focus,
+            h_pos: None,
+        }
+    }
+
     /// Returns a new selection with the focus moved to the next cluster in
     /// visual order.
     ///


### PR DESCRIPTION
This is a first pass at adding IME support to the editor example.

I don't speak languages that require the use of an IME, so I'm not myself a user of them. I think the implementation is in the right direction.

https://github.com/user-attachments/assets/863677fd-111c-4d39-8e62-b791113a3d68