### PR TITLE
Allow Bidi `base_level` to be determined from text

### DIFF
--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -109,7 +109,7 @@ impl<B: Brush> LayoutContext<B> {
             self.bidi.resolve(
                 text.chars()
                     .zip(self.info.iter().map(|info| info.0.bidi_class())),
-                Some(0),
+                None,
             );
         }
     }


### PR DESCRIPTION
`Layout::is_rtl` always returns `false` when `base_level` is forced to 0. Can it already safely be determined from the string buffer? It seems to work OK with this change: the fist strong Bidi character encountered determines the `base_level`.