### PR TITLE
Get as close as possible to full no_std support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,6 +1815,7 @@ dependencies = [
 name = "parley"
 version = "0.2.0"
 dependencies = [
+ "core_maths",
  "fontique",
  "peniko",
  "skrifa",

--- a/fontique/src/attributes.rs
+++ b/fontique/src/attributes.rs
@@ -3,7 +3,8 @@
 
 //! Properties for specifying font weight, stretch and style.
 
-#[cfg(all(feature = "libm", not(test)))]
+#[cfg(feature = "libm")]
+#[allow(unused_imports)]
 use core_maths::*;
 
 use core::fmt;

--- a/fontique/src/attributes.rs
+++ b/fontique/src/attributes.rs
@@ -3,11 +3,7 @@
 
 //! Properties for specifying font weight, stretch and style.
 
-// This is unused due to an issue in CI and the fact that our
-// no_std support doesn't really work correctly yet.
-// See https://github.com/linebender/parley/issues/86
-#[cfg(not(feature = "std"))]
-#[allow(unused_imports)]
+#[cfg(all(feature = "libm", not(test)))]
 use core_maths::*;
 
 use core::fmt;

--- a/fontique/src/collection/mod.rs
+++ b/fontique/src/collection/mod.rs
@@ -7,7 +7,6 @@ mod query;
 
 pub use query::{Query, QueryFamily, QueryFont, QueryStatus};
 
-#[cfg(feature = "std")]
 use super::SourceCache;
 
 use super::{
@@ -166,7 +165,6 @@ impl Collection {
     }
 
     /// Returns an object for selecting fonts from this collection.
-    #[cfg(feature = "std")]
     pub fn query<'a>(&'a mut self, source_cache: &'a mut SourceCache) -> Query<'a> {
         Query::new(self, source_cache)
     }

--- a/fontique/src/collection/query.rs
+++ b/fontique/src/collection/query.rs
@@ -3,10 +3,8 @@
 
 //! Query support.
 
-#[cfg(feature = "std")]
 use super::super::{Collection, SourceCache};
 
-#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 use super::{
@@ -33,14 +31,12 @@ impl QueryState {
 pub struct Query<'a> {
     collection: &'a mut Inner,
     state: &'a mut QueryState,
-    #[cfg(feature = "std")]
     source_cache: &'a mut SourceCache,
     attributes: Attributes,
     fallbacks: Option<FallbackKey>,
 }
 
 impl<'a> Query<'a> {
-    #[cfg(feature = "std")]
     pub(super) fn new(collection: &'a mut Collection, source_cache: &'a mut SourceCache) -> Self {
         collection.query_state.clear();
         Self {
@@ -108,7 +104,6 @@ impl<'a> Query<'a> {
     ///
     /// Return [`QueryStatus::Stop`] to end iterating over the matching
     /// fonts or [`QueryStatus::Continue`] to continue iterating.
-    #[cfg(feature = "std")]
     pub fn matches_with(&mut self, mut f: impl FnMut(&QueryFont) -> QueryStatus) {
         for family in self
             .state
@@ -226,7 +221,6 @@ pub struct QueryFont {
     pub synthesis: Synthesis,
 }
 
-#[cfg(feature = "std")]
 fn load_font<'a>(
     family: &FamilyInfo,
     attributes: Attributes,

--- a/fontique/src/font.rs
+++ b/fontique/src/font.rs
@@ -5,7 +5,6 @@
 
 use super::attributes::{Stretch, Style, Weight};
 use super::source::{SourceInfo, SourceKind};
-#[cfg(feature = "std")]
 use super::{source_cache::SourceCache, Blob};
 use skrifa::raw::{types::Tag, FontRef, TableProvider as _};
 use smallvec::SmallVec;
@@ -54,13 +53,13 @@ impl FontInfo {
     }
 
     /// Attempts to load the font, optionally from a source cache.
-    #[cfg(feature = "std")]
     pub fn load(&self, source_cache: Option<&mut SourceCache>) -> Option<Blob<u8>> {
         if let Some(source_cache) = source_cache {
             source_cache.get(&self.source)
         } else {
             match &self.source.kind {
                 SourceKind::Memory(blob) => Some(blob.clone()),
+                #[cfg(feature = "std")]
                 SourceKind::Path(path) => super::source_cache::load_blob(path),
             }
         }

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -4,9 +4,7 @@
 //! Font enumeration and fallback.
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-// TODO: Remove this dead code allowance and hide the offending code behind the std feature gate.
-#![cfg_attr(not(feature = "std"), allow(dead_code))]
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(any(feature = "std", feature = "libm")))]
 compile_error!("fontique requires either the `std` or `libm` feature to be enabled");
@@ -26,7 +24,6 @@ mod scan;
 mod script;
 mod source;
 
-#[cfg(feature = "std")]
 mod source_cache;
 
 pub use icu_locid::LanguageIdentifier as Language;
@@ -41,5 +38,4 @@ pub use generic::GenericFamily;
 pub use script::Script;
 pub use source::{SourceId, SourceInfo, SourceKind};
 
-#[cfg(feature = "std")]
 pub use source_cache::{SourceCache, SourceCacheOptions};

--- a/fontique/src/scan.rs
+++ b/fontique/src/scan.rs
@@ -17,7 +17,6 @@ use smallvec::SmallVec;
 #[cfg(feature = "std")]
 use {super::source::SourcePathMap, std::path::Path};
 
-#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 #[cfg(feature = "std")]

--- a/fontique/src/source_cache.rs
+++ b/fontique/src/source_cache.rs
@@ -3,9 +3,15 @@
 
 //! Cache for font data.
 
-use super::source::{SourceId, SourceInfo, SourceKind};
+#[cfg(feature = "std")]
+use super::source::SourceId;
+use super::source::{SourceInfo, SourceKind};
+#[cfg(feature = "std")]
 use hashbrown::HashMap;
-use peniko::{Blob, WeakBlob};
+use peniko::Blob;
+#[cfg(feature = "std")]
+use peniko::WeakBlob;
+#[cfg(feature = "std")]
 use std::{
     path::Path,
     sync::{Arc, Mutex},
@@ -16,6 +22,7 @@ use std::{
 /// [source cache]: SourceCache
 #[derive(Copy, Clone, Default, Debug)]
 pub struct SourceCacheOptions {
+    #[cfg(feature = "std")]
     /// If true, the source cache will use a secondary shared cache
     /// guaranteeing that all clones will use the same backing store.
     ///
@@ -29,8 +36,11 @@ pub struct SourceCacheOptions {
 /// Cache for font data loaded from the file system.
 #[derive(Clone, Default)]
 pub struct SourceCache {
+    #[cfg(feature = "std")]
     cache: HashMap<SourceId, Entry<Blob<u8>>>,
+    #[cfg(feature = "std")]
     serial: u64,
+    #[cfg(feature = "std")]
     shared: Option<Arc<Mutex<Shared>>>,
 }
 
@@ -38,16 +48,17 @@ impl SourceCache {
     /// Creates an empty cache with the given [options].
     ///
     /// [options]: SourceCacheOptions
+    #[cfg_attr(not(feature = "std"), allow(unused))]
     pub fn new(options: SourceCacheOptions) -> Self {
+        #[cfg(feature = "std")]
         if options.shared {
-            Self {
+            return Self {
                 cache: Default::default(),
                 serial: 0,
                 shared: Some(Arc::new(Mutex::new(Shared::default()))),
-            }
-        } else {
-            Self::default()
+            };
         }
+        Self::default()
     }
 
     /// Creates an empty cache that is suitable for multi-threaded use.
@@ -57,6 +68,7 @@ impl SourceCache {
     ///
     /// This is the same as calling [`SourceCache::new`] with an options
     /// struct where `shared = true`.
+    #[cfg(feature = "std")]
     pub fn new_shared() -> Self {
         Self {
             cache: Default::default(),
@@ -72,49 +84,52 @@ impl SourceCache {
     ///
     /// [blob]: Blob
     pub fn get(&mut self, source: &SourceInfo) -> Option<Blob<u8>> {
-        let path = match &source.kind {
-            SourceKind::Memory(memory) => return Some(memory.clone()),
-            SourceKind::Path(path) => &**path,
-        };
-        use hashbrown::hash_map::Entry as HashEntry;
-        match self.cache.entry(source.id()) {
-            HashEntry::Vacant(vacant) => {
-                if let Some(mut shared) = self.shared.as_ref().and_then(|shared| shared.lock().ok())
-                {
-                    // If we have a backing cache, try to load it there first
-                    // and then propagate the result here.
-                    if let Some(blob) = shared.get(source.id(), path) {
-                        vacant.insert(Entry::Loaded(EntryData {
-                            font_data: blob.clone(),
-                            serial: self.serial,
-                        }));
-                        Some(blob)
-                    } else {
-                        vacant.insert(Entry::Failed);
-                        None
+        match &source.kind {
+            SourceKind::Memory(memory) => Some(memory.clone()),
+            #[cfg(feature = "std")]
+            SourceKind::Path(path) => {
+                use hashbrown::hash_map::Entry as HashEntry;
+                match self.cache.entry(source.id()) {
+                    HashEntry::Vacant(vacant) => {
+                        if let Some(mut shared) =
+                            self.shared.as_ref().and_then(|shared| shared.lock().ok())
+                        {
+                            // If we have a backing cache, try to load it there first
+                            // and then propagate the result here.
+                            if let Some(blob) = shared.get(source.id(), path) {
+                                vacant.insert(Entry::Loaded(EntryData {
+                                    font_data: blob.clone(),
+                                    serial: self.serial,
+                                }));
+                                Some(blob)
+                            } else {
+                                vacant.insert(Entry::Failed);
+                                None
+                            }
+                        } else {
+                            // Otherwise, load it ourselves.
+                            if let Some(blob) = load_blob(path) {
+                                vacant.insert(Entry::Loaded(EntryData {
+                                    font_data: blob.clone(),
+                                    serial: self.serial,
+                                }));
+                                Some(blob)
+                            } else {
+                                vacant.insert(Entry::Failed);
+                                None
+                            }
+                        }
                     }
-                } else {
-                    // Otherwise, load it ourselves.
-                    if let Some(blob) = load_blob(path) {
-                        vacant.insert(Entry::Loaded(EntryData {
-                            font_data: blob.clone(),
-                            serial: self.serial,
-                        }));
-                        Some(blob)
-                    } else {
-                        vacant.insert(Entry::Failed);
-                        None
+                    HashEntry::Occupied(mut occupied) => {
+                        let entry = occupied.get_mut();
+                        match entry {
+                            Entry::Loaded(data) => {
+                                data.serial = self.serial;
+                                Some(data.font_data.clone())
+                            }
+                            Entry::Failed => None,
+                        }
                     }
-                }
-            }
-            HashEntry::Occupied(mut occupied) => {
-                let entry = occupied.get_mut();
-                match entry {
-                    Entry::Loaded(data) => {
-                        data.serial = self.serial;
-                        Some(data.font_data.clone())
-                    }
-                    Entry::Failed => None,
                 }
             }
         }
@@ -122,21 +137,27 @@ impl SourceCache {
 
     /// Removes all cached blobs that have not been accessed in the last
     /// `max_age` times `prune` has been called.
+    #[cfg_attr(not(feature = "std"), allow(unused))]
     pub fn prune(&mut self, max_age: u64, prune_failed: bool) {
-        self.cache.retain(|_, entry| match entry {
-            Entry::Failed => !prune_failed,
-            Entry::Loaded(data) => self.serial.saturating_sub(data.serial) < max_age,
-        });
-        self.serial = self.serial.saturating_add(1);
+        #[cfg(feature = "std")]
+        {
+            self.cache.retain(|_, entry| match entry {
+                Entry::Failed => !prune_failed,
+                Entry::Loaded(data) => self.serial.saturating_sub(data.serial) < max_age,
+            });
+            self.serial = self.serial.saturating_add(1);
+        }
     }
 }
 
 /// Shared backing store for a font data cache.
+#[cfg(feature = "std")]
 #[derive(Default)]
 struct Shared {
     cache: HashMap<SourceId, Entry<WeakBlob<u8>>>,
 }
 
+#[cfg(feature = "std")]
 impl Shared {
     pub fn get(&mut self, id: SourceId, path: &Path) -> Option<Blob<u8>> {
         use hashbrown::hash_map::Entry as HashEntry;
@@ -177,6 +198,7 @@ impl Shared {
     }
 }
 
+#[cfg(feature = "std")]
 #[derive(Clone, Default)]
 enum Entry<T> {
     Loaded(EntryData<T>),
@@ -184,12 +206,14 @@ enum Entry<T> {
     Failed,
 }
 
+#[cfg(feature = "std")]
 #[derive(Clone)]
 struct EntryData<T> {
     font_data: T,
     serial: u64,
 }
 
+#[cfg(feature = "std")]
 pub(crate) fn load_blob(path: &Path) -> Option<Blob<u8>> {
     let file = std::fs::File::open(path).ok()?;
     let mapped = unsafe { memmap2::Mmap::map(&file).ok()? };

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [features]
 default = ["system"]
 std = ["fontique/std", "skrifa/std", "peniko/std"]
-libm = ["fontique/libm", "skrifa/libm", "peniko/libm"]
+libm = ["fontique/libm", "skrifa/libm", "peniko/libm", "dep:core_maths"]
 # Enables support for system font backends
 system = ["std", "fontique/system"]
 
@@ -27,3 +27,4 @@ swash = { workspace = true }
 skrifa = { workspace = true }
 peniko = { workspace = true }
 fontique = { workspace = true }
+core_maths = { version = "0.1.0", optional = true }

--- a/parley/src/bidi.rs
+++ b/parley/src/bidi.rs
@@ -3,7 +3,6 @@
 
 //! Unicode bidirectional algorithm.
 
-#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 use swash::text::{BidiClass, BracketType, Codepoint as _};

--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -7,9 +7,9 @@ use super::context::*;
 use super::style::*;
 use super::FontContext;
 
-#[cfg(feature = "std")]
 use super::layout::Layout;
 
+use alloc::string::String;
 use core::ops::RangeBounds;
 
 use crate::inline_box::InlineBox;
@@ -46,7 +46,6 @@ impl<B: Brush> RangedBuilder<'_, B> {
         self.lcx.inline_boxes.push(inline_box);
     }
 
-    #[cfg(feature = "std")]
     pub fn build_into(&mut self, layout: &mut Layout<B>, text: impl AsRef<str>) {
         // Apply RangedStyleBuilder styles to LayoutContext
         self.lcx.ranged_style_builder.finish(&mut self.lcx.styles);
@@ -55,7 +54,6 @@ impl<B: Brush> RangedBuilder<'_, B> {
         build_into_layout(layout, self.scale, text.as_ref(), self.lcx, self.fcx);
     }
 
-    #[cfg(feature = "std")]
     pub fn build(&mut self, text: impl AsRef<str>) -> Layout<B> {
         let mut layout = Layout::default();
         self.build_into(&mut layout, text);
@@ -114,7 +112,6 @@ impl<B: Brush> TreeBuilder<'_, B> {
             .set_white_space_mode(white_space_collapse);
     }
 
-    #[cfg(feature = "std")]
     pub fn build_into(&mut self, layout: &mut Layout<B>) -> String {
         // Apply TreeStyleBuilder styles to LayoutContext
         let text = self.lcx.tree_style_builder.finish(&mut self.lcx.styles);
@@ -127,7 +124,6 @@ impl<B: Brush> TreeBuilder<'_, B> {
         text
     }
 
-    #[cfg(feature = "std")]
     pub fn build(&mut self) -> (Layout<B>, String) {
         let mut layout = Layout::default();
         let text = self.build_into(&mut layout);
@@ -135,7 +131,6 @@ impl<B: Brush> TreeBuilder<'_, B> {
     }
 }
 
-#[cfg(feature = "std")]
 fn build_into_layout<B: Brush>(
     layout: &mut Layout<B>,
     scale: f32,

--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -3,7 +3,6 @@
 
 //! Context for layout.
 
-#[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 
 use self::tree::TreeStyleBuilder;
@@ -80,7 +79,6 @@ impl<B: Brush> LayoutContext<B> {
         self.analyze_text(text);
         self.ranged_style_builder.begin(text.len());
 
-        #[cfg(feature = "std")]
         fcx.source_cache.prune(128, false);
 
         RangedBuilder {
@@ -101,7 +99,6 @@ impl<B: Brush> LayoutContext<B> {
         let resolved_root_style = self.resolve_style_set(fcx, scale, raw_style);
         self.tree_style_builder.begin(resolved_root_style);
 
-        #[cfg(feature = "std")]
         fcx.source_cache.prune(128, false);
 
         TreeBuilder {

--- a/parley/src/font.rs
+++ b/parley/src/font.rs
@@ -3,7 +3,6 @@
 
 use fontique::Collection;
 
-#[cfg(feature = "std")]
 use fontique::SourceCache;
 
 /// A font database/cache (wrapper around a Fontique [`Collection`] and [`SourceCache`]).
@@ -12,7 +11,6 @@ use fontique::SourceCache;
 #[derive(Default)]
 pub struct FontContext {
     pub collection: Collection,
-    #[cfg(feature = "std")]
     pub source_cache: SourceCache,
 }
 

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -11,7 +11,6 @@ use swash::shape::Shaper;
 use swash::text::cluster::{Boundary, ClusterInfo};
 use swash::Synthesis;
 
-#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 #[derive(Copy, Clone)]

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -11,7 +11,7 @@ use crate::{
     style::{Brush, StyleProperty},
     FontContext, LayoutContext, Rect,
 };
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{borrow::ToOwned, string::String, sync::Arc, vec::Vec};
 
 #[derive(Copy, Clone, Debug)]
 pub enum ActiveText<'a> {

--- a/parley/src/layout/line/greedy.rs
+++ b/parley/src/layout/line/greedy.rs
@@ -3,8 +3,10 @@
 
 //! Greedy line breaking.
 
-#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+
+#[cfg(all(feature = "libm", not(test)))]
+use core_maths::*;
 
 use crate::layout::alignment::unjustify;
 use crate::layout::*;

--- a/parley/src/layout/line/greedy.rs
+++ b/parley/src/layout/line/greedy.rs
@@ -5,7 +5,8 @@
 
 use alloc::vec::Vec;
 
-#[cfg(all(feature = "libm", not(test)))]
+#[cfg(feature = "libm")]
+#[allow(unused_imports)]
 use core_maths::*;
 
 use crate::layout::alignment::unjustify;

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -12,9 +12,6 @@ pub(crate) mod data;
 
 pub mod cursor;
 
-// TODO: make editor `no_std` capable.
-//       `std` required only because of `RangedEditor::build_into`.
-#[cfg(feature = "std")]
 pub mod editor;
 
 use self::alignment::align;

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -73,9 +73,7 @@
 //! ```
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-// TODO: Remove this dead code allowance and hide the offending code behind the std feature gate.
-#![cfg_attr(not(feature = "std"), allow(dead_code))]
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(any(feature = "std", feature = "libm")))]
 compile_error!("parley requires either the `std` or `libm` feature to be enabled");
@@ -108,7 +106,6 @@ pub use inline_box::InlineBox;
 #[doc(inline)]
 pub use layout::Layout;
 
-#[cfg(feature = "std")]
 pub use layout::editor::{PlainEditor, PlainEditorTxn};
 
 pub use layout::*;

--- a/parley/src/resolve/mod.rs
+++ b/parley/src/resolve/mod.rs
@@ -8,7 +8,6 @@ pub mod tree;
 
 pub use range::RangedStyleBuilder;
 
-#[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 
 use super::style::{

--- a/parley/src/resolve/range.rs
+++ b/parley/src/resolve/range.rs
@@ -3,7 +3,6 @@
 
 //! Range based style application.
 
-#[cfg(not(feature = "std"))]
 use alloc::vec;
 
 use super::*;

--- a/parley/src/resolve/tree.rs
+++ b/parley/src/resolve/tree.rs
@@ -3,7 +3,6 @@
 
 //! Hierarchical tree based style application.
 use alloc::borrow::Cow;
-#[cfg(not(feature = "std"))]
 use alloc::{string::String, vec::Vec};
 
 use crate::style::WhiteSpaceCollapse;

--- a/parley/src/shape.rs
+++ b/parley/src/shape.rs
@@ -1,24 +1,20 @@
 // Copyright 2021 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#[cfg(feature = "std")]
 use super::layout::Layout;
 use super::resolve::{RangedStyle, ResolveContext, Resolved};
 use super::style::{Brush, FontFeature, FontVariation};
-#[cfg(feature = "std")]
 use crate::util::nearly_eq;
-#[cfg(feature = "std")]
 use crate::Font;
-#[cfg(feature = "std")]
 use fontique::QueryFamily;
 use fontique::{self, Query, QueryFont};
 use swash::shape::*;
-#[cfg(feature = "std")]
 use swash::text::cluster::{CharCluster, CharInfo, Token};
 use swash::text::{Language, Script};
 use swash::{FontRef, Synthesis};
 
-#[cfg(feature = "std")]
+use alloc::vec::Vec;
+
 use crate::inline_box::InlineBox;
 
 struct Item {
@@ -33,7 +29,6 @@ struct Item {
     letter_spacing: f32,
 }
 
-#[cfg(feature = "std")]
 #[allow(clippy::too_many_arguments)]
 pub fn shape_text<'a, B: Brush>(
     rcx: &'a ResolveContext,
@@ -265,7 +260,6 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
     }
 }
 
-#[cfg(feature = "std")]
 impl<B: Brush> partition::Selector for FontSelector<'_, '_, B> {
     type SelectedFont = SelectedFont;
 

--- a/parley/src/style/font.rs
+++ b/parley/src/style/font.rs
@@ -44,9 +44,10 @@ impl<'a> FontFamily<'a> {
     ///
     /// # Example
     /// ```
+    /// # extern crate alloc;
+    /// use alloc::borrow::Cow;
     /// use parley::style::FontFamily::{self, *};
     /// use parley::style::GenericFamily::*;
-    /// use std::borrow::Cow;
     ///
     /// assert_eq!(FontFamily::parse("Palatino Linotype"), Some(Named(Cow::Borrowed("Palatino Linotype"))));
     /// assert_eq!(FontFamily::parse("monospace"), Some(Generic(Monospace)));
@@ -63,9 +64,10 @@ impl<'a> FontFamily<'a> {
     ///
     /// # Example
     /// ```
+    /// # extern crate alloc;
+    /// use alloc::borrow::Cow;
     /// use parley::style::FontFamily::{self, *};
     /// use parley::style::GenericFamily::*;
-    /// use std::borrow::Cow;
     ///
     /// let source = "Arial, 'Times New Roman', serif";
     ///

--- a/parley/src/util.rs
+++ b/parley/src/util.rs
@@ -3,6 +3,9 @@
 
 //! Misc helpers.
 
+#[cfg(all(feature = "libm", not(test)))]
+use core_maths::*;
+
 pub fn nearly_eq(x: f32, y: f32) -> bool {
     (x - y).abs() < f32::EPSILON
 }

--- a/parley/src/util.rs
+++ b/parley/src/util.rs
@@ -3,7 +3,8 @@
 
 //! Misc helpers.
 
-#[cfg(all(feature = "libm", not(test)))]
+#[cfg(feature = "libm")]
+#[allow(unused_imports)]
 use core_maths::*;
 
 pub fn nearly_eq(x: f32, y: f32) -> bool {


### PR DESCRIPTION
To really get no-std support in parley, we need to land dfrg/swash#63. But I believe I've done everything else that's necessary, in both parley and fontique. One can test the build by patching Cargo.toml to use the working branch for that swash PR, and modifying parley/Cargo.toml to specify swash/std or swash/libm as appropriate. If we decide to land dfrg/swash#63 before landing this one, then I can make the latter modification to parley/Cargo.toml before merging this PR.

Some of my changes, e.g. unconditionally using `alloc::vec::Vec`, are designed to minimize the amount of noise when searching the whole source tree for "std".