### PR TITLE
Derive `Clone` for `PlainEditor`

### DIFF
--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -22,6 +22,7 @@ pub enum ActiveText<'a> {
 }
 
 /// Basic plain text editor with a single default style.
+#[derive(Clone)]
 pub struct PlainEditor<T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,


### PR DESCRIPTION
This is useful if you want to include a `PlainEditor` within a struct that implements `Clone`.