### PR TITLE
Fix `no_std` compilation in `fontique`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,8 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
 
-      # TODO: Add --target x86_64-unknown-none to the no_std check once we solve the compilation issues with it
+      # TODO: Add --target x86_64-unknown-none to the no_std check once we solve the compilation issues with it.
+      #       https://github.com/linebender/parley/issues/86
       - name: cargo clippy (no_std)
         run: cargo hack clippy --workspace --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} -- -D warnings
 
@@ -195,7 +196,8 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
 
-      # TODO: Add --target x86_64-unknown-none to the no_std check once we solve the compilation issues with it
+      # TODO: Add --target x86_64-unknown-none to the no_std check once we solve the compilation issues with it.
+      #       https://github.com/linebender/parley/issues/86
       - name: cargo check (no_std)
         run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }}
 

--- a/examples/vello_editor/Cargo.toml
+++ b/examples/vello_editor/Cargo.toml
@@ -21,5 +21,5 @@ workspace = true
 [target.'cfg(target_os = "android")'.dependencies]
 winit = { version = "0.30.5", features = ["android-native-activity"] }
 
-[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+[target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))'.dependencies]
 clipboard-rs = "0.1.11"

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -67,7 +67,7 @@ impl Editor {
                     .unwrap_or_default();
 
                 match event.logical_key {
-                    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+                    #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
                     Key::Character(c) if action_mod && matches!(c.as_str(), "c" | "x" | "v") => {
                         use clipboard_rs::{Clipboard, ClipboardContext};
                         use parley::layout::editor::ActiveText;

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -35,16 +35,16 @@ icu_properties = { version = "1.5.1", optional = true }
 icu_locid = "1.5.0"
 hashbrown = "0.15.0"
 
-[target.'cfg(target_family="windows")'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58.0", features = ["implement", "Win32_Graphics_DirectWrite"] }
 windows-core = { version = "0.58" }
 
-[target.'cfg(target_vendor="apple")'.dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 core-text = "20.1.0"
 core-foundation = "0.9.4"
 objc2 = { version = "0.5.2" }
 objc2-foundation = { version = "0.2.2", features = ["NSArray", "NSEnumerator", "NSPathUtilities", "NSString"] }
 
-[target.'cfg(not(any(target_vendor="apple", target_family="windows")))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 fontconfig-cache-parser = "0.2.0"
 roxmltree = "0.19.0"


### PR DESCRIPTION
The following command now passes:
```
cargo check -p fontique --locked --no-default-features --features libm --target x86_64-unknown-none
```

The key was removing the use of `not(any(target_vendor="apple", target_family="windows"))` to include `std` using dependencies, which triggers with `x86_64-unknown-none`.

I also synced the dependency conditionals with what the code expects.