### PR TITLE
CoWify style types

### DIFF
--- a/examples/swash_render/src/main.rs
+++ b/examples/swash_render/src/main.rs
@@ -10,6 +10,7 @@ use parley::layout::{Alignment, Glyph, GlyphRun, Layout, PositionedLayoutItem};
 use parley::style::{FontStack, FontWeight, StyleProperty, TextStyle};
 use parley::{FontContext, InlineBox, LayoutContext};
 use peniko::Color;
+use std::borrow::Cow;
 use std::fs::File;
 use swash::scale::image::Content;
 use swash::scale::{Render, ScaleContext, Scaler, Source, StrikeWith};
@@ -46,8 +47,8 @@ fn main() {
 
     // Setup some Parley text styles
     let brush_style = StyleProperty::Brush(text_color);
-    let font_stack = FontStack::Source("system-ui");
-    let font_stack_style: StyleProperty<Color> = StyleProperty::FontStack(font_stack);
+    let font_stack = FontStack::Source(Cow::Borrowed("system-ui"));
+    let font_stack_style: StyleProperty<Color> = StyleProperty::FontStack(font_stack.clone());
     let bold = FontWeight::new(600.0);
     let bold_style = StyleProperty::FontWeight(bold);
 

--- a/examples/tiny_skia_render/src/main.rs
+++ b/examples/tiny_skia_render/src/main.rs
@@ -7,6 +7,8 @@
 //! Note: Emoji rendering is not currently implemented in this example. See the swash example
 //! if you need emoji rendering.
 
+use std::borrow::Cow;
+
 use parley::layout::{Alignment, GlyphRun, Layout, PositionedLayoutItem};
 use parley::style::{FontStack, FontWeight, StyleProperty};
 use parley::{FontContext, InlineBox, LayoutContext};
@@ -53,7 +55,7 @@ fn main() {
     builder.push_default(&brush_style);
 
     // Set default font family
-    let font_stack = FontStack::Source("system-ui");
+    let font_stack = FontStack::Source(Cow::Borrowed("system-ui"));
     let font_stack_style = StyleProperty::FontStack(font_stack);
     builder.push_default(&font_stack_style);
     builder.push_default(&StyleProperty::LineHeight(1.3));

--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -49,7 +49,7 @@ struct SimpleVelloApp<'s> {
     scene: Scene,
 
     // Our text state object
-    editor: text::Editor<'s>,
+    editor: text::Editor,
 }
 
 impl ApplicationHandler for SimpleVelloApp<'_> {

--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use anyhow::Result;
+use std::borrow::Cow;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use vello::peniko::Color;
@@ -135,7 +136,7 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
                         parley::style::StyleProperty::FontSize(32.0),
                         parley::style::StyleProperty::LineHeight(1.2),
                         parley::style::StyleProperty::FontStack(parley::style::FontStack::Source(
-                            "system-ui",
+                            Cow::Borrowed("system-ui"),
                         )),
                     ])),
                 ]);

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -20,10 +20,10 @@ use parley::{FontContext, LayoutContext, PlainEditor, PlainEditorOp};
 pub const INSET: f32 = 32.0;
 
 #[derive(Default)]
-pub struct Editor<'a> {
+pub struct Editor {
     font_cx: FontContext,
     layout_cx: LayoutContext<Color>,
-    editor: PlainEditor<'a, Color>,
+    editor: PlainEditor<Color>,
     last_click_time: Option<Instant>,
     click_count: u32,
     pointer_down: bool,
@@ -31,8 +31,8 @@ pub struct Editor<'a> {
     modifiers: Option<Modifiers>,
 }
 
-impl<'a> Editor<'a> {
-    pub fn transact(&mut self, t: impl IntoIterator<Item = PlainEditorOp<'a, Color>>) {
+impl Editor {
+    pub fn transact(&mut self, t: impl IntoIterator<Item = PlainEditorOp<Color>>) {
         self.editor
             .transact(&mut self.font_cx, &mut self.layout_cx, t);
     }

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -22,11 +22,11 @@ pub enum ActiveText<'a> {
 }
 
 /// Basic plain text editor with a single default style.
-pub struct PlainEditor<'a, T>
+pub struct PlainEditor<T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,
 {
-    default_style: Arc<[StyleProperty<'a, T>]>,
+    default_style: Arc<[StyleProperty<'static, T>]>,
     buffer: String,
     layout: Layout<T>,
     selection: Selection,
@@ -36,7 +36,7 @@ where
 }
 
 // TODO: When MSRV >= 1.80 we can remove this. Default was not implemented for Arc<[T]> where T: !Default until 1.80
-impl<'a, T> Default for PlainEditor<'a, T>
+impl<T> Default for PlainEditor<T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,
 {
@@ -55,7 +55,7 @@ where
 
 /// Operations on a `PlainEditor` for `PlainEditor::transact`
 #[non_exhaustive]
-pub enum PlainEditorOp<'a, T>
+pub enum PlainEditorOp<T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,
 {
@@ -66,7 +66,7 @@ where
     /// Set the scale for the layout
     SetScale(f32),
     /// Set the default style for the layout
-    SetDefaultStyle(Arc<[StyleProperty<'a, T>]>),
+    SetDefaultStyle(Arc<[StyleProperty<'static, T>]>),
     /// Insert at cursor, or replace selection
     InsertOrReplaceSelection(Arc<str>),
     /// Delete the selection
@@ -133,7 +133,7 @@ where
     ExtendSelectionToPoint(f32, f32),
 }
 
-impl<'a, T> PlainEditor<'a, T>
+impl<T> PlainEditor<T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,
 {
@@ -142,7 +142,7 @@ where
         &mut self,
         font_cx: &mut FontContext,
         layout_cx: &mut LayoutContext<T>,
-        t: impl IntoIterator<Item = PlainEditorOp<'a, T>>,
+        t: impl IntoIterator<Item = PlainEditorOp<T>>,
     ) {
         let mut layout_after = false;
 

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -6,6 +6,8 @@
 mod brush;
 mod font;
 
+use alloc::borrow::Cow;
+
 pub use brush::*;
 pub use font::{
     FontFamily, FontFeature, FontSettings, FontStack, FontStretch, FontStyle, FontVariation,
@@ -111,13 +113,13 @@ pub struct TextStyle<'a, B: Brush> {
 impl<B: Brush> Default for TextStyle<'_, B> {
     fn default() -> Self {
         TextStyle {
-            font_stack: FontStack::Source("sans-serif"),
+            font_stack: FontStack::Source(Cow::Borrowed("sans-serif")),
             font_size: 16.0,
             font_stretch: Default::default(),
             font_style: Default::default(),
             font_weight: Default::default(),
-            font_variations: FontSettings::List(&[]),
-            font_features: FontSettings::List(&[]),
+            font_variations: FontSettings::List(Cow::Borrowed(&[])),
+            font_features: FontSettings::List(Cow::Borrowed(&[])),
             locale: Default::default(),
             brush: Default::default(),
             has_underline: Default::default(),


### PR DESCRIPTION
This:
- Converts parley style types to use `std::borrow::Cow` instead of references
- Removes the lifetime parameter from `PlainEditor` and `PlainEditorOp` by making them using `StyleProperty<'static>`

This isn't ideal from an API point of view, but does at least allow `PlainEditor` to be stored within a struct.

It would be an option to leave the lifetime parameter in `PlainEditor` and make uses who want to store it in a struct specify `PlainEditor<'static>` themselves. I have not done so because I don't think there's much use for the borrowed editor outside of toy examples.