### PR TITLE
Rename `Stretch`, `Style`, `Weight` to have `Font` prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ This release has an [MSRV] of 1.75.
 
 ### Changed
 
-### Parley
+#### Fontique
+
+- Breaking change: `Stretch`, `Style`, and `Weight` renamed to `FontStretch`, `FontStyle`, `FontWeight ([#211][] by [@waywardmonkeys][])
+
+#### Parley
 
 - Breaking change: `PlainEditor`'s semantics are no longer transactional ([#192][] by [@DJMcNab][])
 
@@ -103,6 +107,7 @@ This release has an [MSRV] of 1.70.
 [#143]: https://github.com/linebender/parley/pull/143
 [#192]: https://github.com/linebender/parley/pull/192
 [#198]: https://github.com/linebender/parley/pull/198
+[#211]: https://github.com/linebender/parley/pull/211
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/linebender/parley/releases/tag/v0.2.0

--- a/fontique/src/attributes.rs
+++ b/fontique/src/attributes.rs
@@ -9,7 +9,7 @@ use core_maths::CoreFloat;
 
 use core::fmt;
 
-/// Primary attributes for font matching: [`Stretch`], [`Style`] and [`Weight`].
+/// Primary attributes for font matching: [`FontStretch`], [`FontStyle`] and [`FontWeight`].
 ///
 /// These are used to [configure] a [`Query`].
 ///
@@ -17,14 +17,14 @@ use core::fmt;
 /// [`Query`]: crate::Query
 #[derive(Copy, Clone, PartialEq, Default, Debug)]
 pub struct Attributes {
-    pub stretch: Stretch,
-    pub style: Style,
-    pub weight: Weight,
+    pub stretch: FontStretch,
+    pub style: FontStyle,
+    pub weight: FontWeight,
 }
 
 impl Attributes {
     /// Creates new attributes from the given stretch, style and weight.
-    pub fn new(stretch: Stretch, style: Style, weight: Weight) -> Self {
+    pub fn new(stretch: FontStretch, style: FontStyle, weight: FontWeight) -> Self {
         Self {
             stretch,
             style,
@@ -46,7 +46,7 @@ impl fmt::Display for Attributes {
 /// Visual width of a font-- a relative change from the normal aspect
 /// ratio, typically in the range `0.5` to `2.0`.
 ///
-/// The default value is [`Stretch::NORMAL`] or `1.0`.
+/// The default value is [`FontStretch::NORMAL`] or `1.0`.
 ///
 /// In variable fonts, this can be controlled with the `wdth` [axis].
 ///
@@ -57,9 +57,9 @@ impl fmt::Display for Attributes {
 /// [axis]: crate::AxisInfo
 /// [`font-width`]: https://www.w3.org/TR/css-fonts-4/#font-width-prop
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
-pub struct Stretch(f32);
+pub struct FontStretch(f32);
 
-impl Stretch {
+impl FontStretch {
     /// Width that is 50% of normal.
     pub const ULTRA_CONDENSED: Self = Self(0.5);
 
@@ -88,7 +88,7 @@ impl Stretch {
     pub const ULTRA_EXPANDED: Self = Self(2.0);
 }
 
-impl Stretch {
+impl FontStretch {
     /// Creates a new stretch attribute with the given ratio.
     ///
     /// This can also be created [from a percentage](Self::from_percentage).
@@ -96,8 +96,8 @@ impl Stretch {
     /// # Example
     ///
     /// ```
-    /// # use fontique::Stretch;
-    /// assert_eq!(Stretch::from_ratio(1.5), Stretch::EXTRA_EXPANDED);
+    /// # use fontique::FontStretch;
+    /// assert_eq!(FontStretch::from_ratio(1.5), FontStretch::EXTRA_EXPANDED);
     /// ```
     pub fn from_ratio(ratio: f32) -> Self {
         Self(ratio)
@@ -110,8 +110,8 @@ impl Stretch {
     /// # Example
     ///
     /// ```
-    /// # use fontique::Stretch;
-    /// assert_eq!(Stretch::from_percentage(87.5), Stretch::SEMI_CONDENSED);
+    /// # use fontique::FontStretch;
+    /// assert_eq!(FontStretch::from_percentage(87.5), FontStretch::SEMI_CONDENSED);
     /// ```
     pub fn from_percentage(percentage: f32) -> Self {
         Self(percentage / 100.0)
@@ -124,8 +124,8 @@ impl Stretch {
     /// # Example
     ///
     /// ```
-    /// # use fontique::Stretch;
-    /// assert_eq!(Stretch::NORMAL.ratio(), 1.0);
+    /// # use fontique::FontStretch;
+    /// assert_eq!(FontStretch::NORMAL.ratio(), 1.0);
     /// ```
     pub fn ratio(self) -> f32 {
         self.0
@@ -140,21 +140,21 @@ impl Stretch {
 
     /// Returns `true` if the stretch is [normal].
     ///
-    /// [normal]: Stretch::NORMAL
+    /// [normal]: FontStretch::NORMAL
     pub fn is_normal(self) -> bool {
         self == Self::NORMAL
     }
 
     /// Returns `true` if the stretch is condensed (less than [normal]).
     ///
-    /// [normal]: Stretch::NORMAL
+    /// [normal]: FontStretch::NORMAL
     pub fn is_condensed(self) -> bool {
         self < Self::NORMAL
     }
 
     /// Returns `true` if the stretch is expanded (greater than [normal]).
     ///
-    /// [normal]: Stretch::NORMAL
+    /// [normal]: FontStretch::NORMAL
     pub fn is_expanded(self) -> bool {
         self > Self::NORMAL
     }
@@ -164,10 +164,10 @@ impl Stretch {
     /// # Examples
     ///
     /// ```
-    /// # use fontique::Stretch;
-    /// assert_eq!(Stretch::parse("semi-condensed"), Some(Stretch::SEMI_CONDENSED));
-    /// assert_eq!(Stretch::parse("80%"), Some(Stretch::from_percentage(80.0)));
-    /// assert_eq!(Stretch::parse("wideload"), None);
+    /// # use fontique::FontStretch;
+    /// assert_eq!(FontStretch::parse("semi-condensed"), Some(FontStretch::SEMI_CONDENSED));
+    /// assert_eq!(FontStretch::parse("80%"), Some(FontStretch::from_percentage(80.0)));
+    /// assert_eq!(FontStretch::parse("wideload"), None);
     /// ```
     pub fn parse(s: &str) -> Option<Self> {
         let s = s.trim();
@@ -191,7 +191,7 @@ impl Stretch {
     }
 }
 
-impl fmt::Display for Stretch {
+impl fmt::Display for FontStretch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let value = self.0 * 1000.0;
         if value.fract() == 0.0 {
@@ -216,7 +216,7 @@ impl fmt::Display for Stretch {
     }
 }
 
-impl Default for Stretch {
+impl Default for FontStretch {
     fn default() -> Self {
         Self::NORMAL
     }
@@ -224,7 +224,7 @@ impl Default for Stretch {
 
 /// Visual weight class of a font, typically on a scale from 1.0 to 1000.0.
 ///
-/// The default value is [`Weight::NORMAL`] or `400.0`.
+/// The default value is [`FontWeight::NORMAL`] or `400.0`.
 ///
 /// In variable fonts, this can be controlled with the `wght` [axis].
 ///
@@ -235,9 +235,9 @@ impl Default for Stretch {
 /// [axis]: crate::AxisInfo
 /// [`font-weight`]: https://www.w3.org/TR/css-fonts-4/#font-weight-prop
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
-pub struct Weight(f32);
+pub struct FontWeight(f32);
 
-impl Weight {
+impl FontWeight {
     /// Weight value of 100.
     pub const THIN: Self = Self(100.0);
 
@@ -272,7 +272,7 @@ impl Weight {
     pub const EXTRA_BLACK: Self = Self(950.0);
 }
 
-impl Weight {
+impl FontWeight {
     /// Creates a new weight attribute with the given value.
     pub fn new(weight: f32) -> Self {
         Self(weight)
@@ -288,11 +288,11 @@ impl Weight {
     /// # Examples
     ///
     /// ```
-    /// # use fontique::Weight;
-    /// assert_eq!(Weight::parse("normal"), Some(Weight::NORMAL));
-    /// assert_eq!(Weight::parse("bold"), Some(Weight::BOLD));
-    /// assert_eq!(Weight::parse("850"), Some(Weight::new(850.0)));
-    /// assert_eq!(Weight::parse("invalid"), None);
+    /// # use fontique::FontWeight;
+    /// assert_eq!(FontWeight::parse("normal"), Some(FontWeight::NORMAL));
+    /// assert_eq!(FontWeight::parse("bold"), Some(FontWeight::BOLD));
+    /// assert_eq!(FontWeight::parse("850"), Some(FontWeight::new(850.0)));
+    /// assert_eq!(FontWeight::parse("invalid"), None);
     /// ```
     pub fn parse(s: &str) -> Option<Self> {
         let s = s.trim();
@@ -304,13 +304,13 @@ impl Weight {
     }
 }
 
-impl Default for Weight {
+impl Default for FontWeight {
     fn default() -> Self {
         Self::NORMAL
     }
 }
 
-impl fmt::Display for Weight {
+impl fmt::Display for FontWeight {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let value = self.0;
         if value.fract() == 0.0 {
@@ -335,7 +335,7 @@ impl fmt::Display for Weight {
 
 /// Visual style or 'slope' of a font.
 ///
-/// The default value is [`Style::Normal`].
+/// The default value is [`FontStyle::Normal`].
 ///
 /// In variable fonts, this can be controlled with the `ital`
 /// and `slnt` [axes] for italic and oblique styles, respectively.
@@ -347,7 +347,7 @@ impl fmt::Display for Weight {
 /// [axes]: crate::AxisInfo
 /// [`font-style`]: https://www.w3.org/TR/css-fonts-4/#font-style-prop
 #[derive(Copy, Clone, PartialEq, Default, Debug)]
-pub enum Style {
+pub enum FontStyle {
     /// An upright or "roman" style.
     #[default]
     Normal,
@@ -359,7 +359,7 @@ pub enum Style {
     Oblique(Option<f32>),
 }
 
-impl Style {
+impl FontStyle {
     /// Parses a font style from a CSS value.
     pub fn parse(mut s: &str) -> Option<Self> {
         s = s.trim();
@@ -399,7 +399,7 @@ impl Style {
     }
 }
 
-impl fmt::Display for Style {
+impl fmt::Display for FontStyle {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let value = match self {
             Self::Normal => "normal",

--- a/fontique/src/backend/fontconfig/cache.rs
+++ b/fontique/src/backend/fontconfig/cache.rs
@@ -1,12 +1,12 @@
 // Copyright 2024 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use super::{Stretch, Style, Weight};
+use super::{FontStretch, FontStyle, FontWeight};
 use fontconfig_cache_parser::{Cache, CharSetLeaf, Object, Pattern, Value};
 use std::io::Read;
 use std::path::PathBuf;
 
-impl Stretch {
+impl FontStretch {
     /// Creates a new stretch attribute with the given value from Fontconfig.
     ///
     /// The values are determined based on the [fonts.conf documentation].
@@ -28,7 +28,7 @@ impl Stretch {
     }
 }
 
-impl Style {
+impl FontStyle {
     /// Creates a new style attribute with the given value from Fontconfig.
     ///
     /// The values are determined based on the [fonts.conf documentation].
@@ -43,7 +43,7 @@ impl Style {
     }
 }
 
-impl Weight {
+impl FontWeight {
     /// Creates a new weight attribute with the given value from Fontconfig.
     ///
     /// The values are determined based on the [fonts.conf documentation].
@@ -79,7 +79,7 @@ impl Weight {
                 return Self::new(ot_a + (ot_b - ot_a) * t);
             }
         }
-        Weight::EXTRA_BLACK
+        Self::EXTRA_BLACK
     }
 }
 
@@ -88,9 +88,9 @@ pub struct CachedFont {
     pub family: Vec<String>,
     pub path: PathBuf,
     pub index: u32,
-    pub stretch: Stretch,
-    pub style: Style,
-    pub weight: Weight,
+    pub stretch: FontStretch,
+    pub style: FontStyle,
+    pub weight: FontWeight,
     pub coverage: Coverage,
 }
 
@@ -100,9 +100,9 @@ impl CachedFont {
         self.path.clear();
         self.index = 0;
         self.coverage.clear();
-        self.weight = Weight::default();
-        self.style = Style::default();
-        self.stretch = Stretch::default();
+        self.weight = FontWeight::default();
+        self.style = FontStyle::default();
+        self.stretch = FontStretch::default();
     }
 }
 
@@ -177,21 +177,21 @@ fn parse_font(
             Object::Slant => {
                 for val in elt.values().ok()? {
                     if let Value::Int(i) = val.ok()? {
-                        font.style = Style::from_fc(i as _);
+                        font.style = FontStyle::from_fc(i as _);
                     }
                 }
             }
             Object::Weight => {
                 for val in elt.values().ok()? {
                     if let Value::Int(i) = val.ok()? {
-                        font.weight = Weight::from_fc(i as _);
+                        font.weight = FontWeight::from_fc(i as _);
                     }
                 }
             }
             Object::Width => {
                 for val in elt.values().ok()? {
                     if let Value::Int(i) = val.ok()? {
-                        font.stretch = Stretch::from_fc(i as _);
+                        font.stretch = FontStretch::from_fc(i as _);
                     }
                 }
             }

--- a/fontique/src/backend/fontconfig/mod.rs
+++ b/fontique/src/backend/fontconfig/mod.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use super::{
-    super::{Stretch, Style, Weight},
+    super::{FontStretch, FontStyle, FontWeight},
     FallbackKey, FamilyId, FamilyInfo, FamilyName, FamilyNameMap, FontInfo, GenericFamily,
     GenericFamilyMap, Script, SourceInfo, SourcePathMap,
 };
@@ -301,9 +301,9 @@ struct RawFamily {
 struct RawFont {
     source: SourceInfo,
     index: u32,
-    stretch: Stretch,
-    style: Style,
-    weight: Weight,
+    stretch: FontStretch,
+    style: FontStyle,
+    weight: FontWeight,
     coverage: cache::Coverage,
 }
 

--- a/fontique/src/family.rs
+++ b/fontique/src/family.rs
@@ -4,7 +4,7 @@
 //! Model for font families.
 
 use super::{
-    attributes::{Stretch, Style, Weight},
+    attributes::{FontStretch, FontStyle, FontWeight},
     family_name::FamilyName,
     font::FontInfo,
 };
@@ -84,9 +84,9 @@ impl FamilyInfo {
     /// Returns the index of the best font from the family for the given attributes.
     pub fn match_index(
         &self,
-        stretch: Stretch,
-        style: Style,
-        weight: Weight,
+        stretch: FontStretch,
+        style: FontStyle,
+        weight: FontWeight,
         synthesize_style: bool,
     ) -> Option<usize> {
         super::matching::match_font(self.fonts(), stretch, style, weight, synthesize_style)
@@ -95,9 +95,9 @@ impl FamilyInfo {
     /// Selects the best font from the family for the given attributes.
     pub fn match_font(
         &self,
-        stretch: Stretch,
-        style: Style,
-        weight: Weight,
+        stretch: FontStretch,
+        style: FontStyle,
+        weight: FontWeight,
         synthesize_style: bool,
     ) -> Option<&FontInfo> {
         self.fonts()

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -49,7 +49,7 @@ mod source_cache;
 pub use icu_locid::LanguageIdentifier as Language;
 pub use peniko::Blob;
 
-pub use attributes::{Attributes, Stretch, Style, Weight};
+pub use attributes::{Attributes, FontStretch, FontStyle, FontWeight};
 pub use collection::{Collection, CollectionOptions, Query, QueryFamily, QueryFont, QueryStatus};
 pub use fallback::FallbackKey;
 pub use family::{FamilyId, FamilyInfo};

--- a/fontique/src/matching.rs
+++ b/fontique/src/matching.rs
@@ -3,7 +3,7 @@
 
 //! Implementation of the CSS font matching algorithm.
 
-use super::attributes::{Stretch, Style, Weight};
+use super::attributes::{FontStretch, FontStyle, FontWeight};
 use super::font::FontInfo;
 use smallvec::SmallVec;
 
@@ -11,9 +11,9 @@ const DEFAULT_OBLIQUE_ANGLE: f32 = 14.0;
 
 pub fn match_font(
     set: &[FontInfo],
-    stretch: Stretch,
-    style: Style,
-    weight: Weight,
+    stretch: FontStretch,
+    style: FontStyle,
+    weight: FontWeight,
     synthesize_style: bool,
 ) -> Option<usize> {
     const OBLIQUE_THRESHOLD: f32 = DEFAULT_OBLIQUE_ANGLE;
@@ -26,7 +26,7 @@ pub fn match_font(
     struct Candidate {
         index: usize,
         stretch: i32,
-        style: Style,
+        style: FontStyle,
         weight: f32,
         has_slnt: bool,
     }
@@ -102,7 +102,7 @@ pub fn match_font(
     let mut _use_slnt = false;
     if !set.iter().any(|f| f.style == use_style) {
         // If the value of font-style is italic:
-        if style == Style::Italic {
+        if style == FontStyle::Italic {
             // oblique values greater than or equal to 14deg are checked in
             // ascending order
             if let Some(found) = oblique_fonts
@@ -162,16 +162,16 @@ pub fn match_font(
                         if set.iter().any(|f| f.has_slnt) {
                             _use_slnt = true;
                         } else {
-                            use_style = if set.iter().any(|f| f.style == Style::Normal) {
-                                Style::Normal
+                            use_style = if set.iter().any(|f| f.style == FontStyle::Normal) {
+                                FontStyle::Normal
                             } else {
                                 set[0].style
                             };
                         }
                     } else {
                         // Choose an italic style
-                        if set.iter().any(|f| f.style == Style::Italic) {
-                            use_style = Style::Italic;
+                        if set.iter().any(|f| f.style == FontStyle::Italic) {
+                            use_style = FontStyle::Italic;
                         }
                         // oblique values less than or equal to 0deg are checked in descending order
                         else if let Some(found) = oblique_fonts
@@ -215,16 +215,16 @@ pub fn match_font(
                         if set.iter().any(|f| f.has_slnt) {
                             _use_slnt = true;
                         } else {
-                            use_style = if set.iter().any(|f| f.style == Style::Normal) {
-                                Style::Normal
+                            use_style = if set.iter().any(|f| f.style == FontStyle::Normal) {
+                                FontStyle::Normal
                             } else {
                                 set[0].style
                             };
                         }
                     } else {
                         // Choose an italic style
-                        if set.iter().any(|f| f.style == Style::Italic) {
-                            use_style = Style::Italic;
+                        if set.iter().any(|f| f.style == FontStyle::Italic) {
+                            use_style = FontStyle::Italic;
                         }
                         // oblique values less than or equal to 0deg are checked in descending order
                         else if let Some(found) = oblique_fonts
@@ -267,16 +267,16 @@ pub fn match_font(
                         if set.iter().any(|f| f.has_slnt) {
                             _use_slnt = true;
                         } else {
-                            use_style = if set.iter().any(|f| f.style == Style::Normal) {
-                                Style::Normal
+                            use_style = if set.iter().any(|f| f.style == FontStyle::Normal) {
+                                FontStyle::Normal
                             } else {
                                 set[0].style
                             };
                         }
                     } else {
                         // Choose an italic style
-                        if set.iter().any(|f| f.style == Style::Italic) {
-                            use_style = Style::Italic;
+                        if set.iter().any(|f| f.style == FontStyle::Italic) {
+                            use_style = FontStyle::Italic;
                         }
                         // oblique values greater than or equal to 0deg are checked in ascending order
                         else if let Some(found) = oblique_fonts
@@ -319,16 +319,16 @@ pub fn match_font(
                         if set.iter().any(|f| f.has_slnt) {
                             _use_slnt = true;
                         } else {
-                            use_style = if set.iter().any(|f| f.style == Style::Normal) {
-                                Style::Normal
+                            use_style = if set.iter().any(|f| f.style == FontStyle::Normal) {
+                                FontStyle::Normal
                             } else {
                                 set[0].style
                             };
                         }
                     } else {
                         // Choose an italic style
-                        if set.iter().any(|f| f.style == Style::Italic) {
-                            use_style = Style::Italic;
+                        if set.iter().any(|f| f.style == FontStyle::Italic) {
+                            use_style = FontStyle::Italic;
                         }
                         // oblique values greater than or equal to 0deg are checked in ascending order
                         else if let Some(found) = oblique_fonts
@@ -356,7 +356,7 @@ pub fn match_font(
                 use_style = found.0;
             }
             // followed by italic fonts
-            else if let Some(found) = set.iter().find(|f| f.style == Style::Italic) {
+            else if let Some(found) = set.iter().find(|f| f.style == FontStyle::Italic) {
                 use_style = found.style;
             }
             // followed by oblique values less than 0deg in descending order
@@ -449,16 +449,16 @@ pub fn match_font(
     None
 }
 
-fn oblique_angle(style: Style) -> Option<f32> {
+fn oblique_angle(style: FontStyle) -> Option<f32> {
     match style {
-        Style::Oblique(angle) => Some(angle.unwrap_or(DEFAULT_OBLIQUE_ANGLE)),
+        FontStyle::Oblique(angle) => Some(angle.unwrap_or(DEFAULT_OBLIQUE_ANGLE)),
         _ => None,
     }
 }
 
-fn oblique_style(style: Style) -> Option<(Style, f32)> {
+fn oblique_style(style: FontStyle) -> Option<(FontStyle, f32)> {
     match style {
-        Style::Oblique(angle) => Some((style, angle.unwrap_or(DEFAULT_OBLIQUE_ANGLE))),
+        FontStyle::Oblique(angle) => Some((style, angle.unwrap_or(DEFAULT_OBLIQUE_ANGLE))),
         _ => None,
     }
 }

--- a/parley/src/style/font.rs
+++ b/parley/src/style/font.rs
@@ -5,9 +5,7 @@ use alloc::borrow::Cow;
 use alloc::borrow::ToOwned;
 use core::fmt;
 
-pub use fontique::{
-    GenericFamily, Stretch as FontStretch, Style as FontStyle, Weight as FontWeight,
-};
+pub use fontique::{FontStretch, FontStyle, FontWeight, GenericFamily};
 
 /// Setting for a font variation.
 pub type FontVariation = swash::Setting<f32>;


### PR DESCRIPTION
This brings them into line with how they're used in `parley::style` as well as closer to how they're named in CSS where these properties are `font-stretch` (since renamed to `font-width`), `font-style`, and `font-weight`.

This is a precursor to extracting this code into a separate crate for styling text.