### PR TITLE
Eliminate extraneous allocation and dynamic dispatch in `PlainEditor`

### DIFF
--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -16,7 +16,7 @@ use winit::window::Window;
 
 // #[path = "text2.rs"]
 mod text;
-use parley::{GenericFamily, PlainEditorOp, StyleProperty};
+use parley::{GenericFamily, StyleProperty};
 
 // Simple struct to hold the state of the renderer
 pub struct ActiveRenderState<'s> {
@@ -65,11 +65,11 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
 
         let size = window.inner_size();
 
-        self.editor.transact([
-            PlainEditorOp::SetScale(1.0),
-            PlainEditorOp::SetWidth(Some(size.width as f32 - 2f32 * text::INSET)),
-            PlainEditorOp::SetText(text::LOREM.into()),
-        ]);
+        self.editor.transact(|txn| {
+            txn.set_scale(1.0);
+            txn.set_width(Some(size.width as f32 - 2f32 * text::INSET));
+            txn.set_text(text::LOREM);
+        });
 
         // Create a vello Surface
         let surface_future = {
@@ -148,15 +148,15 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
             WindowEvent::Resized(size) => {
                 self.context
                     .resize_surface(&mut render_state.surface, size.width, size.height);
-                self.editor.transact([
-                    PlainEditorOp::SetScale(1.0),
-                    PlainEditorOp::SetWidth(Some(size.width as f32 - 2f32 * text::INSET)),
-                    PlainEditorOp::SetDefaultStyle(Arc::new([
+                self.editor.transact(|txn| {
+                    txn.set_scale(1.0);
+                    txn.set_width(Some(size.width as f32 - 2f32 * text::INSET));
+                    txn.set_default_style(Arc::new([
                         StyleProperty::FontSize(32.0),
                         StyleProperty::LineHeight(1.2),
                         GenericFamily::SystemUi.into(),
-                    ])),
-                ]);
+                    ]));
+                });
                 render_state.window.request_redraw();
             }
 

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -108,7 +108,7 @@ pub use inline_box::InlineBox;
 pub use layout::Layout;
 
 #[cfg(feature = "std")]
-pub use layout::editor::{PlainEditor, PlainEditorOp};
+pub use layout::editor::{PlainEditor, PlainEditorTxn};
 
 pub use layout::*;
 pub use style::*;


### PR DESCRIPTION
I started by wanting to eliminate `Arc<str>`. Then I noticed that `vello_editor` was allocating temporary `Vec`s for the `PlainEditorOp`s. Finally, it occurred to me that we could probably do something altogether more efficient than `PlainEditorOp`. I think my refactored version, with separate functions in `PlainEditorTxn`, will be nicer to maintain as well.