### PR TITLE
Delay CI cache restore until the toolchain has been installed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -106,6 +101,11 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
 
       # TODO: Add --target x86_64-unknown-none to the no_std check once we solve the compilation issues with it
       - name: cargo clippy (no_std)
@@ -126,11 +126,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -142,6 +137,11 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: cargo clippy
         run: cargo hack clippy --workspace --locked --target ${{ matrix.target }} --optional-deps --each-feature --ignore-unknown-features --features std -- -D warnings
@@ -158,15 +158,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_STABLE_VER }}
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: cargo test
         run: cargo test --workspace --locked --all-features
@@ -180,11 +180,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
       - name: install msrv toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -194,6 +189,11 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
 
       # TODO: Add --target x86_64-unknown-none to the no_std check once we solve the compilation issues with it
       - name: cargo check (no_std)
@@ -211,11 +211,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
       - name: install msrv toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -226,6 +221,11 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: cargo check
         run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --target ${{ matrix.target }} --optional-deps --each-feature --ignore-unknown-features --features std
@@ -239,13 +239,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
       - name: restore cache
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
-
-      - name: install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
 
       # We test documentation using nightly to match docs.rs. This prevents potential breakages
       - name: cargo doc


### PR DESCRIPTION
The [cache action's docs](https://github.com/Swatinem/rust-cache/blob/68b3cb7503c78e67dae8373749990a220eb65352/README.md) state:
> selecting a toolchain either by action or manual `rustup` calls should happen before the plugin, as the cache uses the current rustc version as its cache key

In practice we weren't affected too much, because it turns out the cache key is also derived using all environment variables that have the prefix `RUST`, which includes e.g. our `RUST_STABLE_VER`. So even if the key was derived using the CI runner's pre-installed old Rust toolchain, our env variable prevented most conflicts.

The cache docs also state that it does not cache, by cleaning the following:
> Any files in ~/.cargo/bin that were present before the action ran (for example rustc).

As we were installing the toolchain after the cache action, the potential for caching the toolchain seems there. However the cache size hasn't changed after this ordering change. Perhaps it does a simple path check only and the pre-installed toolchain was in the same path.

In any case, better to invoke the cache action after the toolchain has been installed, as the docs suggest.