### PR TITLE
Handle inline boxes in cluster geometry and path

### DIFF
--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -21,11 +21,8 @@ impl<'a, B: Brush> Cluster<'a, B> {
         let mut path = ClusterPath::default();
         if let Some((line_index, line)) = layout.line_for_byte_index(byte_index) {
             path.line_index = line_index as u32;
-            for run_index in 0..line.len() {
-                let Some(run) = line.run(run_index) else {
-                    continue;
-                };
-                path.run_index = run_index as u32;
+            for run in line.runs() {
+                path.run_index = run.index;
                 if !run.text_range().contains(&byte_index) {
                     continue;
                 }

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -21,7 +21,10 @@ impl<'a, B: Brush> Cluster<'a, B> {
         let mut path = ClusterPath::default();
         if let Some((line_index, line)) = layout.line_for_byte_index(byte_index) {
             path.line_index = line_index as u32;
-            for (run_index, run) in line.runs().enumerate() {
+            for run_index in 0..line.len() {
+                let Some(run) = line.run(run_index) else {
+                    continue;
+                };
                 path.run_index = run_index as u32;
                 if !run.text_range().contains(&byte_index) {
                     continue;
@@ -44,13 +47,17 @@ impl<'a, B: Brush> Cluster<'a, B> {
             path.line_index = line_index as u32;
             let mut offset = line.metrics().offset;
             let last_run_index = line.len().saturating_sub(1);
-            for (run_index, run) in line.runs().enumerate() {
+            for run_index in 0..line.len() {
+                let advance = line.item(run_index).unwrap().advance;
+                let Some(run) = line.run(run_index) else {
+                    offset += advance;
+                    continue;
+                };
                 let is_last_run = run_index == last_run_index;
-                let run_advance = run.advance();
                 path.run_index = run_index as u32;
                 path.logical_index = 0;
-                if x > offset + run_advance && !is_last_run {
-                    offset += run_advance;
+                if x > offset + advance && !is_last_run {
+                    offset += advance;
                     continue;
                 }
                 let last_cluster_index = run.cluster_range().len().saturating_sub(1);
@@ -354,16 +361,15 @@ impl<'a, B: Brush> Cluster<'a, B> {
     pub fn visual_offset(&self) -> Option<f32> {
         let line = self.path.line(self.run.layout)?;
         let mut offset = line.metrics().offset;
-        for run_index in 0..=self.path.run_index() {
-            let run = line.run(run_index)?;
-            if run_index != self.path.run_index() {
-                offset += run.advance();
-            } else {
-                let visual_index = run.logical_to_visual(self.path.logical_index())?;
-                for cluster in run.visual_clusters().take(visual_index) {
-                    offset += cluster.advance();
-                }
-            }
+        for run_index in 0..self.path.run_index() {
+            let item = line.item(run_index)?;
+            offset += item.advance;
+        }
+
+        let run = line.run(self.path.run_index())?;
+        let visual_index = run.logical_to_visual(self.path.logical_index())?;
+        for cluster in run.visual_clusters().take(visual_index) {
+            offset += cluster.advance();
         }
         Some(offset)
     }

--- a/parley/src/layout/cursor.rs
+++ b/parley/src/layout/cursor.rs
@@ -832,7 +832,7 @@ impl Selection {
                     let PositionedLayoutItem::GlyphRun(run) = item else {
                         continue;
                     };
-                    let offset = run.offset();
+                    let offset = run.offset() + metrics.offset;
                     let run = run.run();
                     for (ix, cluster) in run.visual_clusters().enumerate() {
                         let advance = cluster.advance() as f64;


### PR DESCRIPTION
Inline boxes are currently silently ignored in some places, making text selection wrong when they are used, as their advance is not used in offset calculation and the run indices are counted wrong as the boxes are skipped.

To see the issues currently present, insert the following in `PlainEditor::update_layout` and run vello_editor.

```rust
builder.push_inline_box(crate::InlineBox {
    id: 0,
    index: 7,
    width: 50.0,
    height: 50.0,
});
```

This PR fixes the issues I've found, though the cursor position when the cursor has a downstream affinity at the byte index of an inline box is still wrong, I believe. For example, in "AB" with an inline box between "A" and "B", when the cursor is between the two characters with downstream affinity, it shows up on the right side of the A, whereas it would be expected to show up at the left side of the B.