### PR TITLE
Minimise the need to batch operations in `PlainEditor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ This release has an [MSRV] of 1.75.
 
 - `Generation` on `PlainEditor` to help implement lazy drawing. ([#143] by [@xorgy])
 
+### Changed
+
+### Parley
+
+- Breaking change: `PlainEditor`'s semantics are no longer transactional ([#192][] by [@DJMcNab][])
 
 ## [0.2.0] - 2024-10-10
 
@@ -76,6 +81,7 @@ This release has an [MSRV] of 1.70.
 [MSRV]: README.md#minimum-supported-rust-version-msrv
 
 [@dfrg]: https://github.com/dfrg
+[@DJMcNab]: https://github.com/DJMcNab
 [@nicoburns]: https://github.com/nicoburns
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 [@xorgy]: https://github.com/xorgy
@@ -93,6 +99,7 @@ This release has an [MSRV] of 1.70.
 [#126]: https://github.com/linebender/parley/pull/126
 [#129]: https://github.com/linebender/parley/pull/129
 [#143]: https://github.com/linebender/parley/pull/143
+[#192]: https://github.com/linebender/parley/pull/192
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/linebender/parley/releases/tag/v0.2.0

--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -28,7 +28,6 @@ mod access_ids;
 use access_ids::{TEXT_INPUT_ID, WINDOW_ID};
 
 mod text;
-use parley::{GenericFamily, StyleProperty};
 
 const WINDOW_TITLE: &str = "Vello Text Editor";
 
@@ -116,12 +115,6 @@ impl ApplicationHandler<accesskit_winit::Event> for SimpleVelloApp<'_> {
         window.set_visible(true);
 
         let size = window.inner_size();
-
-        self.editor.transact(|txn| {
-            txn.set_scale(1.0);
-            txn.set_width(Some(size.width as f32 - 2f32 * text::INSET));
-            txn.set_text(text::LOREM);
-        });
 
         // Create a vello Surface
         let surface_future = {
@@ -236,15 +229,9 @@ impl ApplicationHandler<accesskit_winit::Event> for SimpleVelloApp<'_> {
             WindowEvent::Resized(size) => {
                 self.context
                     .resize_surface(&mut render_state.surface, size.width, size.height);
-                self.editor.transact(|txn| {
-                    txn.set_scale(1.0);
-                    txn.set_width(Some(size.width as f32 - 2f32 * text::INSET));
-                    txn.set_default_style(Arc::new([
-                        StyleProperty::FontSize(32.0),
-                        StyleProperty::LineHeight(1.2),
-                        GenericFamily::SystemUi.into(),
-                    ]));
-                });
+                let editor = self.editor.editor();
+                editor.set_scale(1.0);
+                editor.set_width(Some(size.width as f32 - 2f32 * text::INSET));
                 render_state.window.request_redraw();
             }
 
@@ -352,7 +339,7 @@ fn main() -> Result<()> {
         renderers: vec![],
         state: RenderState::Suspended(None),
         scene: Scene::new(),
-        editor: text::Editor::default(),
+        editor: text::Editor::new(text::LOREM),
         last_drawn_generation: Default::default(),
         event_loop_proxy: event_loop.create_proxy(),
     };

--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -113,6 +113,7 @@ impl ApplicationHandler<accesskit_winit::Event> for SimpleVelloApp<'_> {
         let access_adapter =
             accesskit_winit::Adapter::with_event_loop_proxy(&window, self.event_loop_proxy.clone());
         window.set_visible(true);
+        window.set_ime_allowed(true);
 
         let size = window.inner_size();
 
@@ -348,7 +349,8 @@ fn main() -> Result<()> {
     event_loop
         .run_app(&mut app)
         .expect("Couldn't run event loop");
-    print!("{}", app.editor.text());
+    let [text1, text2] = app.editor.text();
+    print!("{text1}{text2}");
     Ok(())
 }
 

--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -349,8 +349,8 @@ fn main() -> Result<()> {
     event_loop
         .run_app(&mut app)
         .expect("Couldn't run event loop");
-    let [text1, text2] = app.editor.text();
-    print!("{text1}{text2}");
+    let text = app.editor.text();
+    print!("{text}");
     Ok(())
 }
 

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -22,7 +22,7 @@ std = ["fontique/std", "skrifa/std", "peniko/std"]
 libm = ["fontique/libm", "skrifa/libm", "peniko/libm", "dep:core_maths"]
 # Enables support for system font backends
 system = ["std", "fontique/system"]
-accesskit = ["dep:accesskit", "dep:hashbrown"]
+accesskit = ["dep:accesskit"]
 
 [dependencies]
 swash = { workspace = true }
@@ -31,7 +31,7 @@ peniko = { workspace = true }
 fontique = { workspace = true }
 core_maths = { version = "0.1.0", optional = true }
 accesskit = { workspace = true, optional = true }
-hashbrown = { workspace = true, optional = true }
+hashbrown = { workspace = true }
 
 [dev-dependencies]
 tiny-skia = "0.11.4"

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -382,6 +382,7 @@ where
     pub fn move_to_text_start(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
             isize::MIN,
@@ -393,6 +394,7 @@ where
     pub fn move_to_line_start(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.line_start(&self.editor.layout, false));
     }
@@ -401,6 +403,7 @@ where
     pub fn move_to_text_end(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
             isize::MAX,
@@ -412,6 +415,7 @@ where
     pub fn move_to_line_end(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.line_end(&self.editor.layout, false));
     }
@@ -420,6 +424,7 @@ where
     pub fn move_up(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(
             self.editor
                 .selection
@@ -431,6 +436,7 @@ where
     pub fn move_down(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.next_line(&self.editor.layout, false));
     }
@@ -439,6 +445,7 @@ where
     pub fn move_left(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(
             self.editor
                 .selection
@@ -450,6 +457,7 @@ where
     pub fn move_right(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(
             self.editor
                 .selection
@@ -461,6 +469,7 @@ where
     pub fn move_word_left(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(
             self.editor
                 .selection
@@ -472,6 +481,7 @@ where
     pub fn move_word_right(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(
             self.editor
                 .selection
@@ -483,6 +493,7 @@ where
     pub fn select_all(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(
             Selection::from_byte_index(&self.editor.layout, 0_usize, Affinity::default())
                 .move_lines(&self.editor.layout, isize::MAX, true),
@@ -500,6 +511,7 @@ where
     pub fn select_to_text_start(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
             isize::MIN,
@@ -511,6 +523,7 @@ where
     pub fn select_to_line_start(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.line_start(&self.editor.layout, true));
     }
@@ -519,6 +532,7 @@ where
     pub fn select_to_text_end(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
             isize::MAX,
@@ -530,6 +544,7 @@ where
     pub fn select_to_line_end(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.line_end(&self.editor.layout, true));
     }
@@ -538,6 +553,7 @@ where
     pub fn select_up(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(
             self.editor
                 .selection
@@ -549,6 +565,7 @@ where
     pub fn select_down(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.next_line(&self.editor.layout, true));
     }
@@ -557,6 +574,7 @@ where
     pub fn select_left(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(
             self.editor
                 .selection
@@ -568,6 +586,7 @@ where
     pub fn select_right(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.next_visual(&self.editor.layout, true));
     }
@@ -576,6 +595,7 @@ where
     pub fn select_word_left(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(
             self.editor
                 .selection
@@ -587,6 +607,7 @@ where
     pub fn select_word_right(&mut self) {
         assert!(!self.editor.is_composing());
 
+        self.refresh_layout();
         self.editor.set_selection(
             self.editor
                 .selection
@@ -691,7 +712,7 @@ where
     }
     // --- MARK: Internal helpers---
     /// Update the layout if needed.
-    fn refresh_layout(&mut self) {
+    pub fn refresh_layout(&mut self) {
         self.editor.refresh_layout(self.font_cx, self.layout_cx);
     }
 

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -1,21 +1,23 @@
 // Copyright 2024 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use core::{cmp::PartialEq, default::Default, fmt::Debug};
+//! Import of Parley's `PlainEditor` as the version in Parley is insufficient for our needs.
 
-#[cfg(feature = "accesskit")]
-use crate::layout::LayoutAccessibility;
 use crate::{
     layout::{
         cursor::{Cursor, Selection},
-        Affinity, Alignment, Layout, Line,
+        Affinity, Alignment, Layout,
     },
-    style::{Brush, StyleProperty},
-    FontContext, LayoutContext, Rect,
+    style::Brush,
+    FontContext, LayoutContext, Rect, StyleProperty, StyleSet,
 };
+use alloc::{borrow::ToOwned, string::String, vec::Vec};
+use core::{cmp::PartialEq, default::Default, fmt::Debug, ops::Range};
+
+#[cfg(feature = "accesskit")]
+use crate::layout::LayoutAccessibility;
 #[cfg(feature = "accesskit")]
 use accesskit::{Node, NodeId, TreeUpdate};
-use alloc::{borrow::ToOwned, string::String, sync::Arc, vec::Vec};
 
 /// Opaque representation of a generation.
 ///
@@ -40,12 +42,15 @@ pub struct PlainEditor<T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,
 {
-    default_style: Arc<[StyleProperty<'static, T>]>,
+    default_style: StyleSet<T>,
     buffer: String,
     layout: Layout<T>,
     #[cfg(feature = "accesskit")]
     layout_access: LayoutAccessibility,
     selection: Selection,
+    /// Byte offsets of IME composing preedit text in the text buffer.
+    /// `None` if the IME is not currently composing.
+    compose: Option<Range<usize>>,
     width: Option<f32>,
     scale: f32,
     // Simple tracking of when the layout needs to be updated
@@ -54,25 +59,31 @@ where
     // Not all operations on `PlainEditor` need to operate on a
     // clean layout, and not all operations trigger a layout.
     layout_dirty: bool,
+    // TODO: We could avoid redoing the full text layout if linebreaking or
+    // alignment were unchanged
+    // linebreak_dirty: bool,
+    // alignment_dirty: bool,
+    alignment: Alignment,
     generation: Generation,
 }
 
-// TODO: When MSRV >= 1.80 we can remove this. Default was not implemented for Arc<[T]> where T: !Default until 1.80
-impl<T> Default for PlainEditor<T>
+impl<T> PlainEditor<T>
 where
-    T: Brush + Clone + Debug + PartialEq + Default,
+    T: Brush,
 {
-    fn default() -> Self {
+    pub fn new(font_size: f32) -> Self {
         Self {
-            default_style: Arc::new([]),
+            default_style: StyleSet::new(font_size),
             buffer: Default::default(),
             layout: Default::default(),
             #[cfg(feature = "accesskit")]
             layout_access: Default::default(),
             selection: Default::default(),
-            width: Default::default(),
+            compose: None,
+            width: None,
             scale: 1.0,
-            layout_dirty: Default::default(),
+            layout_dirty: true,
+            alignment: Alignment::Start,
             // We don't use the `default` value to start with, as our consumers
             // will choose to use that as their initial value, but will probably need
             // to redraw if they haven't already.
@@ -87,53 +98,35 @@ pub struct PlainEditorTxn<'a, T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,
 {
-    editor: &'a mut PlainEditor<T>,
-    font_cx: &'a mut FontContext,
-    layout_cx: &'a mut LayoutContext<T>,
+    pub editor: &'a mut PlainEditor<T>,
+    pub font_cx: &'a mut FontContext,
+    pub layout_cx: &'a mut LayoutContext<T>,
 }
 
 impl<T> PlainEditorTxn<'_, T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,
 {
-    /// Replace the whole text buffer.
-    pub fn set_text(&mut self, is: &str) {
-        self.editor.buffer.clear();
-        self.editor.buffer.push_str(is);
-        self.editor.layout_dirty = true;
-    }
-
-    /// Set the width of the layout.
-    pub fn set_width(&mut self, width: Option<f32>) {
-        self.editor.width = width;
-        self.editor.layout_dirty = true;
-    }
-
-    /// Set the scale for the layout.
-    pub fn set_scale(&mut self, scale: f32) {
-        self.editor.scale = scale;
-        self.editor.layout_dirty = true;
-    }
-
-    /// Set the default style for the layout.
-    pub fn set_default_style(&mut self, style: Arc<[StyleProperty<'static, T>]>) {
-        self.editor.default_style = style;
-        self.editor.layout_dirty = true;
-    }
-
+    // --- MARK: Forced relayout ---
     /// Insert at cursor, or replace selection.
     pub fn insert_or_replace_selection(&mut self, s: &str) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .replace_selection(self.font_cx, self.layout_cx, s);
     }
 
     /// Delete the selection.
     pub fn delete_selection(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.insert_or_replace_selection("");
     }
 
     /// Delete the selection or the next cluster (typical ‘delete’ behavior).
     pub fn delete(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.selection.is_collapsed() {
             // Upstream cluster range
             if let Some(range) = self
@@ -155,6 +148,8 @@ where
 
     /// Delete the selection or up to the next word boundary (typical ‘ctrl + delete’ behavior).
     pub fn delete_word(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.selection.is_collapsed() {
             let focus = self.editor.selection.focus();
             let start = focus.index();
@@ -174,6 +169,8 @@ where
 
     /// Delete the selection or the previous cluster (typical ‘backspace’ behavior).
     pub fn backdelete(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.selection.is_collapsed() {
             // Upstream cluster
             if let Some(cluster) = self
@@ -214,6 +211,8 @@ where
 
     /// Delete the selection or back to the previous word boundary (typical ‘ctrl + backspace’ behavior).
     pub fn backdelete_word(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.selection.is_collapsed() {
             let focus = self.editor.selection.focus();
             let end = focus.index();
@@ -231,8 +230,75 @@ where
         }
     }
 
+    // --- MARK: IME ---
+    /// Set the IME preedit composing text.
+    ///
+    /// This starts composing. Composing is reset by calling [`PlainEditorTxn::clear_compose`].
+    /// While composing, it is a logic error to call anything other than
+    /// [`PlainEditorTxn::set_compose`] or [`PlainEditorTxn::clear_compose`].
+    ///
+    /// The preedit text replaces the current selection if this call starts composing.
+    ///
+    /// The selection is updated based on `cursor`, which contains the byte offsets relative to the
+    /// start of the preedit text. If `cursor` is `None`, the selection is collapsed to a caret in
+    /// front of the preedit text.
+    pub fn set_compose(&mut self, text: &str, cursor: Option<(usize, usize)>) {
+        debug_assert!(!text.is_empty());
+        debug_assert!(cursor.map(|cursor| cursor.1 <= text.len()).unwrap_or(true));
+
+        let start = if let Some(preedit_range) = self.editor.compose.clone() {
+            self.editor
+                .buffer
+                .replace_range(preedit_range.clone(), text);
+            preedit_range.start
+        } else {
+            if self.editor.selection.is_collapsed() {
+                self.editor
+                    .buffer
+                    .insert_str(self.editor.selection.text_range().start, text);
+            } else {
+                self.editor
+                    .buffer
+                    .replace_range(self.editor.selection.text_range(), text);
+            }
+            self.editor.selection.text_range().start
+        };
+        self.editor.compose = Some(start..start + text.len());
+        self.update_layout();
+
+        if let Some(cursor) = cursor {
+            // Select the location indicated by the IME.
+            self.editor.set_selection(Selection::new(
+                self.editor.cursor_at(start + cursor.0),
+                self.editor.cursor_at(start + cursor.1),
+            ));
+        } else {
+            // IME indicates nothing is to be selected: collapse the selection to a
+            // caret just in front of the preedit.
+            self.editor
+                .set_selection(self.editor.cursor_at(start).into());
+        }
+    }
+
+    /// Stop IME composing.
+    ///
+    /// This removes the IME preedit text.
+    pub fn clear_compose(&mut self) {
+        if let Some(preedit_range) = self.editor.compose.clone() {
+            self.editor.buffer.replace_range(preedit_range.clone(), "");
+            self.editor.compose = None;
+            self.update_layout();
+
+            self.editor
+                .set_selection(self.editor.cursor_at(preedit_range.start).into());
+        }
+    }
+
+    // --- MARK: Cursor Movement ---
     /// Move the cursor to the cluster boundary nearest this point in the layout.
     pub fn move_to_point(&mut self, x: f32, y: f32) {
+        debug_assert!(!self.editor.is_composing());
+
         self.refresh_layout();
         self.editor
             .set_selection(Selection::from_point(&self.editor.layout, x, y));
@@ -242,6 +308,8 @@ where
     ///
     /// No-op if index is not a char boundary.
     pub fn move_to_byte(&mut self, index: usize) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.buffer.is_char_boundary(index) {
             self.refresh_layout();
             self.editor
@@ -251,6 +319,8 @@ where
 
     /// Move the cursor to the start of the buffer.
     pub fn move_to_text_start(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
             isize::MIN,
@@ -260,12 +330,16 @@ where
 
     /// Move the cursor to the start of the physical line.
     pub fn move_to_line_start(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.line_start(&self.editor.layout, false));
     }
 
     /// Move the cursor to the end of the buffer.
     pub fn move_to_text_end(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
             isize::MAX,
@@ -275,12 +349,16 @@ where
 
     /// Move the cursor to the end of the physical line.
     pub fn move_to_line_end(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.line_end(&self.editor.layout, false));
     }
 
     /// Move up to the closest physical cluster boundary on the previous line, preserving the horizontal position for repeated movements.
     pub fn move_up(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -290,12 +368,16 @@ where
 
     /// Move down to the closest physical cluster boundary on the next line, preserving the horizontal position for repeated movements.
     pub fn move_down(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.next_line(&self.editor.layout, false));
     }
 
     /// Move to the next cluster left in visual order.
     pub fn move_left(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -305,6 +387,8 @@ where
 
     /// Move to the next cluster right in visual order.
     pub fn move_right(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -314,6 +398,8 @@ where
 
     /// Move to the next word boundary left.
     pub fn move_word_left(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -323,6 +409,8 @@ where
 
     /// Move to the next word boundary right.
     pub fn move_word_right(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -332,19 +420,25 @@ where
 
     /// Select the whole buffer.
     pub fn select_all(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
-            Selection::from_byte_index(&self.editor.layout, 0usize, Affinity::default())
+            Selection::from_byte_index(&self.editor.layout, 0_usize, Affinity::default())
                 .move_lines(&self.editor.layout, isize::MAX, true),
         );
     }
 
     /// Collapse selection into caret.
     pub fn collapse_selection(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(self.editor.selection.collapse());
     }
 
     /// Move the selection focus point to the start of the buffer.
     pub fn select_to_text_start(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
             isize::MIN,
@@ -354,12 +448,16 @@ where
 
     /// Move the selection focus point to the start of the physical line.
     pub fn select_to_line_start(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.line_start(&self.editor.layout, true));
     }
 
     /// Move the selection focus point to the end of the buffer.
     pub fn select_to_text_end(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
             isize::MAX,
@@ -369,12 +467,16 @@ where
 
     /// Move the selection focus point to the end of the physical line.
     pub fn select_to_line_end(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.line_end(&self.editor.layout, true));
     }
 
     /// Move the selection focus point up to the nearest cluster boundary on the previous line, preserving the horizontal position for repeated movements.
     pub fn select_up(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -384,12 +486,16 @@ where
 
     /// Move the selection focus point down to the nearest cluster boundary on the next line, preserving the horizontal position for repeated movements.
     pub fn select_down(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.next_line(&self.editor.layout, true));
     }
 
     /// Move the selection focus point to the next cluster left in visual order.
     pub fn select_left(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -399,12 +505,16 @@ where
 
     /// Move the selection focus point to the next cluster right in visual order.
     pub fn select_right(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.next_visual(&self.editor.layout, true));
     }
 
     /// Move the selection focus point to the next word boundary left.
     pub fn select_word_left(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -414,6 +524,8 @@ where
 
     /// Move the selection focus point to the next word boundary right.
     pub fn select_word_right(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -423,6 +535,8 @@ where
 
     /// Select the word at the point.
     pub fn select_word_at_point(&mut self, x: f32, y: f32) {
+        debug_assert!(!self.editor.is_composing());
+
         self.refresh_layout();
         self.editor
             .set_selection(Selection::word_from_point(&self.editor.layout, x, y));
@@ -430,6 +544,8 @@ where
 
     /// Select the physical line at the point.
     pub fn select_line_at_point(&mut self, x: f32, y: f32) {
+        debug_assert!(!self.editor.is_composing());
+
         self.refresh_layout();
         let line = Selection::line_from_point(&self.editor.layout, x, y);
         self.editor.set_selection(line);
@@ -437,6 +553,8 @@ where
 
     /// Move the selection focus point to the cluster boundary closest to point.
     pub fn extend_selection_to_point(&mut self, x: f32, y: f32) {
+        debug_assert!(!self.editor.is_composing());
+
         self.refresh_layout();
         // FIXME: This is usually the wrong way to handle selection extension for mouse moves, but not a regression.
         self.editor.set_selection(
@@ -450,13 +568,12 @@ where
     ///
     /// No-op if index is not a char boundary.
     pub fn extend_selection_to_byte(&mut self, index: usize) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.buffer.is_char_boundary(index) {
             self.refresh_layout();
-            self.editor.set_selection(
-                self.editor
-                    .selection
-                    .maybe_extend(self.editor.cursor_at(index), true),
-            );
+            self.editor
+                .set_selection(self.editor.selection.extend(self.editor.cursor_at(index)));
         }
     }
 
@@ -464,17 +581,21 @@ where
     ///
     /// No-op if either index is not a char boundary.
     pub fn select_byte_range(&mut self, start: usize, end: usize) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.buffer.is_char_boundary(start) && self.editor.buffer.is_char_boundary(end) {
             self.refresh_layout();
-            self.editor.set_selection(
-                Selection::from(self.editor.cursor_at(start))
-                    .maybe_extend(self.editor.cursor_at(end), true),
-            );
+            self.editor.set_selection(Selection::new(
+                self.editor.cursor_at(start),
+                self.editor.cursor_at(end),
+            ));
         }
     }
 
     #[cfg(feature = "accesskit")]
     pub fn select_from_accesskit(&mut self, selection: &accesskit::TextSelection) {
+        debug_assert!(!self.editor.is_composing());
+
         self.refresh_layout();
         if let Some(selection) = Selection::from_access_selection(
             selection,
@@ -485,6 +606,22 @@ where
         }
     }
 
+    #[cfg(feature = "accesskit")]
+    pub fn accessibility(
+        &mut self,
+        update: &mut TreeUpdate,
+        node: &mut Node,
+        next_node_id: impl FnMut() -> NodeId,
+        x_offset: f64,
+        y_offset: f64,
+    ) -> Option<()> {
+        self.refresh_layout();
+        self.editor
+            .accessibility_raw(update, node, next_node_id, x_offset, y_offset);
+        Some(())
+    }
+
+    // --- MARK: Internal helpers ---
     fn update_layout(&mut self) {
         self.editor.update_layout(self.font_cx, self.layout_cx);
     }
@@ -498,25 +635,39 @@ impl<T> PlainEditor<T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,
 {
-    /// Run a series of [`PlainEditorTxn`] methods, updating the layout
-    /// if necessary.
-    pub fn transact(
+    /// Run a series of [`PlainEditorTxn`] methods.
+    ///
+    /// This is a utility shorthand around [`transaction`](Self::transaction);
+    pub fn transact<R>(
         &mut self,
         font_cx: &mut FontContext,
         layout_cx: &mut LayoutContext<T>,
-        callback: impl FnOnce(&mut PlainEditorTxn<'_, T>),
-    ) {
-        let mut txn = PlainEditorTxn {
+        callback: impl FnOnce(&mut PlainEditorTxn<'_, T>) -> R,
+    ) -> R {
+        let mut txn = self.transaction(font_cx, layout_cx);
+        callback(&mut txn)
+    }
+
+    /// Run a series of [`PlainEditorTxn`] methods, updating the layout
+    /// if necessary.
+    ///
+    /// This is a utility shorthand to simplify methods which require the editor
+    /// and the provided contexts.
+    pub fn transaction<'txn>(
+        &'txn mut self,
+        font_cx: &'txn mut FontContext,
+        layout_cx: &'txn mut LayoutContext<T>,
+    ) -> PlainEditorTxn<'txn, T> {
+        PlainEditorTxn {
             editor: self,
             font_cx,
             layout_cx,
-        };
-        callback(&mut txn);
-        txn.refresh_layout();
+        }
     }
 
     /// Make a cursor at a given byte index
     fn cursor_at(&self, index: usize) -> Cursor {
+        // TODO: Do we need to be non-dirty?
         // FIXME: `Selection` should make this easier
         if index >= self.buffer.len() {
             Cursor::from_byte_index(&self.layout, self.buffer.len(), Affinity::Upstream)
@@ -555,37 +706,7 @@ where
         {
             self.generation.nudge();
         }
-        // Keeping this commented debug code in for now because it's quite
-        // useful when diagnosing selection problems:
-        //----------------------------------------------------------------------
-        // #[cfg(feature = "std")]
-        // {
-        //     let focus = new_sel.focus();
-        //     let cluster = focus.logical_clusters(&self.layout);
-        //     let dbg = (
-        //         cluster[0].as_ref().map(|c| &self.buffer[c.text_range()]),
-        //         focus.index(),
-        //         focus.affinity(),
-        //         cluster[1].as_ref().map(|c| &self.buffer[c.text_range()]),
-        //     );
-        //     print!("{dbg:?}");
-        //     let cluster = focus.visual_clusters(&self.layout);
-        //     let dbg = (
-        //         cluster[0].as_ref().map(|c| &self.buffer[c.text_range()]),
-        //         cluster[0]
-        //             .as_ref()
-        //             .map(|c| if c.is_word_boundary() { " W" } else { "" })
-        //             .unwrap_or_default(),
-        //         focus.index(),
-        //         focus.affinity(),
-        //         cluster[1].as_ref().map(|c| &self.buffer[c.text_range()]),
-        //         cluster[1]
-        //             .as_ref()
-        //             .map(|c| if c.is_word_boundary() { " W" } else { "" })
-        //             .unwrap_or_default(),
-        //     );
-        //     println!(" | visual: {dbg:?}");
-        // }
+
         self.selection = new_sel;
     }
 
@@ -609,16 +730,6 @@ where
         Some(self.selection.focus().geometry(&self.layout, size))
     }
 
-    /// Returns the underlying `Layout`.
-    pub fn layout(&self) -> &Layout<T> {
-        &self.layout
-    }
-
-    /// Get the lines from the `Layout`.
-    pub fn lines(&self) -> impl Iterator<Item = Line<T>> + '_ + Clone {
-        self.layout.lines()
-    }
-
     /// Borrow the text content of the buffer.
     pub fn text(&self) -> &str {
         &self.buffer
@@ -632,6 +743,64 @@ where
         self.generation
     }
 
+    /// Get the full read-only details from the layout
+    pub fn layout(
+        &mut self,
+        font_cx: &mut FontContext,
+        layout_cx: &mut LayoutContext<T>,
+    ) -> &Layout<T> {
+        self.refresh_layout(font_cx, layout_cx);
+        &self.layout
+    }
+
+    /// Get the full read-only details from the layout, if valid.
+    pub fn get_layout(&self) -> Option<&Layout<T>> {
+        if self.layout_dirty {
+            None
+        } else {
+            Some(&self.layout)
+        }
+    }
+
+    /// Get the (potentially invalid) details from the layout.
+    pub fn layout_raw(&self) -> &Layout<T> {
+        &self.layout
+    }
+
+    /// Replace the whole text buffer.
+    pub fn set_text(&mut self, is: &str) {
+        self.buffer.clear();
+        self.buffer.push_str(is);
+        self.layout_dirty = true;
+    }
+
+    /// Set the width of the layout.
+    // TODO: If this is infinite, is the width used for alignnment the min width?
+    pub fn set_width(&mut self, width: Option<f32>) {
+        // Don't allow empty widths:
+        // https://github.com/linebender/parley/issues/186
+        self.width = width.map(|width| if width > 10. { width } else { 10. });
+        self.layout_dirty = true;
+    }
+
+    /// Set the alignment of the layout.
+    pub fn set_alignment(&mut self, alignment: Alignment) {
+        self.alignment = alignment;
+        self.layout_dirty = true;
+    }
+
+    /// Set the scale for the layout.
+    pub fn set_scale(&mut self, scale: f32) {
+        self.scale = scale;
+        self.layout_dirty = true;
+    }
+
+    /// Set the default style for the layout.
+    pub fn edit_styles(&mut self) -> &mut StyleSet<T> {
+        self.layout_dirty = true;
+        &mut self.default_style
+    }
+
     /// Update the layout if it is dirty.
     fn refresh_layout(&mut self, font_cx: &mut FontContext, layout_cx: &mut LayoutContext<T>) {
         if self.layout_dirty {
@@ -642,19 +811,48 @@ where
     /// Update the layout.
     fn update_layout(&mut self, font_cx: &mut FontContext, layout_cx: &mut LayoutContext<T>) {
         let mut builder = layout_cx.ranged_builder(font_cx, &self.buffer, self.scale);
-        for prop in self.default_style.iter() {
+        for prop in self.default_style.inner().values() {
             builder.push_default(prop.to_owned());
         }
-        builder.build_into(&mut self.layout, &self.buffer);
+        if let Some(ref preedit_range) = self.compose {
+            builder.push(StyleProperty::Underline(true), preedit_range.clone());
+        }
+        self.layout = builder.build(&self.buffer);
         self.layout.break_all_lines(self.width);
-        self.layout.align(self.width, Alignment::Start);
+        self.layout.align(self.width, self.alignment);
         self.selection = self.selection.refresh(&self.layout);
         self.layout_dirty = false;
         self.generation.nudge();
     }
 
+    /// Whether the editor is currently in IME composing mode.
+    pub fn is_composing(&self) -> bool {
+        self.compose.is_some()
+    }
+
     #[cfg(feature = "accesskit")]
-    pub fn accessibility(
+    #[inline]
+    /// Perform an accessibility update if the layout is valid.
+    ///
+    /// Returns `None` if the layout is not up-to-date.
+    pub fn try_accessibility(
+        &mut self,
+        update: &mut TreeUpdate,
+        node: &mut Node,
+        next_node_id: impl FnMut() -> NodeId,
+        x_offset: f64,
+        y_offset: f64,
+    ) -> Option<()> {
+        if self.layout_dirty {
+            return None;
+        }
+        self.accessibility_raw(update, node, next_node_id, x_offset, y_offset);
+        Some(())
+    }
+
+    #[cfg(feature = "accesskit")]
+    /// Perform an accessibility update, even if the layout isn't valid.
+    pub fn accessibility_raw(
         &mut self,
         update: &mut TreeUpdate,
         node: &mut Node,

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -131,7 +131,7 @@ pub use inline_box::InlineBox;
 #[doc(inline)]
 pub use layout::Layout;
 
-pub use layout::editor::{PlainEditor, PlainEditorTxn};
+pub use layout::editor::{PlainEditor, PlainEditorDriver};
 
 pub use layout::*;
 pub use style::*;

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -5,6 +5,7 @@
 
 mod brush;
 mod font;
+mod styleset;
 
 use alloc::borrow::Cow;
 
@@ -13,6 +14,7 @@ pub use font::{
     FontFamily, FontFeature, FontSettings, FontStack, FontStretch, FontStyle, FontVariation,
     FontWeight, GenericFamily,
 };
+pub use styleset::StyleSet;
 
 #[derive(Debug, Clone, Copy)]
 pub enum WhiteSpaceCollapse {

--- a/parley/src/style/styleset.rs
+++ b/parley/src/style/styleset.rs
@@ -11,6 +11,8 @@ type StyleProperty<Brush> = crate::StyleProperty<'static, Brush>;
 ///
 /// This is used by [`PlainEditor`](crate::editor::PlainEditor) to provide a reasonably ergonomic
 /// mutable API for styles applied to all text managed by it.
+/// This can be accessed using [`PlainEditor::edit_styles`](crate::editor::PlainEditor::edit_styles).
+///
 /// These styles do not have a corresponding range, and are generally unsuited for rich text.
 #[derive(Clone, Debug)]
 pub struct StyleSet<Brush: crate::Brush>(

--- a/parley/src/style/styleset.rs
+++ b/parley/src/style/styleset.rs
@@ -1,0 +1,74 @@
+// Copyright 2024 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use core::mem::Discriminant;
+use hashbrown::HashMap;
+
+type StyleProperty<Brush> = crate::StyleProperty<'static, Brush>;
+
+/// A long-lived collection of [`StyleProperties`](super::StyleProperty), containing at
+/// most one of each property.
+///
+/// This is used by [`PlainEditor`](crate::editor::PlainEditor) to provide a reasonably ergonomic
+/// mutable API for styles applied to all text managed by it.
+/// These styles do not have a corresponding range, and are generally unsuited for rich text.
+#[derive(Clone, Debug)]
+pub struct StyleSet<Brush: crate::Brush>(
+    HashMap<Discriminant<StyleProperty<Brush>>, StyleProperty<Brush>>,
+);
+
+impl<Brush: crate::Brush> StyleSet<Brush> {
+    /// Create a new collection of styles.
+    ///
+    /// The font size will be `font_size`, and can be overwritten at runtime by
+    /// [inserting](Self::insert) a new [`FontSize`](crate::StyleProperty::FontSize).
+    pub fn new(font_size: f32) -> Self {
+        let mut this = Self(Default::default());
+        this.insert(StyleProperty::FontSize(font_size));
+        this
+    }
+
+    /// Add `style` to this collection, returning any overwritten value.
+    ///
+    /// Note: Adding a [font stack](crate::StyleProperty::FontStack) to this collection is not
+    /// additive, and instead overwrites any previously added font stack.
+    pub fn insert(&mut self, style: StyleProperty<Brush>) -> Option<StyleProperty<Brush>> {
+        let discriminant = core::mem::discriminant(&style);
+        self.0.insert(discriminant, style)
+    }
+
+    /// [Retain](std::vec::Vec::retain) only the styles for which `f` returns true.
+    ///
+    /// Styles which are removed return to their default values.
+    ///
+    /// Removing the [font size](crate::StyleProperty::FontSize) is not recommended, as an unspecified
+    /// fallback font size will be used.
+    pub fn retain(&mut self, mut f: impl FnMut(&StyleProperty<Brush>) -> bool) {
+        self.0.retain(|_, v| f(v));
+    }
+
+    /// Remove the style with the discriminant `property`.
+    ///
+    /// Styles which are removed return to their default values.
+    ///
+    /// To get the discriminant requires constructing a valid `StyleProperty` for the
+    /// the desired property and passing it to [`core::mem::discriminant`].
+    /// Getting this discriminant is usually possible in a `const` context.
+    ///
+    /// Removing the [font size](crate::StyleProperty::FontSize) is not recommended, as an unspecified
+    /// fallback font size will be used.
+    pub fn remove(
+        &mut self,
+        property: Discriminant<StyleProperty<Brush>>,
+    ) -> Option<StyleProperty<Brush>> {
+        self.0.remove(&property)
+    }
+
+    /// Read the raw underlying storage of this.
+    ///
+    /// Write access is not provided due to the invariant that keys
+    /// are the discriminant of their corresponding value.
+    pub fn inner(&self) -> &HashMap<Discriminant<StyleProperty<Brush>>, StyleProperty<Brush>> {
+        &self.0
+    }
+}

--- a/parley/src/tests/test_editor.rs
+++ b/parley/src/tests/test_editor.rs
@@ -7,27 +7,25 @@ use crate::testenv;
 fn editor_simple_move() {
     let mut env = testenv!();
     let mut editor = env.editor("Hi, all!\nNext");
-    env.check_editor_snapshot(&editor);
-    env.transact(&mut editor, |e| {
-        e.move_right();
-        e.move_right();
-        e.move_right();
-    });
-    env.check_editor_snapshot(&editor);
-    env.transact(&mut editor, |e| e.move_down());
-    env.check_editor_snapshot(&editor);
-    env.transact(&mut editor, |e| e.move_left());
-    env.check_editor_snapshot(&editor);
-    env.transact(&mut editor, |e| e.move_up());
-    env.check_editor_snapshot(&editor);
+    env.check_editor_snapshot(&mut editor);
+    let mut drv = env.driver(&mut editor);
+    drv.move_right();
+    drv.move_right();
+    drv.move_right();
+
+    env.check_editor_snapshot(&mut editor);
+    env.driver(&mut editor).move_down();
+    env.check_editor_snapshot(&mut editor);
+    env.driver(&mut editor).move_left();
+    env.check_editor_snapshot(&mut editor);
+    env.driver(&mut editor).move_up();
+    env.check_editor_snapshot(&mut editor);
 }
 
 #[test]
 fn editor_select_all() {
     let mut env = testenv!();
     let mut editor = env.editor("Hi, all!\nNext");
-    env.transact(&mut editor, |e| {
-        e.select_all();
-    });
-    env.check_editor_snapshot(&editor);
+    env.driver(&mut editor).select_all();
+    env.check_editor_snapshot(&mut editor);
 }


### PR DESCRIPTION
The current design of `PlainEditor` and `PlainEditorTransaction` is that if the editor is accessible, the inner layout is always valid and up-to-date (barring a caught panic in the `transact` method). This is not ideal for Masonry, because it forces event handling to recreate the full layout even if the old version could be reused; this potential reuse is especially prevalent in updates driven by Xilem.

This does bring in another change from Masonry, which is `StyleSet`; this is a set of style properties, differentiated by their kind. It can contain at most one font size, line height, etc.
This has some potentially unexpected behaviour with `FontStack`s, as in the other APIs they "combine", but in this format they. However, this combining behaviour is not documented as far as I can see, so I think it's reasonable.
This implemented using a hashmap of discriminants in the enum.
The current API of `Arc<[StyleProperty]>` is horrendously unergonomic.

To reflect this change, I've renamed `PlainEditorTxn` to `PlainEditorDriver`. Suggestions for an alternative name are welcome.