### PR TITLE
Fix and un-allow `clippy::unseparated_literal_suffix` lints

### DIFF
--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -6,7 +6,6 @@
 #![allow(unreachable_pub)]
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::shadow_unrelated)]
-#![allow(clippy::unseparated_literal_suffix)]
 
 use accesskit::{Node, Role, Tree, TreeUpdate};
 use anyhow::Result;
@@ -248,7 +247,7 @@ impl ApplicationHandler<accesskit_winit::Event> for SimpleVelloApp<'_> {
                     .resize_surface(&mut render_state.surface, size.width, size.height);
                 let editor = self.editor.editor();
                 editor.set_scale(1.0);
-                editor.set_width(Some(size.width as f32 - 2f32 * text::INSET));
+                editor.set_width(Some(size.width as f32 - 2_f32 * text::INSET));
                 render_state.window.request_redraw();
             }
 

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -106,7 +106,7 @@ impl Editor {
         match event {
             WindowEvent::Resized(size) => {
                 self.editor
-                    .set_width(Some(size.width as f32 - 2f32 * INSET));
+                    .set_width(Some(size.width as f32 - 2_f32 * INSET));
             }
             WindowEvent::ModifiersChanged(modifiers) => {
                 self.modifiers = Some(modifiers);

--- a/fontique/src/family_name.rs
+++ b/fontique/src/family_name.rs
@@ -103,7 +103,7 @@ struct NameKey {
 impl NameKey {
     fn from_str(s: &str) -> Self {
         let mut res = Self::default();
-        let mut buf = [0u8; 4];
+        let mut buf = [0_u8; 4];
         for ch in s.chars() {
             for ch in ch.to_lowercase() {
                 res.data

--- a/fontique/src/font.rs
+++ b/fontique/src/font.rs
@@ -85,7 +85,7 @@ impl FontInfo {
     /// Returns synthesis suggestions for this font with the given attributes.
     pub fn synthesis(&self, width: FontWidth, style: FontStyle, weight: FontWeight) -> Synthesis {
         let mut synth = Synthesis::default();
-        let mut len = 0usize;
+        let mut len = 0_usize;
         if self.has_width_axis() && self.width != width {
             synth.vars[len] = (Tag::new(b"wdth"), width.percentage());
             len += 1;
@@ -201,7 +201,7 @@ impl FontInfo {
         let (width, style, weight) = read_attributes(font);
         let (axes, attr_axes) = if let Ok(fvar_axes) = font.fvar().and_then(|fvar| fvar.axes()) {
             let mut axes = SmallVec::<[AxisInfo; 1]>::with_capacity(fvar_axes.len());
-            let mut attrs_axes = 0u8;
+            let mut attrs_axes = 0_u8;
             for fvar_axis in fvar_axes {
                 let axis = AxisInfo {
                     tag: fvar_axis.axis_tag(),

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -22,7 +22,6 @@
 #![allow(clippy::exhaustive_enums)]
 #![allow(clippy::partial_pub_fields)]
 #![allow(clippy::shadow_unrelated)]
-#![allow(clippy::unseparated_literal_suffix)]
 #![allow(clippy::use_self)]
 
 #[cfg(not(any(feature = "std", feature = "libm")))]

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -145,7 +145,7 @@ impl LineItemData {
     pub(crate) fn compute_line_height<B: Brush>(&self, layout: &LayoutData<B>) -> f32 {
         match self.kind {
             LayoutItemKind::TextRun => {
-                let mut line_height = 0f32;
+                let mut line_height = 0_f32;
                 let run = &layout.runs[self.index];
                 let glyph_start = run.glyph_start;
                 for cluster in &layout.clusters[run.cluster_range.clone()] {
@@ -325,7 +325,7 @@ impl<B: Brush> LayoutData<B> {
             advance: 0.,
         };
         // Track these so that we can flush if they overflow a u16.
-        let mut glyph_count = 0usize;
+        let mut glyph_count = 0_usize;
         let mut text_offset = 0;
         macro_rules! flush_run {
             () => {

--- a/parley/src/layout/line/greedy.rs
+++ b/parley/src/layout/line/greedy.rs
@@ -617,9 +617,9 @@ impl<B: Brush> Drop for BreakLines<'_, B> {
     fn drop(&mut self) {
         // Compute the overall width and height of the entire layout
         // The "width" excludes trailing whitespace. The "full_width" includes it.
-        let mut width = 0f32;
-        let mut full_width = 0f32;
-        let mut height = 0f32;
+        let mut width = 0_f32;
+        let mut full_width = 0_f32;
+        let mut height = 0_f32;
         for line in &self.lines.lines {
             width = width.max(line.metrics.advance - line.metrics.trailing_whitespace);
             full_width = full_width.max(line.metrics.advance);

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -92,7 +92,6 @@
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::return_self_not_must_use)]
 #![allow(clippy::shadow_unrelated)]
-#![allow(clippy::unseparated_literal_suffix)]
 #![allow(clippy::use_self)]
 
 #[cfg(not(any(feature = "std", feature = "libm")))]

--- a/parley/src/swash_convert.rs
+++ b/parley/src/swash_convert.rs
@@ -6,7 +6,7 @@ pub(crate) fn script_to_fontique(script: swash::text::Script) -> fontique::Scrip
 }
 
 pub(crate) fn locale_to_fontique(locale: swash::text::Language) -> Option<fontique::Language> {
-    let mut buf = [0u8; 16];
+    let mut buf = [0_u8; 16];
     let mut len = 0;
     for byte in locale.language().bytes() {
         buf[len] = byte;


### PR DESCRIPTION
Remove the `allow` for them as well.