### PR TITLE
Make fontique actually no-std-compatible

### DIFF
--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -22,7 +22,7 @@ libm = ["skrifa/libm", "peniko/libm", "dep:core_maths"]
 icu_properties = ["dep:icu_properties"]
 unicode_script = ["dep:unicode-script"]
 # Enables support for system font backends
-system = ["std"]
+system = ["std", "dep:windows", "dep:windows-core", "dep:core-text", "dep:core-foundation", "dep:objc2", "dep:objc2-foundation", "dep:fontconfig-cache-parser", "dep:roxmltree"]
 
 [dependencies]
 skrifa = { workspace = true }
@@ -36,15 +36,15 @@ icu_locid = "1.5.0"
 hashbrown = "0.15.0"
 
 [target.'cfg(target_family="windows")'.dependencies]
-windows = { version = "0.58.0", features = ["implement", "Win32_Graphics_DirectWrite"] }
-windows-core = { version = "0.58" }
+windows = { version = "0.58.0", features = ["implement", "Win32_Graphics_DirectWrite"], optional = true }
+windows-core = { version = "0.58", optional = true }
 
 [target.'cfg(target_vendor="apple")'.dependencies]
-core-text = "20.1.0"
-core-foundation = "0.9.4"
-objc2 = { version = "0.5.2" }
-objc2-foundation = { version = "0.2.2", features = ["NSArray", "NSEnumerator", "NSPathUtilities", "NSString"] }
+core-text = { version = "20.1.0", optional = true }
+core-foundation = { version = "0.9.4", optional = true }
+objc2 = { version = "0.5.2", optional = true }
+objc2-foundation = { version = "0.2.2", features = ["NSArray", "NSEnumerator", "NSPathUtilities", "NSString"], optional = true }
 
 [target.'cfg(not(any(target_vendor="apple", target_family="windows")))'.dependencies]
-fontconfig-cache-parser = "0.2.0"
-roxmltree = "0.19.0"
+fontconfig-cache-parser = { version = "0.2.0", optional = true }
+roxmltree = { version = "0.19.0", optional = true }


### PR DESCRIPTION
This is a prerequisite for making parley actually no-std-compatible, which I want to do so we can make sure we don't break no-std support in parley going forward, including with my AccessKit integration.