### PR TITLE
Fix whitespace collapsing at the start of inline spans

### DIFF
--- a/parley/src/resolve/tree.rs
+++ b/parley/src/resolve/tree.rs
@@ -107,10 +107,8 @@ impl<B: Brush> TreeStyleBuilder<B> {
         };
         let span_text = span_text.as_ref();
 
-        // Nothing to do if there is no uncommitted text
+        // Nothing to do if there is no uncommitted text.
         if span_text.is_empty() {
-            // This is for the case of an inline box. This possibly ought to be made more explicit.
-            self.is_span_first = false;
             return;
         }
 


### PR DESCRIPTION
Generally, whitespace collapsing collapses sequences of whitespace into a single space character. However, whitespace at the very start or end of a span should be elided entirely.

We use a flag to track if we are in this state. However, there was a bug which was causing this flag to cleared when whitespace itself was pushed, which caused start-of-span whitespace to appear as a single space if it is pushed into the builder in multiple chunks.

This patch prevents the flag from being cleared by whitespace to fix that bug.

This patch fixes the rendering of a number of websites in Blitz including https://alistapart.com, an older snapshot of https://google.com (the latest version doesn't run into this bug), and around 40 WPT tests.

### Blitz rendering google.com with this patch

<img width="913" alt="Screenshot 2024-12-02 at 10 58 06" src="https://github.com/user-attachments/assets/3b202d59-8232-448f-bcaa-f0b350718c08">
