### PR TITLE
Remove broken line break condition in right-side handling in `Cursor::previous_visual`

### DIFF
--- a/parley/src/layout/cursor.rs
+++ b/parley/src/layout/cursor.rs
@@ -282,14 +282,6 @@ impl Cursor {
             return *self;
         };
         if !self.affinity.is_visually_leading(self.is_rtl) {
-            // Handle hard line breaks
-            if cluster.is_hard_line_break() {
-                // If we're at the back of a hard line break and moving
-                // left, skip directly to the trailing edge of the next cluster
-                if let Some(next) = cluster.previous_logical() {
-                    return Self::from_cluster(next, self.affinity);
-                }
-            }
             // Check for directional boundary condition
             if let Some(prev) = cluster.previous_visual() {
                 if prev.is_rtl() != self.is_rtl {


### PR DESCRIPTION
That code was clearly adapted from the left-side handling in `Cursor::next_visual`, but it doesn't seem to belong here. It caused this bug: In vello_editor, move down to the first line of the second paragraph (after the blank line), arrow right once, then arrow left. That should leave the cursor back at the start of that line, but instead it jumps back to the blank line.