### PR TITLE
Fix off-by-one error in `PlainEditor::cursor_at`

### DIFF
--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -519,11 +519,7 @@ where
     fn cursor_at(&self, index: usize) -> Cursor {
         // FIXME: `Selection` should make this easier
         if index >= self.buffer.len() {
-            Cursor::from_byte_index(
-                &self.layout,
-                self.buffer.len().saturating_sub(1),
-                Affinity::Upstream,
-            )
+            Cursor::from_byte_index(&self.layout, self.buffer.len(), Affinity::Upstream)
         } else {
             Cursor::from_byte_index(&self.layout, index, Affinity::Downstream)
         }


### PR DESCRIPTION
I believe the cursor should still land at index `self.buffer.len()` (logically following the last cluster).

E.g., in https://github.com/linebender/xilem/pull/762, if used without this change, the selection can't span the last cluster using `cursor_at`.