### PR TITLE
Don't use `peniko::Color` with `swash_render`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,7 +2474,6 @@ version = "0.1.0"
 dependencies = [
  "image",
  "parley",
- "peniko",
  "skrifa",
  "swash",
 ]

--- a/examples/swash_render/Cargo.toml
+++ b/examples/swash_render/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [dependencies]
 parley = { workspace = true, default-features = true }
 skrifa = { workspace = true }
-peniko = { workspace = true }
 image = { version = "0.25.2", default-features = false, features = ["png"] }
 swash = { workspace = true, default-features = true }
 


### PR DESCRIPTION
Just make our own `ColorBrush` struct and use `image::Rgba` rather than pulling in Peniko and doing extra conversions.

This will also simplify things when Peniko is updated and gets the new color code.