### PR TITLE
Impl bytemuck traits for `GenericFamily`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -963,6 +963,7 @@ dependencies = [
 name = "fontique"
 version = "0.2.0"
 dependencies = [
+ "bytemuck",
  "core-foundation",
  "core-text",
  "core_maths",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ clippy.wildcard_dependencies = "warn"
 
 [workspace.dependencies]
 accesskit = "0.17"
+bytemuck = { version = "1.20.0", default-features = false }
 fontique = { version = "0.2.0", default-features = false, path = "fontique" }
 hashbrown = "0.15.2"
 parley = { version = "0.2.0", default-features = false, path = "parley" }

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -30,6 +30,7 @@ system = [
 ]
 
 [dependencies]
+bytemuck = { workspace = true }
 read-fonts = { workspace = true }
 peniko = { workspace = true }
 smallvec = "1.13.2"


### PR DESCRIPTION
This can be used in the future as part of FFI work, but for now, the `Contiguous` trait is used to provide a `MAX_VALUE` used by `GenericFamilyMap`.

This is a backport of part of #209 where the separation between `GenericFamily` and `GenericFamilyMap` has grown to span crates.

The testing here borrows from (copies) what is done for similar testing of `bytemuck` traits in the `color` crate.

These crates already depend on `bytemuck`, so this isn't a new dependency. A decision is made here though to not use the `derive` feature as when we move this type to a vocabulary crate, we will want to avoid the `derive` feature there to avoid a dependency on proc macros.