### PR TITLE
Fix linebreaking for lines without text runs

### DIFF
--- a/parley/src/layout/line/greedy.rs
+++ b/parley/src/layout/line/greedy.rs
@@ -696,8 +696,6 @@ fn try_commit_line<B: Brush>(
     alignment: Alignment,
     break_reason: BreakReason,
 ) -> bool {
-    let is_empty = layout.data.text_len == 0;
-
     // Ensure that the cluster and item endpoints are within range
     state.clusters.end = state.clusters.end.min(layout.data.clusters.len());
     state.items.end = state.items.end.min(layout.data.items.len());
@@ -760,12 +758,7 @@ fn try_commit_line<B: Brush>(
                     cluster_range.end = state.clusters.end;
                 }
 
-                let overlap = run_data.cluster_range.contains(&cluster_range.start)
-                    && run_data.cluster_range.contains(&(cluster_range.end - 1));
-                if cluster_range.start > cluster_range.end
-                    || (!is_empty && cluster_range.start == cluster_range.end)
-                    || !overlap
-                {
+                if cluster_range.start >= run_data.cluster_range.end {
                     // println!("INVALID CLUSTER");
                     // dbg!(&run_data.text_range);
                     // dbg!(cluster_range);

--- a/parley/src/layout/line/greedy.rs
+++ b/parley/src/layout/line/greedy.rs
@@ -828,7 +828,6 @@ fn try_commit_line<B: Brush>(
     state.num_spaces = 0;
     if committed_text_run {
         state.clusters.start = state.clusters.end;
-        state.clusters.end += 1;
     }
 
     state.items.start = match last_item_kind {

--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -73,3 +73,39 @@ fn only_inboxes_wrap() {
 
     env.check_layout_snapshot(&layout);
 }
+
+#[test]
+fn full_width_inbox() {
+    let mut env = testenv!();
+
+    for (width, test_case_name) in [(99., "smaller"), (100., "exact"), (101., "larger")] {
+        let text = "ABC";
+        let mut builder = env.builder(text);
+        builder.push_inline_box(InlineBox {
+            id: 0,
+            index: 1,
+            width: 10.,
+            height: 10.0,
+        });
+        builder.push_inline_box(InlineBox {
+            id: 1,
+            index: 1,
+            width,
+            height: 10.0,
+        });
+        builder.push_inline_box(InlineBox {
+            id: 2,
+            index: 2,
+            width,
+            height: 10.0,
+        });
+        let mut layout = builder.build(text);
+        layout.break_all_lines(Some(100.));
+        layout.align(
+            None,
+            Alignment::Start,
+            false, /* align_when_overflowing */
+        );
+        env.with_name(test_case_name).check_layout_snapshot(&layout);
+    }
+}

--- a/parley/tests/snapshots/full_width_inbox-exact.png
+++ b/parley/tests/snapshots/full_width_inbox-exact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2452dfcfc39bab0cdabdc75852407daecc72644fd8c6788799b4b4cbbd5ca5c4
+size 2214

--- a/parley/tests/snapshots/full_width_inbox-larger.png
+++ b/parley/tests/snapshots/full_width_inbox-larger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdaba553a627d09ab73e03466fe7f48da8ef89db09f6190e5a3a912de39a18b1
+size 2325

--- a/parley/tests/snapshots/full_width_inbox-smaller.png
+++ b/parley/tests/snapshots/full_width_inbox-smaller.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90e9f056eab56f1c387c1d5d8acd12060def8bf5c6f2f63693c5c4c8624747b5
+size 2317


### PR DESCRIPTION
It turns out that there were actually two bugs that caused the behavior as described in #246.

The first bug happens when a line ends with a text run. In this scenario, the text run is repeated at the start of the next line, so that any remaining clusters can be rendered. However, when there are no more remaining clusters to render, the text run essentially uses clusters from the next run. In the example image in #246, this causes the 'B' to be added to the second line.

The second bug happens when a line that does not contain any text runs is committed. In this case, the cluster range in the current line state is bumped, even though no clusters were actually processed. This is the reason that the 'B' wasn't added to the third line in the image in #246.

I've added a test that tests a scenario with a full width inline box both when the previous line ends with an inline box and when it ends with a text run.

I'm not fully satisfied with the solution in this PR, because it feels rather heavy-handed. It is already unclear to me when both existing conditions in the invalid cluster check even apply, so just adding another one makes it even harder to understand.

Fixes #246