### PR TITLE
Ignore affinities in Selection::is_collapsed

### DIFF
--- a/parley/src/layout/cursor.rs
+++ b/parley/src/layout/cursor.rs
@@ -502,7 +502,7 @@ impl Selection {
     /// This means that the selection represents a single position rather than
     /// a range.
     pub fn is_collapsed(&self) -> bool {
-        self.anchor == self.focus
+        self.anchor.index == self.focus.index
     }
 
     /// Returns the anchor of the selection.


### PR DESCRIPTION
Currently `is_collapsed` is false when a selection's anchor and focus are at the same byte position, but have different affinities.

This changes `is_collapsed` to ignore the affinities, which appears to be the sense of "collapsed" that is assumed throughout, e.g.,`Selection::next_visual` currently requires doing the operation twice when only affinities differ to actually move and `PlainEditor::selected_text` currently returns `""` when only affinities differ.