### PR TITLE
Fix `Cursor::{next,previous}_logical_word` and skip over whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This release has an [MSRV] of 1.88.
 #### Parley
 
 - Breaking change: the `Glyph::style_index` field was removed. Use `Cluster::{style, style_index}` or `GlyphRun::{style, style_index}` instead. (#661 by [@tomcur][])
+- `parley::editing::Cursor::{previous,next}_logical_word` now land at the previous/next logical start of a word and skip over whitespace. ([#215][] by [@tomcur][])
 
 ### Fixed
 
@@ -587,6 +588,7 @@ This release has an [MSRV][] of 1.70.
 [#211]: https://github.com/linebender/parley/pull/211
 [#212]: https://github.com/linebender/parley/pull/212
 [#213]: https://github.com/linebender/parley/pull/213
+[#215]: https://github.com/linebender/parley/pull/215
 [#223]: https://github.com/linebender/parley/pull/223
 [#224]: https://github.com/linebender/parley/pull/224
 [#241]: https://github.com/linebender/parley/pull/241

--- a/parley/src/editing/cursor.rs
+++ b/parley/src/editing/cursor.rs
@@ -243,16 +243,23 @@ impl Cursor {
         cur
     }
 
-    /// Returns a new cursor that is positioned at the next word boundary
-    /// in logical order.
+    /// Returns a new cursor that is positioned at the next word boundary in logical order, skipping
+    /// over whitespace.
     #[must_use]
     pub fn next_logical_word<B: Brush>(&self, layout: &Layout<B>) -> Self {
         let [upstream, downstream] = self.logical_clusters(layout);
-        if let Some(cluster) = downstream.or(upstream) {
-            let start = cluster.clone();
-            let cluster = cluster.next_logical_word().unwrap_or(cluster);
-            if cluster.path == start.path {
-                return Self::from_byte_index(layout, usize::MAX, Affinity::Downstream);
+        if let Some(mut cluster) = downstream.or(upstream) {
+            // `Cluster::next_logical_word` stops at the nearest next cluster marked as word
+            // boundary, which can be whitespace. We keep hopping over whitespace boundaries to land
+            // on the start of the preceding "actual" word.
+            loop {
+                let Some(next) = cluster.next_logical_word() else {
+                    return Self::from_byte_index(layout, usize::MAX, Affinity::Downstream);
+                };
+                cluster = next;
+                if !cluster.data.info.is_whitespace() {
+                    break;
+                }
             }
             // Affine towards the word we land on (e.g., in case of jumping across a soft break, the
             // cursor is attached to the word on the next line).
@@ -261,13 +268,24 @@ impl Cursor {
         *self
     }
 
-    /// Returns a new cursor that is positioned at the previous word boundary
-    /// in logical order.
+    /// Returns a new cursor that is positioned at the previous word boundary in logical order,
+    /// skipping over whitespace.
     #[must_use]
     pub fn previous_logical_word<B: Brush>(&self, layout: &Layout<B>) -> Self {
         let [upstream, downstream] = self.logical_clusters(layout);
-        if let Some(cluster) = downstream.or(upstream) {
-            let cluster = cluster.previous_logical_word().unwrap_or(cluster);
+        if let Some(mut cluster) = downstream.or(upstream) {
+            // `Cluster::previous_logical_word` stops at the nearest previous cluster marked as word
+            // boundary, which can be whitespace. We keep hopping over whitespace boundaries to land
+            // on the start of the preceding "actual" word.
+            loop {
+                let Some(prev) = cluster.previous_logical_word() else {
+                    break;
+                };
+                cluster = prev;
+                if !cluster.data.info.is_whitespace() {
+                    break;
+                }
+            }
             // Affine towards the word we land on (e.g., in case of jumping to a soft break, the
             // cursor is attached to the word on the current line).
             return Self::from_byte_index(layout, cluster.text_range().start, Affinity::Downstream);

--- a/parley/src/editing/cursor.rs
+++ b/parley/src/editing/cursor.rs
@@ -243,15 +243,17 @@ impl Cursor {
         cur
     }
 
-    /// Returns a new cursor that is positioned at the next word boundary in logical order, skipping
-    /// over whitespace.
+    /// Returns a new cursor that is positioned at the next logical start of a word, skipping over
+    /// whitespace.
+    ///
+    /// If there's no next word, the cursor lands at the end of the text.
     #[must_use]
     pub fn next_logical_word<B: Brush>(&self, layout: &Layout<B>) -> Self {
         let [upstream, downstream] = self.logical_clusters(layout);
         if let Some(mut cluster) = downstream.or(upstream) {
             // `Cluster::next_logical_word` stops at the nearest next cluster marked as word
             // boundary, which can be whitespace. We keep hopping over whitespace boundaries to land
-            // on the start of the preceding "actual" word.
+            // on the start of the next "actual" word.
             loop {
                 let Some(next) = cluster.next_logical_word() else {
                     return Self::from_byte_index(layout, usize::MAX, Affinity::Downstream);
@@ -268,8 +270,10 @@ impl Cursor {
         *self
     }
 
-    /// Returns a new cursor that is positioned at the previous word boundary in logical order,
-    /// skipping over whitespace.
+    /// Returns a new cursor that is positioned at the previous logical start of a word, skipping
+    /// over whitespace.
+    ///
+    /// If the cursor is currently inside a word, it lands at that word's logical start.
     #[must_use]
     pub fn previous_logical_word<B: Brush>(&self, layout: &Layout<B>) -> Self {
         let [upstream, downstream] = self.logical_clusters(layout);

--- a/parley/src/editing/cursor.rs
+++ b/parley/src/editing/cursor.rs
@@ -277,10 +277,7 @@ impl Cursor {
             // `Cluster::previous_logical_word` stops at the nearest previous cluster marked as word
             // boundary, which can be whitespace. We keep hopping over whitespace boundaries to land
             // on the start of the preceding "actual" word.
-            loop {
-                let Some(prev) = cluster.previous_logical_word() else {
-                    break;
-                };
+            while let Some(prev) = cluster.previous_logical_word() {
                 cluster = prev;
                 if !cluster.data.info.is_whitespace() {
                     break;

--- a/parley/src/editing/cursor.rs
+++ b/parley/src/editing/cursor.rs
@@ -247,14 +247,16 @@ impl Cursor {
     /// in logical order.
     #[must_use]
     pub fn next_logical_word<B: Brush>(&self, layout: &Layout<B>) -> Self {
-        let [left, right] = self.logical_clusters(layout);
-        if let Some(cluster) = right.or(left) {
+        let [upstream, downstream] = self.logical_clusters(layout);
+        if let Some(cluster) = downstream.or(upstream) {
             let start = cluster.clone();
             let cluster = cluster.next_logical_word().unwrap_or(cluster);
             if cluster.path == start.path {
                 return Self::from_byte_index(layout, usize::MAX, Affinity::Downstream);
             }
-            return Self::from_cluster(layout, cluster, true);
+            // Affine towards the word we land on (e.g., in case of jumping across a soft break, the
+            // cursor is attached to the word on the next line).
+            return Self::from_byte_index(layout, cluster.text_range().start, Affinity::Downstream);
         }
         *self
     }
@@ -263,10 +265,12 @@ impl Cursor {
     /// in logical order.
     #[must_use]
     pub fn previous_logical_word<B: Brush>(&self, layout: &Layout<B>) -> Self {
-        let [left, right] = self.logical_clusters(layout);
-        if let Some(cluster) = left.or(right) {
+        let [upstream, downstream] = self.logical_clusters(layout);
+        if let Some(cluster) = downstream.or(upstream) {
             let cluster = cluster.previous_logical_word().unwrap_or(cluster);
-            return Self::from_cluster(layout, cluster, true);
+            // Affine towards the word we land on (e.g., in case of jumping to a soft break, the
+            // cursor is attached to the word on the current line).
+            return Self::from_byte_index(layout, cluster.text_range().start, Affinity::Downstream);
         }
         *self
     }

--- a/parley/src/editing/selection.rs
+++ b/parley/src/editing/selection.rs
@@ -59,7 +59,11 @@ impl Selection {
                 cluster = prev;
             }
             let anchor = Cursor::from_cluster(layout, cluster.clone(), !cluster.is_rtl());
-            let focus = anchor.next_logical_word(layout);
+            let focus = if let Some(end) = cluster.next_logical_word() {
+                Cursor::from_cluster(layout, end.clone(), !cluster.is_rtl())
+            } else {
+                Cursor::from_byte_index(layout, usize::MAX, Affinity::Downstream)
+            };
             Self {
                 anchor,
                 focus,


### PR DESCRIPTION
Currently, in `foo b|ar` where `|` indicates the cursor position, `Cursor::previous_logical_word` will return `foo| bar`. This doesn't match the behavior of `Cursor::{next_logical_word, previous_visual_word}` which place the cursor at the boundary of the current word. This happens because `Cluster::previous_logical_word` is called from the upstream cluster (the "b") and the cursor then lands between the "o" and the space.

This also renames "left", "right" -> "upstream", "downstream" (naming copied from `Cursor::logical_clusters`) to make it clear we're operating in logical order and not visual, and attaches the cursor to the word whose boundary it lands on.

The upstream/downstream fix on its own with no other changes, would regress how whitespace is handled, e.g., in `foo |bar`, where `previous_logical_word` would then end up at `foo| bar` instead of `|foo bar`. The cleanest way to handle this, I think, is to fold in a fix for #604 at the same time, skipping over whitespace. That's what this PR now proposes. This aligns these logical jumps to the visual `{previous, next}_visual_word`.