### PR TITLE
Use `Layout::width` instead of calculating for alignment

### DIFF
--- a/parley/src/layout/alignment.rs
+++ b/parley/src/layout/alignment.rs
@@ -15,15 +15,7 @@ pub(crate) fn align<B: Brush>(
 ) {
     // Whether the text base direction is right-to-left.
     let is_rtl = layout.base_level & 1 == 1;
-    let alignment_width = alignment_width.unwrap_or_else(|| {
-        let max_line_length = layout
-            .lines
-            .iter()
-            .map(|line| line.metrics.advance)
-            .max_by(f32::total_cmp)
-            .unwrap_or(0.0);
-        max_line_length.min(max_line_length)
-    });
+    let alignment_width = alignment_width.unwrap_or(layout.full_width);
 
     // Apply alignment to line items
     for line in &mut layout.lines {

--- a/parley/src/layout/alignment.rs
+++ b/parley/src/layout/alignment.rs
@@ -15,12 +15,18 @@ pub(crate) fn align<B: Brush>(
 ) {
     // Whether the text base direction is right-to-left.
     let is_rtl = layout.base_level & 1 == 1;
-    let alignment_width = alignment_width.unwrap_or(layout.full_width);
+    let alignment_width = alignment_width.unwrap_or(layout.width);
 
     // Apply alignment to line items
     for line in &mut layout.lines {
         // TODO: remove this field
         line.alignment = alignment;
+
+        if is_rtl {
+            // In RTL text, trailing whitespace is on the left. As we hang that whitespace, offset
+            // the line to the left.
+            line.metrics.offset = -line.metrics.trailing_whitespace;
+        }
 
         // Compute free space.
         let free_space = alignment_width - line.metrics.advance + line.metrics.trailing_whitespace;
@@ -38,10 +44,10 @@ pub(crate) fn align<B: Brush>(
                 // Do nothing
             }
             (Alignment::Right, _) | (Alignment::Start, true) | (Alignment::End, false) => {
-                line.metrics.offset = free_space;
+                line.metrics.offset += free_space;
             }
             (Alignment::Middle, _) => {
-                line.metrics.offset = free_space * 0.5;
+                line.metrics.offset += free_space * 0.5;
             }
             (Alignment::Justified, _) => {
                 // Justified alignment doesn't have any effect if free_space is negative or zero
@@ -54,7 +60,7 @@ pub(crate) fn align<B: Brush>(
                 // case, start-align, i.e., left-align for LTR text and right-align for RTL text.
                 if line.break_reason == BreakReason::None || line.num_spaces == 0 {
                     if is_rtl {
-                        line.metrics.offset = free_space;
+                        line.metrics.offset += free_space;
                     }
                     continue;
                 }
@@ -91,12 +97,6 @@ pub(crate) fn align<B: Brush>(
                         });
                     });
             }
-        }
-
-        if is_rtl {
-            // In RTL text, trailing whitespace is on the left. As we hang that whitespace, offset
-            // the line to the left.
-            line.metrics.offset -= line.metrics.trailing_whitespace;
         }
     }
 }

--- a/parley/src/layout/alignment.rs
+++ b/parley/src/layout/alignment.rs
@@ -34,7 +34,7 @@ pub(crate) fn align<B: Brush>(
         if !align_when_overflowing && free_space <= 0.0 {
             if is_rtl {
                 // In RTL text, right-align on overflow.
-                line.metrics.offset = free_space;
+                line.metrics.offset += free_space;
             }
             continue;
         }

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -161,7 +161,7 @@ impl<B: Brush> Layout<B> {
     ///
     /// You must perform line breaking prior to aligning, through [`Layout::break_lines`] or
     /// [`Layout::break_all_lines`]. If `container_width` is not specified, the layout's
-    /// [`Layout::full_width`] is used.
+    /// [`Layout::width`] is used.
     ///
     /// If `align_when_overflowing` is set to `true`, alignment will apply even if the line
     /// contents are wider than the alignment width. If it is set to `false`, all overflowing lines

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -156,12 +156,16 @@ impl<B: Brush> Layout<B> {
             .break_remaining(max_advance.unwrap_or(f32::MAX));
     }
 
-    // Apply to alignment to layout relative to the specified container width. If container_width is not
-    // specified then the max line length is used.
-    //
-    // If `align_when_overflowing` is set to `true` then `Center` and `End` alignment will apply even if
-    // the line contents are wider than the `container_width`. If it is set to `false` then all overflowing
-    // lines will be `Start` aligned.
+    /// Apply alignment to the layout relative to the specified container width or full layout
+    /// width.
+    ///
+    /// You must perform line breaking prior to aligning, through [`Layout::break_lines`] or
+    /// [`Layout::break_all_lines`]. If `container_width` is not specified, the layout's
+    /// [`Layout::full_width`] is used.
+    ///
+    /// If `align_when_overflowing` is set to `true`, alignment will apply even if the line
+    /// contents are wider than the alignment width. If it is set to `false`, all overflowing lines
+    /// will be [`Alignment::Start`] aligned.
     pub fn align(
         &mut self,
         container_width: Option<f32>,

--- a/parley/tests/snapshots/base_level_alignment_rtl-justified.png
+++ b/parley/tests/snapshots/base_level_alignment_rtl-justified.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43fa397a7a28afbc87020ca386ed94982fee22800978764b4e3a2a7ad857715d
-size 19391
+oid sha256:d98582ed99e97ba066ec8fa114bdfb4670b00cf44b8fffde8cccc91a7576f7af
+size 19320

--- a/parley/tests/snapshots/base_level_alignment_rtl-middle.png
+++ b/parley/tests/snapshots/base_level_alignment_rtl-middle.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0389a37a20bb688c3e6f8ae109af97b8f4ec5ec87f2e6179d6ffe214a44aab6f
-size 19023
+oid sha256:040b1c00c6e41b9e78d1df5544b4322ff03c09234f972346a30a4235c528981e
+size 19080

--- a/parley/tests/snapshots/base_level_alignment_rtl-start.png
+++ b/parley/tests/snapshots/base_level_alignment_rtl-start.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3e1497a26a7f8a99a12113d0562802d1907ccbc5035dc076a8db9fd6e415014
-size 19340
+oid sha256:6f7b657448c89bd8cfcef0d3df94c8c4f40ce7efbefc299b3de153a52108d231
+size 19081


### PR DESCRIPTION
This does require line breaking to have happened, but that is already a requirement, as otherwise `Layout::lines` is empty.

This is a slight change in behavior, as trailing white space is no longer included in the alignment width.