### PR TITLE
Add "AccessKit" to doc-valid-idents

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -10,4 +10,4 @@ trivial-copy-size-limit = 16
 # END LINEBENDER LINT SET
 
 # Don't warn about these identifiers when using clippy::doc_markdown.
-doc-valid-idents = ["OpenType", ".."]
+doc-valid-idents = ["AccessKit", "OpenType", ".."]


### PR DESCRIPTION
clippy:

```
warning: item in documentation is missing backticks
   --> examples/vello_editor/src/main.rs:100:46
    |
100 |     /// The event loop proxy required by the AccessKit winit adapter.
    |                                              ^^^^^^^^^
...
```