### PR TITLE
Test leading white space collapsing

### DIFF
--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -1,14 +1,14 @@
 // Copyright 2024 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::{testenv, Alignment, InlineBox};
+use crate::{testenv, Alignment, InlineBox, WhiteSpaceCollapse};
 
 #[test]
 fn plain_multiline_text() {
     let mut env = testenv!();
 
     let text = "Hello world!\nLine 2\nLine 4";
-    let mut builder = env.builder(text);
+    let mut builder = env.ranged_builder(text);
     let mut layout = builder.build(text);
     layout.break_all_lines(None);
     layout.align(
@@ -31,7 +31,7 @@ fn placing_inboxes() {
         (13, "start_nl"),
     ] {
         let text = "Hello world!\nLine 2\nLine 4";
-        let mut builder = env.builder(text);
+        let mut builder = env.ranged_builder(text);
         builder.push_inline_box(InlineBox {
             id: 0,
             index: position,
@@ -54,7 +54,7 @@ fn only_inboxes_wrap() {
     let mut env = testenv!();
 
     let text = "";
-    let mut builder = env.builder(text);
+    let mut builder = env.ranged_builder(text);
     for id in 0..10 {
         builder.push_inline_box(InlineBox {
             id,
@@ -80,7 +80,7 @@ fn full_width_inbox() {
 
     for (width, test_case_name) in [(99., "smaller"), (100., "exact"), (101., "larger")] {
         let text = "ABC";
-        let mut builder = env.builder(text);
+        let mut builder = env.ranged_builder(text);
         builder.push_inline_box(InlineBox {
             id: 0,
             index: 1,
@@ -115,7 +115,7 @@ fn trailing_whitespace() {
     let mut env = testenv!();
 
     let text = "AAA BBB";
-    let mut builder = env.builder(text);
+    let mut builder = env.ranged_builder(text);
     let mut layout = builder.build(text);
     layout.break_all_lines(Some(45.));
     layout.align(None, Alignment::Start, false);
@@ -126,4 +126,32 @@ fn trailing_whitespace() {
     );
 
     env.check_layout_snapshot(&layout);
+}
+
+#[test]
+fn leading_whitespace() {
+    let mut env = testenv!();
+
+    for (mode, test_case_name) in [
+        (WhiteSpaceCollapse::Preserve, "preserve"),
+        (WhiteSpaceCollapse::Collapse, "collapse"),
+    ] {
+        let mut builder = env.tree_builder();
+        builder.set_white_space_mode(mode);
+        builder.push_text("Line 1");
+        builder.push_style_modification_span(None);
+        builder.set_white_space_mode(WhiteSpaceCollapse::Preserve);
+        builder.push_text("\n");
+        builder.pop_style_span();
+        builder.set_white_space_mode(mode);
+        builder.push_text("  Line 2");
+        let (mut layout, _) = builder.build();
+        layout.break_all_lines(None);
+        layout.align(
+            None,
+            Alignment::Start,
+            false, /* align_when_overflowing */
+        );
+        env.with_name(test_case_name).check_layout_snapshot(&layout);
+    }
 }

--- a/parley/src/tests/utils/env.rs
+++ b/parley/src/tests/utils/env.rs
@@ -4,7 +4,7 @@
 use crate::tests::utils::renderer::{render_layout, ColorBrush, RenderingConfig};
 use crate::{
     FontContext, FontFamily, FontStack, Layout, LayoutContext, PlainEditor, PlainEditorDriver,
-    RangedBuilder, Rect, StyleProperty,
+    RangedBuilder, Rect, StyleProperty, TextStyle, TreeBuilder,
 };
 use fontique::{Collection, CollectionOptions};
 use std::path::{Path, PathBuf};
@@ -148,12 +148,21 @@ impl TestEnv {
         ]
     }
 
-    pub(crate) fn builder<'a>(&'a mut self, text: &'a str) -> RangedBuilder<'a, ColorBrush> {
+    pub(crate) fn ranged_builder<'a>(&'a mut self, text: &'a str) -> RangedBuilder<'a, ColorBrush> {
         let default_style = self.default_style();
         let mut builder = self.layout_cx.ranged_builder(&mut self.font_cx, text, 1.0);
         for style in default_style {
             builder.push_default(style);
         }
+        builder
+    }
+
+    pub(crate) fn tree_builder(&mut self) -> TreeBuilder<'_, ColorBrush> {
+        let default_style = self.default_style();
+        let mut builder =
+            self.layout_cx
+                .tree_builder(&mut self.font_cx, 1.0, &TextStyle::default());
+        builder.push_style_modification_span(&default_style);
         builder
     }
 

--- a/parley/tests/snapshots/leading_whitespace-collapse.png
+++ b/parley/tests/snapshots/leading_whitespace-collapse.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42c214dc4dca9dd33665f74925bd877bac8f5068bb93c7f4ee464f2833cc7abd
+size 2939

--- a/parley/tests/snapshots/leading_whitespace-preserve.png
+++ b/parley/tests/snapshots/leading_whitespace-preserve.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b267d9dfe6cdc2a43d804b9332aec6a918876a7dadd154d1795b5ca729046146
+size 2917


### PR DESCRIPTION
Adds `tree_builder` to `TestEnv` to be able to set white space collapsing mode.

A quick follow-up to https://github.com/linebender/parley/pull/254.