### PR TITLE
Fix binary search in Layout::line_for_offset

### DIFF
--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -176,7 +176,7 @@ impl<B: Brush> Layout<B> {
         let maybe_line_index = self.data.lines.binary_search_by(|line| {
             if offset < line.metrics.min_coord {
                 Ordering::Greater
-            } else if offset > line.metrics.max_coord {
+            } else if offset >= line.metrics.max_coord {
                 Ordering::Less
             } else {
                 Ordering::Equal

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -168,7 +168,8 @@ impl<B: Brush> Layout<B> {
     /// given `offset`.
     ///
     /// The offset is specified in the direction orthogonal to line direction.
-    /// For horizontal text, this is a vertical or y offset.
+    /// For horizontal text, this is a vertical or y offset. If the offset is
+    /// on a line boundary, it is considered to be contained by the later line.
     pub(crate) fn line_for_offset(&self, offset: f32) -> Option<(usize, Line<B>)> {
         if offset < 0.0 {
             return Some((0, self.get(0)?));


### PR DESCRIPTION
There currently is an issue with `PlainEditorTxn::select_all` not working correctly (and probably some other methods as well). I believe the cause is in `Layout::line_for_offset`.

The current binary search appears to have a discontinuity at the line edge, as an offset on a line boundary is considered to be inside both lines. The sensible thing to do is probably to define the offset being on the min coord edge of a line to be inside that line, and when on the max coord edge of a line to be outside that line. That fits best with current usage in, e.g., `Cursor::line`.

For example, with two lines with the following metrics and the following offset,

```
min_coord = 507.0, max_coord = 546.0
min_coord = 546.0, max_coord = 585.0
offset = 546.0
```

currently, the chosen line is the one earlier in the stream (i.e., the one with `max_coord = 546.0`). Depending on the exact number of lines and specific metrics, sometimes the line later in the stream is chosen.