### PR TITLE
fontique: Move creation of attributes from fontconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This release has an [MSRV] of 1.75.
 
 ### Added
 
+#### Fontique
+
+- `FontStretch`, `FontStyle`, and `FontWeight` get helper functions `from_fontconfig` ([#212] by [@waywardmonkeys][])
+
 #### Parley
 
 - `Generation` on `PlainEditor` to help implement lazy drawing. ([#143] by [@xorgy])

--- a/fontique/src/attributes.rs
+++ b/fontique/src/attributes.rs
@@ -333,6 +333,8 @@ impl FontWeight {
     ///
     /// [fonts.conf documentation]: https://www.freedesktop.org/software/fontconfig/fontconfig-user.html
     pub fn from_fontconfig(weight: i32) -> Self {
+        // A selection of OpenType weights (first) and their corresponding fontconfig value (second)
+        // Invariant: The fontconfig values are sorted
         const MAP: &[(i32, i32)] = &[
             (0, 0),
             (100, 0),

--- a/fontique/src/attributes.rs
+++ b/fontique/src/attributes.rs
@@ -354,6 +354,7 @@ impl FontWeight {
             if weight == *fc {
                 return Self::new(*ot as f32);
             }
+            // Linear interpolation if not an exact match
             if weight < *fc {
                 let weight = weight as f32;
                 let fc_a = MAP[i - 1].1 as f32;


### PR DESCRIPTION
This exposes `from_fontconfig` functions on `FontStretch`, `FontStyle`, and `FontWeight` rather than only defining them locally within the fontconfig code.

This is in preparation for a change similar to #209 where these types and others get pulled into a shared vocabulary crate and this sort of constructor helper would be useful to others.