### PR TITLE
Skip adding font family as fallback if it has zero coverage for given script

### DIFF
--- a/fontique/src/backend/fontconfig/mod.rs
+++ b/fontique/src/backend/fontconfig/mod.rs
@@ -254,14 +254,14 @@ fn find_best_family<'a>(
     raw_families: impl Iterator<Item = &'a RawFamily>,
     text: &str,
 ) -> Option<FamilyId> {
-    let text_len = text.len();
+    let char_count = text.chars().count();
     let mut best_id = None;
     let mut best_coverage = 0;
     for family in raw_families {
         let id = family.name.id();
         for font in &family.fonts {
             let coverage = font.coverage.compute_for_str(text);
-            if coverage == text_len {
+            if coverage == char_count {
                 return Some(id);
             }
             if coverage > best_coverage {


### PR DESCRIPTION
Fontconfig can be and is so in some distros, configured wrong. It can report fonts as a fallback for given language when in reality the font family has zero coverage for given language.

This change does preliminary coverage check for fonts loaded from fontconfig and skips font families that have zero coverage for given language it reports.

This PR also contains small fix for calculating coverage, where it could never match font with full coverage for multi-byte chars as computing coverage returns how many characters it matches but we compared it to number of bytes in a string.

Fixes #174

I've tested this on fresh install of PopOS where the font fallback for Arabic script failed and works with this change.
I've also tested this on fresh install of Ubuntu 24.04 where fontconfig is configured correctly, fallback worked correctly without this change and still works correctly with this change.
