### PR TITLE
Handle IME selection cursor hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This release has an [MSRV] of 1.75.
 #### Parley
 
 - `Generation` on `PlainEditor` to help implement lazy drawing. ([#143] by [@xorgy])
-- Support for preedit for input methods in `PlainEditor` ([#192][] by [@tomcur][])
+- Support for preedit for input methods in `PlainEditor` ([#192][], [#198][] by [@tomcur][])
 
 ### Changed
 
@@ -102,6 +102,7 @@ This release has an [MSRV] of 1.70.
 [#129]: https://github.com/linebender/parley/pull/129
 [#143]: https://github.com/linebender/parley/pull/143
 [#192]: https://github.com/linebender/parley/pull/192
+[#198]: https://github.com/linebender/parley/pull/198
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/linebender/parley/releases/tag/v0.2.0

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -331,8 +331,8 @@ where
         self.update_layout();
 
         // Select the location indicated by the IME. If `cursor` is none, collapse the selection to
-        // a caret at the start of the preedit text. As `self.show_cursor` is `false`, it won't
-        // show up.
+        // a caret at the start of the preedit text. As `self.editor.show_cursor` is `false`, it
+        // won't show up.
         let cursor = cursor.unwrap_or((0, 0));
         self.editor.set_selection(Selection::new(
             self.editor.cursor_at(start + cursor.0),
@@ -756,8 +756,8 @@ where
 
     /// Get rectangles representing the selected portions of text.
     pub fn selection_geometry(&self) -> Vec<Rect> {
-        // We do not check `show_cursor` here, as the IME handling code collapses the selection to
-        // a caret in that case.
+        // We do not check `self.show_cursor` here, as the IME handling code collapses the
+        // selection to a caret in that case.
         self.selection.geometry(&self.layout)
     }
 


### PR DESCRIPTION
When the IME indicates a cursor of `None`, it means we should hide the cursor. This does that by collapsing the selection, hiding the caret, and clearing the text selection from the AccessKit node.