### PR TITLE
Add `PlainEditor` method to get IME cursor area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This release has an [MSRV] of 1.75.
 
 - `Generation` on `PlainEditor` to help implement lazy drawing. ([#143] by [@xorgy])
 - Support for preedit for input methods in `PlainEditor` ([#192][], [#198][] by [@tomcur][])
+- `PlainEditor` method to get a cursor area for use by the platform's input method ([#224][] by [@tomcur][])
 
 ### Changed
 
@@ -113,6 +114,7 @@ This release has an [MSRV] of 1.70.
 [#198]: https://github.com/linebender/parley/pull/198
 [#211]: https://github.com/linebender/parley/pull/211
 [#223]: https://github.com/linebender/parley/pull/223
+[#224]: https://github.com/linebender/parley/pull/224
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/linebender/parley/releases/tag/v0.2.0

--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -96,7 +96,7 @@ struct SimpleVelloApp<'s> {
     last_drawn_generation: text::Generation,
 
     /// The IME cursor area we last sent to the platform.
-    last_sent_ime_cursor_area: Option<kurbo::Rect>,
+    last_sent_ime_cursor_area: kurbo::Rect,
 
     /// The event loop proxy required by the AccessKit winit adapter.
     event_loop_proxy: EventLoopProxy<accesskit_winit::Event>,
@@ -220,8 +220,8 @@ impl ApplicationHandler<accesskit_winit::Event> for SimpleVelloApp<'_> {
         if self.last_drawn_generation != self.editor.generation() {
             render_state.window.request_redraw();
             let area = self.editor.editor().ime_cursor_area();
-            if self.last_sent_ime_cursor_area != Some(area) {
-                self.last_sent_ime_cursor_area = Some(area);
+            if self.last_sent_ime_cursor_area != area {
+                self.last_sent_ime_cursor_area = area;
                 // Note: on X11 `set_ime_cursor_area` may cause the exclusion area to be obscured
                 // until https://github.com/rust-windowing/winit/pull/3966 is in the Winit release
                 // used by this example.
@@ -358,7 +358,7 @@ fn main() -> Result<()> {
         scene: Scene::new(),
         editor: text::Editor::new(text::LOREM),
         last_drawn_generation: Default::default(),
-        last_sent_ime_cursor_area: None,
+        last_sent_ime_cursor_area: kurbo::Rect::new(f64::NAN, f64::NAN, f64::NAN, f64::NAN),
         event_loop_proxy: event_loop.create_proxy(),
     };
 


### PR DESCRIPTION
The area reported is the area of text the user is currently editing. It is usually used by platforms to place a candidate box for IME near it, while ensuring it is not obscured.

The implementation here ensures the area is usually near the focus, that the area contains at least some surrounding context (in case the platform places something to the side of the area, instead of above or under), and that the IME candidate box usually does not need to jump around when the IME starts or continues composing.