### PR TITLE
parley: Fix swash example rendering.

### DIFF
--- a/examples/swash_render/src/main.rs
+++ b/examples/swash_render/src/main.rs
@@ -80,6 +80,7 @@ fn main() {
     let mut layout: Layout<Color> = builder.build();
 
     // Perform layout (including bidi resolution and shaping) with start alignment
+    layout.break_all_lines(max_advance);
     layout.align(max_advance, Alignment::Start);
 
     // Create image to render into


### PR DESCRIPTION
This line may have been mistakenly removed in #106 (14070d547913e407abf8c7cad2d5ca7fcd00cb59).

Fix #114.