### PR TITLE
Improvements to docs 

### DIFF
--- a/examples/swash_render/src/main.rs
+++ b/examples/swash_render/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
     //
     // These are all intended to be constructed rarely (perhaps even once per app (or once per thread))
     // and provide caches and scratch space to avoid allocations
-    let mut font_cx = FontContext::default();
+    let mut font_cx = FontContext::new();
     let mut layout_cx = LayoutContext::new();
     let mut scale_cx = ScaleContext::new();
 

--- a/examples/tiny_skia_render/src/main.rs
+++ b/examples/tiny_skia_render/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
     //
     // These are both intended to be constructed rarely (perhaps even once per app (or once per thread))
     // and provide caches and scratch space to avoid allocations
-    let mut font_cx = FontContext::default();
+    let mut font_cx = FontContext::new();
     let mut layout_cx = LayoutContext::new();
 
     // Create a RangedBuilder

--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -50,7 +50,7 @@ struct SimpleVelloApp<'s> {
     editor: text::Editor,
 }
 
-impl<'s> ApplicationHandler for SimpleVelloApp<'s> {
+impl ApplicationHandler for SimpleVelloApp<'_> {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         let RenderState::Suspended(cached_window) = &mut self.state else {
             return;

--- a/fontique/src/collection/mod.rs
+++ b/fontique/src/collection/mod.rs
@@ -476,9 +476,9 @@ struct GenericFamilies<I> {
     system: Option<I>,
 }
 
-impl<'a, I> Iterator for GenericFamilies<I>
+impl<I> Iterator for GenericFamilies<I>
 where
-    I: Iterator<Item = FamilyId> + 'a,
+    I: Iterator<Item = FamilyId>,
 {
     type Item = FamilyId;
 

--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -21,7 +21,7 @@ pub struct RangedBuilder<'a, B: Brush> {
     pub(crate) fcx: &'a mut FontContext,
 }
 
-impl<'a, B: Brush> RangedBuilder<'a, B> {
+impl<B: Brush> RangedBuilder<'_, B> {
     pub fn push_default(&mut self, property: &StyleProperty<B>) {
         let resolved = self
             .lcx
@@ -66,7 +66,7 @@ pub struct TreeBuilder<'a, B: Brush> {
     pub(crate) fcx: &'a mut FontContext,
 }
 
-impl<'a, B: Brush> TreeBuilder<'a, B> {
+impl<B: Brush> TreeBuilder<'_, B> {
     pub fn push_style_span(&mut self, style: TextStyle<B>) {
         let resolved = self
             .lcx

--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -20,7 +20,7 @@ use swash::text::cluster::CharInfo;
 use crate::builder::TreeBuilder;
 use crate::inline_box::InlineBox;
 
-/// Context for building a text layout.
+/// Shared scratch space used when constructing text layouts
 pub struct LayoutContext<B: Brush = [u8; 4]> {
     pub(crate) bidi: bidi::BidiResolver,
     pub(crate) rcx: ResolveContext,

--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -20,7 +20,9 @@ use swash::text::cluster::CharInfo;
 use crate::builder::TreeBuilder;
 use crate::inline_box::InlineBox;
 
-/// Shared scratch space used when constructing text layouts
+/// Shared scratch space used when constructing text layouts.
+///
+/// This type is designed to be a global resource with only one per-application (or per-thread).
 pub struct LayoutContext<B: Brush = [u8; 4]> {
     pub(crate) bidi: bidi::BidiResolver,
     pub(crate) rcx: ResolveContext,

--- a/parley/src/font.rs
+++ b/parley/src/font.rs
@@ -6,9 +6,9 @@ use fontique::Collection;
 #[cfg(feature = "std")]
 use fontique::SourceCache;
 
-/// A font database/cache (wrapper around a the [fontique] crate)
+/// A font database/cache (wrapper around a Fontique [`Collection`] and [`SourceCache`]).
 ///
-/// This type is designed to be a global resource with only one per-application (or per-thread)
+/// This type is designed to be a global resource with only one per-application (or per-thread).
 #[derive(Default)]
 pub struct FontContext {
     pub collection: Collection,
@@ -17,6 +17,7 @@ pub struct FontContext {
 }
 
 impl FontContext {
+    /// Create a new `FontContext`, discovering system fonts if available.
     pub fn new() -> Self {
         Default::default()
     }

--- a/parley/src/font.rs
+++ b/parley/src/font.rs
@@ -6,9 +6,18 @@ use fontique::Collection;
 #[cfg(feature = "std")]
 use fontique::SourceCache;
 
+/// A font database/cache (wrapper around a the [fontique] crate)
+///
+/// This type is designed to be a global resource with only one per-application (or per-thread)
 #[derive(Default)]
 pub struct FontContext {
     pub collection: Collection,
     #[cfg(feature = "std")]
     pub source_cache: SourceCache,
+}
+
+impl FontContext {
+    pub fn new() -> Self {
+        Default::default()
+    }
 }

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -444,7 +444,7 @@ enum GlyphIter<'a> {
     Slice(core::slice::Iter<'a, Glyph>),
 }
 
-impl<'a> Iterator for GlyphIter<'a> {
+impl Iterator for GlyphIter<'_> {
     type Item = Glyph;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/parley/src/layout/line/greedy.rs
+++ b/parley/src/layout/line/greedy.rs
@@ -578,7 +578,7 @@ impl<'a, B: Brush> BreakLines<'a, B> {
     }
 }
 
-impl<'a, B: Brush> Drop for BreakLines<'a, B> {
+impl<B: Brush> Drop for BreakLines<'_, B> {
     fn drop(&mut self) {
         // Compute the overall width and height of the entire layout
         // The "width" excludes trailing whitespace. The "full_width" includes it.

--- a/parley/src/layout/line/mod.rs
+++ b/parley/src/layout/line/mod.rs
@@ -126,12 +126,14 @@ impl LineMetrics {
     }
 }
 
+/// The computed result of an item (glyph run or inline box) within a layout
 #[derive(Clone)]
 pub enum PositionedLayoutItem<'a, B: Brush> {
     GlyphRun(GlyphRun<'a, B>),
     InlineBox(PositionedInlineBox),
 }
 
+/// The computed position of an inline box within a layout
 #[derive(Debug, Clone)]
 pub struct PositionedInlineBox {
     pub x: f32,

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -22,7 +22,7 @@ use swash::text::cluster::{Boundary, ClusterInfo};
 use swash::{GlyphId, NormalizedCoord, Synthesis};
 
 pub use cluster::{Affinity, ClusterPath};
-pub use cursor::Cursor;
+pub use cursor::{Cursor, Selection, VisualMode};
 pub use line::greedy::BreakLines;
 pub use line::{GlyphRun, LineMetrics, PositionedInlineBox, PositionedLayoutItem};
 pub use run::RunMetrics;

--- a/parley/src/layout/run.rs
+++ b/parley/src/layout/run.rs
@@ -162,7 +162,7 @@ struct Clusters<'a, B: Brush> {
     rev: bool,
 }
 
-impl<'a, B: Brush> Clone for Clusters<'a, B> {
+impl<B: Brush> Clone for Clusters<'_, B> {
     fn clone(&self) -> Self {
         Self {
             run: self.run,

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -16,21 +16,26 @@ pub use fontique;
 pub use swash;
 
 mod bidi;
-pub mod font;
+mod builder;
+mod context;
+mod font;
 mod inline_box;
 mod resolve;
 mod shape;
 mod swash_convert;
 mod util;
 
-pub mod builder;
-pub mod context;
 pub mod layout;
 pub mod style;
 
 pub use peniko::Font;
 
+pub use builder::{RangedBuilder, TreeBuilder};
 pub use context::LayoutContext;
 pub use font::FontContext;
 pub use inline_box::InlineBox;
+#[doc(inline)]
 pub use layout::Layout;
+
+pub use layout::*;
+pub use style::*;

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -1,9 +1,9 @@
 // Copyright 2021 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Parley is library for rich text layout.
+//! Parley is a library for rich text layout.
 //!
-//! Key types are:
+//! Some key types are:
 //! - [`FontContext`] and [`LayoutContext`] are resources which should be shared globally (or at coarse-grained boundaries).
 //!   - [`FontContext`] is database of fonts.
 //!   - [`LayoutContext`] is scratch space that allows for reuse of allocations between layouts.
@@ -11,8 +11,8 @@
 //!     - [`RangedBuilder`] allows styles to be specified as a flat `Vec` of spans
 //!     - [`TreeBuilder`] allows styles to be specified as a tree of spans
 //!   
-//!   They are constructed using the [`ranged_builder`](LayoutContext::ranged_builder) and [`tree_builder`](LayoutContext::ranged_builder) on [`LayoutContext`].
-//! - [Layout] which represents styled paragraph(s) of text and can perform shaping, line-breaking, bidi-reordering, and alignment of that text.
+//!   They are constructed using the [`ranged_builder`](LayoutContext::ranged_builder) and [`tree_builder`](LayoutContext::ranged_builder) methods on [`LayoutContext`].
+//! - [`Layout`] which represents styled paragraph(s) of text and can perform shaping, line-breaking, bidi-reordering, and alignment of that text.
 //!   
 //!   `Layout` supports re-linebreaking and re-aligning many times (in case the width at which wrapping should occur changes). But if the text content or
 //!   the styles applied to that content change then a new `Layout` must be created using a new `RangedBuilder` or `TreeBuilder`.
@@ -62,10 +62,10 @@
 //!     for item in line.items() {
 //!         match item {
 //!             PositionedLayoutItem::GlyphRun(glyph_run) => {
-//!                 // Do something with  glyph run
+//!                 // Render the glyph run
 //!             }
 //!             PositionedLayoutItem::InlineBox(inline_box) => {
-//!                 // So something with inline box
+//!                 // Render the inline box
 //!             }
 //!         };
 //!     }

--- a/parley/src/shape.rs
+++ b/parley/src/shape.rs
@@ -266,7 +266,7 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
 }
 
 #[cfg(feature = "std")]
-impl<'a, 'b, B: Brush> partition::Selector for FontSelector<'a, 'b, B> {
+impl<B: Brush> partition::Selector for FontSelector<'_, '_, B> {
     type SelectedFont = SelectedFont;
 
     fn select_font(&mut self, cluster: &mut CharCluster) -> Option<Self::SelectedFont> {

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -108,7 +108,7 @@ pub struct TextStyle<'a, B: Brush> {
     pub letter_spacing: f32,
 }
 
-impl<'a, B: Brush> Default for TextStyle<'a, B> {
+impl<B: Brush> Default for TextStyle<'_, B> {
     fn default() -> Self {
         TextStyle {
             font_stack: FontStack::Source("sans-serif"),


### PR DESCRIPTION
- Simplify public module hierarchy (make some modules private and re-export types instead)
- Re-export all types at the top level (making use of wildcard re-exports to avoid cluttering the docs)
- Add a usage example and basic documentation to `lib.rs`