### PR TITLE
Derive Clone for FontContext

### DIFF
--- a/parley/src/font.rs
+++ b/parley/src/font.rs
@@ -9,7 +9,7 @@ use fontique::SourceCache;
 /// A font database/cache (wrapper around a Fontique [`Collection`] and [`SourceCache`]).
 ///
 /// This type is designed to be a global resource with only one per-application (or per-thread).
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct FontContext {
     pub collection: Collection,
     #[cfg(feature = "std")]


### PR DESCRIPTION
This is useful because cloning a `FontContext` is currently the only way to get a second `FontContext` without reloading system fonts (which is quite expensive). Using this approach to avoid reloading system fonts in Blitz's WPT test runner which has a Blitz `Document` (and thus a `FontContext`) per test brings our total runtime down by about 40%.

It is possible to work around this by manually cloning the `FontContext` (it's two public fields impl `Clone`).

We will probably want a better solution for reusing loaded system fonts at some point.