### PR TITLE
Fix `elided_named_lifetimes` warning on nightly.

### DIFF
--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -51,7 +51,7 @@ impl<B: Brush> LayoutContext<B> {
         fcx: &'a mut FontContext,
         text: &'a str,
         scale: f32,
-    ) -> RangedBuilder<B, &'a str> {
+    ) -> RangedBuilder<'a, B, &'a str> {
         self.begin(text);
         #[cfg(feature = "std")]
         fcx.source_cache.prune(128, false);


### PR DESCRIPTION
This warning is now enabled by default on nightly (1.83).