### PR TITLE
On overflow, right-align RTL-text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ This release has an [MSRV] of 1.82.
 
 #### Parley
 
-- Fix alignment of right-to-left text. ([#250][] by [@tomcur][])
+- Fix alignment of right-to-left text. ([#250][], [#268][] by [@tomcur][])
 
 ## [0.2.0] - 2024-10-10
 
@@ -124,6 +124,7 @@ This release has an [MSRV] of 1.70.
 [#223]: https://github.com/linebender/parley/pull/223
 [#224]: https://github.com/linebender/parley/pull/224
 [#250]: https://github.com/linebender/parley/pull/250
+[#268]: https://github.com/linebender/parley/pull/268
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/linebender/parley/releases/tag/v0.2.0

--- a/parley/src/layout/alignment.rs
+++ b/parley/src/layout/alignment.rs
@@ -36,7 +36,7 @@ pub(crate) fn align<B: Brush>(
         if !align_when_overflowing && free_space <= 0.0 {
             if is_rtl {
                 // In RTL text, right-align on overflow.
-                line.metrics.offset = free_space
+                line.metrics.offset = free_space;
             }
             continue;
         }

--- a/parley/src/layout/alignment.rs
+++ b/parley/src/layout/alignment.rs
@@ -34,6 +34,10 @@ pub(crate) fn align<B: Brush>(
         let free_space = alignment_width - line.metrics.advance + line.metrics.trailing_whitespace;
 
         if !align_when_overflowing && free_space <= 0.0 {
+            if is_rtl {
+                // In RTL text, right-align on overflow.
+                line.metrics.offset = free_space
+            }
             continue;
         }
 

--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use peniko::kurbo::Size;
+
 use crate::{testenv, Alignment, InlineBox, WhiteSpaceCollapse};
 
 #[test]
@@ -196,4 +198,23 @@ fn base_level_alignment_rtl() {
         layout.align(None, alignment, false /* align_when_overflowing */);
         env.with_name(test_case_name).check_layout_snapshot(&layout);
     }
+}
+
+#[test]
+/// On overflow without alignment-on-overflow, RTL-text should be start-aligned (i.e., aligned to
+/// the right edge, overflowing on the left).
+fn overflow_alignment_rtl() {
+    let mut env = testenv!();
+
+    let text = "عند برمجة أجهزة الكمبيوتر، قد تجد نفسك فجأة في مواقف غريبة، مثل الكتابة بلغة لا تتحدثها فعليًا.";
+    let mut builder = env.ranged_builder(text);
+    let mut layout = builder.build(text);
+    layout.break_all_lines(Some(1000.0));
+    layout.align(
+        Some(10.),
+        Alignment::Middle,
+        false, /* align_when_overflowing */
+    );
+    env.rendering_config().size = Some(Size::new(10., layout.height().into()));
+    env.check_layout_snapshot(&layout);
 }

--- a/parley/src/tests/utils/cursor_test.rs
+++ b/parley/src/tests/utils/cursor_test.rs
@@ -195,12 +195,14 @@ impl CursorTest {
             inline_box_color: bg_color_expected,
             cursor_color: cursor_color_expected,
             selection_color: selection_color_expected,
+            size: None,
         };
         let rendering_config_actual = RenderingConfig {
             background_color: bg_color_actual,
             inline_box_color: bg_color_actual,
             cursor_color: cursor_color_actual,
             selection_color: selection_color_actual,
+            size: None,
         };
 
         let rect_expected = expected.geometry(&self.layout, CURSOR_WIDTH);
@@ -357,6 +359,7 @@ impl CursorTest {
             inline_box_color: bg_color_cursor,
             cursor_color: cursor_color_cursor,
             selection_color: selection_color_cursor,
+            size: None,
         };
 
         let rect_cursor = cursor.geometry(&self.layout, CURSOR_WIDTH);

--- a/parley/src/tests/utils/env.rs
+++ b/parley/src/tests/utils/env.rs
@@ -151,11 +151,16 @@ impl TestEnv {
                 cursor_color: Color::from_rgba8(255, 0, 0, 255),
                 selection_color: Color::from_rgba8(196, 196, 0, 255),
                 inline_box_color: Color::BLACK,
+                size: None,
             },
             cursor_size: 2.0,
             errors: Vec::new(),
             next_test_case_name: String::new(),
         }
+    }
+
+    pub(crate) fn rendering_config(&mut self) -> &mut RenderingConfig {
+        &mut self.rendering_config
     }
 
     fn default_style(&self) -> [StyleProperty<'static, ColorBrush>; 2] {

--- a/parley/src/tests/utils/renderer.rs
+++ b/parley/src/tests/utils/renderer.rs
@@ -8,6 +8,7 @@
 //! if you need emoji rendering.
 
 use crate::{GlyphRun, Layout, PositionedLayoutItem};
+use peniko::kurbo;
 use skrifa::{
     instance::{LocationRef, NormalizedCoord, Size},
     outline::{DrawSettings, OutlinePen},
@@ -34,6 +35,9 @@ pub(crate) struct RenderingConfig {
     pub inline_box_color: Color,
     pub cursor_color: Color,
     pub selection_color: Color,
+
+    /// The width of the pixmap in pixels, excluding padding.
+    pub size: Option<kurbo::Size>,
 }
 
 fn draw_rect(pen: &mut TinySkiaPen<'_>, x: f32, y: f32, width: f32, height: f32, color: Color) {
@@ -42,6 +46,9 @@ fn draw_rect(pen: &mut TinySkiaPen<'_>, x: f32, y: f32, width: f32, height: f32,
     pen.fill_rect(width, height);
 }
 
+/// Render the layout to a [`Pixmap`].
+///
+/// If given [`RenderingConfig::size`] is not specified, [`Layout::width`] is used.
 pub(crate) fn render_layout(
     config: &RenderingConfig,
     layout: &Layout<ColorBrush>,
@@ -49,8 +56,16 @@ pub(crate) fn render_layout(
     selection_rects: &[crate::Rect],
 ) -> Pixmap {
     let padding = 20;
-    let width = layout.width().ceil() as u32;
-    let height = layout.height().ceil() as u32;
+    let width = config
+        .size
+        .map(|size| size.width as f32)
+        .unwrap_or(layout.width())
+        .ceil() as u32;
+    let height = config
+        .size
+        .map(|size| size.height as f32)
+        .unwrap_or(layout.height())
+        .ceil() as u32;
     let padded_width = width + padding * 2;
     let padded_height = height + padding * 2;
     let fpadding = padding as f32;

--- a/parley/src/tests/utils/renderer.rs
+++ b/parley/src/tests/utils/renderer.rs
@@ -48,7 +48,8 @@ fn draw_rect(pen: &mut TinySkiaPen<'_>, x: f32, y: f32, width: f32, height: f32,
 
 /// Render the layout to a [`Pixmap`].
 ///
-/// If given [`RenderingConfig::size`] is not specified, [`Layout::width`] is used.
+/// If given [`RenderingConfig::size`] is not specified, [`Layout::width`] and [`Layout::height`]
+/// are used.
 pub(crate) fn render_layout(
     config: &RenderingConfig,
     layout: &Layout<ColorBrush>,

--- a/parley/tests/snapshots/overflow_alignment_rtl-0.png
+++ b/parley/tests/snapshots/overflow_alignment_rtl-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e442db8faf6a6d2b88dee7994f651b9d1f21f7b7b33b81e44b8e037c8ee949f5
+size 940


### PR DESCRIPTION
As text should be start-aligned on overflow when `overflow_alignment` is `false`, RTL-text must be right-aligned in this case.