### PR TITLE
Don't use `peniko::Color` with `tiny-skia`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,7 +2596,6 @@ name = "tiny_skia_render"
 version = "0.1.0"
 dependencies = [
  "parley",
- "peniko",
  "skrifa",
  "tiny-skia",
 ]

--- a/examples/tiny_skia_render/Cargo.toml
+++ b/examples/tiny_skia_render/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [dependencies]
 parley = { workspace = true, default-features = true }
 skrifa = { workspace = true }
-peniko = { workspace = true }
 tiny-skia = "0.11.4"
 
 [lints]


### PR DESCRIPTION
Just make our own `ColorBrush` struct and use `tiny_skia::Color` rather than pulling in Peniko and doing extra conversions.

This will also simplify things when Peniko is updated and gets the new color code.