### PR TITLE
Make `PlainEditor` width `Option<f32>`

### DIFF
--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -74,7 +74,7 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
 
         self.editor.transact([
             PlainEditorOp::SetScale(1.0),
-            PlainEditorOp::SetWidth(size.width as f32 - 2f32 * text::INSET),
+            PlainEditorOp::SetWidth(Some(size.width as f32 - 2f32 * text::INSET)),
             PlainEditorOp::SetText(text::LOREM.into()),
         ]);
 
@@ -130,7 +130,7 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
                 render_state.window.request_redraw();
                 self.editor.transact([
                     PlainEditorOp::SetScale(1.0),
-                    PlainEditorOp::SetWidth(size.width as f32 - 2f32 * text::INSET),
+                    PlainEditorOp::SetWidth(Some(size.width as f32 - 2f32 * text::INSET)),
                     PlainEditorOp::SetDefaultStyle(Arc::new([
                         StyleProperty::FontSize(32.0),
                         StyleProperty::LineHeight(1.2),

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -47,7 +47,9 @@ impl Editor {
                 self.editor.transact(
                     &mut self.font_cx,
                     &mut self.layout_cx,
-                    [PlainEditorOp::SetWidth(size.width as f32 - 2f32 * INSET)],
+                    [PlainEditorOp::SetWidth(Some(
+                        size.width as f32 - 2f32 * INSET,
+                    ))],
                 );
             }
             WindowEvent::ModifiersChanged(modifiers) => {

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -31,7 +31,7 @@ where
     layout: Layout<T>,
     selection: Selection,
     cursor_mode: VisualMode,
-    width: f32,
+    width: Option<f32>,
     scale: f32,
 }
 
@@ -62,7 +62,7 @@ where
     /// Replace the whole text buffer
     SetText(Arc<str>),
     /// Set the width of the layout
-    SetWidth(f32),
+    SetWidth(Option<f32>),
     /// Set the scale for the layout
     SetScale(f32),
     /// Set the default style for the layout
@@ -448,8 +448,8 @@ where
             builder.push_default(prop.to_owned());
         }
         builder.build_into(&mut self.layout, &self.buffer);
-        self.layout.break_all_lines(Some(self.width));
-        self.layout.align(Some(self.width), Alignment::Start);
+        self.layout.break_all_lines(self.width);
+        self.layout.align(self.width, Alignment::Start);
         self.selection = self.selection.refresh(&self.layout);
     }
 }


### PR DESCRIPTION
This matches `Layout`, and is useful for single-line text inputs that shouldn't ever wrap.