### PR TITLE
Strip whitespace following a newline when whitespace collapsing is enabled

### DIFF
--- a/parley/src/resolve/tree.rs
+++ b/parley/src/resolve/tree.rs
@@ -78,7 +78,13 @@ impl<B: Brush> TreeStyleBuilder<B> {
             WhiteSpaceCollapse::Collapse => {
                 let mut span_text = self.uncommitted_text.as_str();
 
-                if self.is_span_first {
+                if self.is_span_first
+                    || self
+                        .text
+                        .chars()
+                        .last()
+                        .is_some_and(|c| c.is_ascii_whitespace())
+                {
                     span_text = span_text.trim_start();
                 }
                 if is_span_last {


### PR DESCRIPTION
This follows https://www.w3.org/TR/CSS2/text.html#white-space-model. Further work will be required to completely match that spec. In particular, whitespace preceding a newline also ought to be stripped but:

1. This is harder to implement in the current whitespace collapsing code
2. This is less consequential as trailing whitespace isn't usually visible.

This fixes a visible 1-space indent at the start of lines following a `<br />` tag in Blitz.