### PR TITLE
Update to `hashbrown` 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "font-types"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,7 +748,7 @@ dependencies = [
  "core-text",
  "core_maths",
  "fontconfig-cache-parser",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "icu_locid",
  "icu_properties",
  "memmap2",
@@ -951,6 +957,11 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hassle-rs"

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -33,7 +33,7 @@ unicode-script = { version = "0.5.7", optional = true }
 core_maths = { version = "0.1.0", optional = true }
 icu_properties = { version = "1.5.1", optional = true }
 icu_locid = "1.5.0"
-hashbrown = "0.14.5"
+hashbrown = "0.15.0"
 
 [target.'cfg(target_family="windows")'.dependencies]
 windows = { version = "0.58.0", features = ["implement", "Win32_Graphics_DirectWrite"] }


### PR DESCRIPTION
Among other things, this changes the default hash from `ahash` to `foldhash`.