### PR TITLE
Update Rust stable to 1.83

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ env:
   # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.82" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
+  RUST_STABLE_VER: "1.83" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
   # The purpose of checking with the minimum supported Rust toolchain is to detect its staleness.
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,

--- a/parley/src/style/font.rs
+++ b/parley/src/style/font.rs
@@ -85,13 +85,13 @@ impl<'a> FontFamily<'a> {
     }
 }
 
-impl<'a> From<GenericFamily> for FontFamily<'a> {
+impl From<GenericFamily> for FontFamily<'_> {
     fn from(f: GenericFamily) -> Self {
         FontFamily::Generic(f)
     }
 }
 
-impl<'a> From<GenericFamily> for FontStack<'a> {
+impl From<GenericFamily> for FontStack<'_> {
     fn from(f: GenericFamily) -> Self {
         FontStack::Single(f.into())
     }

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -155,7 +155,7 @@ impl<'a, B: Brush> From<FontFamily<'a>> for StyleProperty<'a, B> {
     }
 }
 
-impl<'a, B: Brush> From<GenericFamily> for StyleProperty<'a, B> {
+impl<B: Brush> From<GenericFamily> for StyleProperty<'_, B> {
     fn from(f: GenericFamily) -> Self {
         StyleProperty::FontStack(f.into())
     }


### PR DESCRIPTION
Some changes needed for `needless_lifetimes` , but none of them bad.