### PR TITLE
Correctly calculate trailing whitespace for all lines

### DIFF
--- a/parley/src/layout/line/greedy.rs
+++ b/parley/src/layout/line/greedy.rs
@@ -526,19 +526,17 @@ impl<'a, B: Brush> BreakLines<'a, B> {
             }
 
             // Compute size of line's trailing whitespace
-            line.metrics.trailing_whitespace = 0.0;
-            if !line.item_range.is_empty() {
-                // Note: there may not be a "last run" if there are no runs in the line
-                let last_item = &self.lines.line_items.last();
-                if let Some(last_item) = last_item {
-                    if last_item.is_text_run() && !last_item.cluster_range.is_empty() {
-                        let cluster = &self.layout.data.clusters[last_item.cluster_range.end - 1];
-                        if cluster.info.whitespace().is_space_or_nbsp() {
-                            line.metrics.trailing_whitespace = cluster.advance;
-                        }
-                    }
-                }
-            }
+            let last_run = &self.lines.line_items[line.item_range.clone()]
+                .last()
+                .filter(|item| item.is_text_run());
+            line.metrics.trailing_whitespace = last_run
+                .and_then(|run| {
+                    self.layout.data.clusters[run.cluster_range.clone()]
+                        .last()
+                        .filter(|cluster| cluster.info.whitespace().is_space_or_nbsp())
+                        .map(|cluster| cluster.advance)
+                })
+                .unwrap_or(0.0);
 
             if !have_metrics {
                 // Line consisting entirely of whitespace?

--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -109,3 +109,21 @@ fn full_width_inbox() {
         env.with_name(test_case_name).check_layout_snapshot(&layout);
     }
 }
+
+#[test]
+fn trailing_whitespace() {
+    let mut env = testenv!();
+
+    let text = "AAA BBB";
+    let mut builder = env.builder(text);
+    let mut layout = builder.build(text);
+    layout.break_all_lines(Some(45.));
+    layout.align(None, Alignment::Start, false);
+
+    assert!(
+        layout.width() < layout.full_width(),
+        "Trailing whitespace should cause a difference between width and full_width"
+    );
+
+    env.check_layout_snapshot(&layout);
+}

--- a/parley/tests/snapshots/trailing_whitespace-0.png
+++ b/parley/tests/snapshots/trailing_whitespace-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07db667621bcc96cff9833faa4f63ae3898c8905f895f204f3e2875f0815541b
+size 2581


### PR DESCRIPTION
This should resolve the issue identified in #251. The current version of the code incorrectly checks the last of all line items, instead of the last line item of the current line.

I've also reduced the nested control flow blocks somewhat.

Fixes #251