### PR TITLE
Rename the CI `cargo fmt` job to `formatting`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ on:
 
 jobs:
   fmt:
-    name: cargo fmt
+    name: formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This brings the CI in sync with the latest Linebender standard, see e.g. [xilem](https://github.com/linebender/xilem/blob/c3a6bd55163d1c37251bd8af47f0067be81319e5/.github/workflows/ci.yml#L73).