### PR TITLE
Update to Linebender lint set v2.

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,7 +1,13 @@
-# The default Clippy value for this is 8 bytes, which is chosen to improve performance on 32-bit.
-# Given that we're building for the future and even mobile phones have 64-bit CPUs,
+# LINEBENDER LINT SET - .clippy.toml - v1
+# See https://linebender.org/wiki/canonical-lints/
+
+# The default Clippy value is capped at 8 bytes, which was chosen to improve performance on 32-bit.
+# Given that we are building for the future and even low-end mobile phones have 64-bit CPUs,
 # it makes sense to optimize for 64-bit and accept the performance hits on 32-bit.
 # 16 bytes is the number of bytes that fits into two 64-bit CPU registers.
 trivial-copy-size-limit = 16
+
+# END LINEBENDER LINT SET
+
 # Don't warn about these identifiers when using clippy::doc_markdown.
 doc-valid-idents = ["OpenType", ".."]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/parley"
 
 [workspace.lints]
-# LINEBENDER LINT SET - v1
+# LINEBENDER LINT SET - Cargo.toml - v2
 # See https://linebender.org/wiki/canonical-lints/
 rust.keyword_idents_2024 = "forbid"
 rust.non_ascii_idents = "forbid"
@@ -65,6 +65,7 @@ clippy.semicolon_if_nothing_returned = "warn"
 clippy.shadow_unrelated = "warn"
 clippy.should_panic_without_expect = "warn"
 clippy.todo = "warn"
+clippy.trivially_copy_pass_by_ref = "warn"
 clippy.unseparated_literal_suffix = "warn"
 clippy.use_self = "warn"
 clippy.wildcard_imports = "warn"

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -22,7 +22,12 @@ libm = ["read-fonts/libm", "peniko/libm", "dep:core_maths"]
 icu_properties = ["dep:icu_properties"]
 unicode_script = ["dep:unicode-script"]
 # Enables support for system font backends
-system = ["std"]
+system = [
+	"std",
+	"dep:windows", "dep:windows-core",
+	"dep:core-text", "dep:core-foundation", "dep:objc2", "dep:objc2-foundation",
+	"dep:fontconfig-cache-parser", "dep:roxmltree",
+]
 
 [dependencies]
 read-fonts = { workspace = true }
@@ -36,15 +41,17 @@ icu_locid = "1.5.0"
 hashbrown = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.58.0", features = ["implement", "Win32_Graphics_DirectWrite"] }
-windows-core = { version = "0.58" }
+windows = { version = "0.58.0", features = ["implement", "Win32_Graphics_DirectWrite"], optional = true }
+windows-core = { version = "0.58", optional = true }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-core-text = "20.1.0"
-core-foundation = "0.9.4"
-objc2 = { version = "0.5.2" }
-objc2-foundation = { version = "0.2.2", features = ["NSArray", "NSEnumerator", "NSPathUtilities", "NSString"] }
+core-text = { version = "20.1.0", optional = true }
+core-foundation = { version = "0.9.4", optional = true }
+objc2 = { version = "0.5.2", optional = true }
+objc2-foundation = { version = "0.2.2", features = ["NSArray", "NSEnumerator", "NSPathUtilities", "NSString"], optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+fontconfig-cache-parser = { version = "0.2.0", optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-fontconfig-cache-parser = "0.2.0"
-roxmltree = "0.19.0"
+roxmltree = { version = "0.19.0", optional = true }

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -3,6 +3,13 @@
 
 //! Font enumeration and fallback.
 
+// LINEBENDER LINT SET - lib.rs - v1
+// See https://linebender.org/wiki/canonical-lints/
+// These lints aren't included in Cargo.toml because they
+// shouldn't apply to examples and tests
+#![warn(unused_crate_dependencies)]
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(elided_lifetimes_in_paths)]

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -72,6 +72,13 @@
 //! }
 //! ```
 
+// LINEBENDER LINT SET - lib.rs - v1
+// See https://linebender.org/wiki/canonical-lints/
+// These lints aren't included in Cargo.toml because they
+// shouldn't apply to examples and tests
+#![warn(unused_crate_dependencies)]
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(elided_lifetimes_in_paths)]


### PR DESCRIPTION
The new `unused_crate_dependencies` lint revealed some system dependencies in `fontique` that needed to be better feature gated.