### PR TITLE
Add Hans and Hant scripts; improve Hani sample

### DIFF
--- a/fontique/src/script.rs
+++ b/fontique/src/script.rs
@@ -109,8 +109,10 @@ pub const SCRIPT_SAMPLES: &[(Script, &str)] = &[
         "\u{a01}\u{a02}ਃਅਆਇਈਉਊਏਐਓਔਕਖਗ",
     ),
     (Script::from_str_unchecked("Hang"), "가"),
-    (Script::from_str_unchecked("Hani"), "今"),
+    (Script::from_str_unchecked("Hani"), "严揯今"),
     (Script::from_str_unchecked("Hano"), "ᜠᜡᜢᜣᜤᜥᜦᜧᜨᜩᜪᜫᜬᜭᜮᜯ"),
+    (Script::from_str_unchecked("Hans"), "严"),
+    (Script::from_str_unchecked("Hant"), "揯"),
     (Script::from_str_unchecked("Hatr"), "𐣠𐣡𐣢𐣣𐣤𐣥𐣦𐣧𐣨𐣩𐣪𐣫𐣬𐣭𐣮𐣯"),
     (
         Script::from_str_unchecked("Hebr"),


### PR DESCRIPTION
This is a somewhat hacky fix to allow properly loading fallbacks for Chinese scripts on Windows.

The "Hans" and "Hant" (simplified and traditional Chinese) script identifiers were missing, and "Hani" included a character which is included in Yu Gothic UI, Windows' default Japanese font, which only contains kanji.

This means that selecting a "Hani" (all Han ideographs) fallback would select a Japanese-only font that's missing some ideographs that seem to be used in Chinese.

I do not actually speak Chinese; I found these characters by looking in gaps in Yu Gothic UI's coverage that Microsoft JhengHei UI fills. Someone more familiar with Chinese and/or Japanese could probably do a better job finding sample characters that are used only in Chinese and not Japanese.

We need to put the Chinese-only characters first in the "Hani" sample because of the way the DirectWrite fallback handling works--we call [`IDWriteFontFallback::MapCharacters`](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_2/nf-dwrite_2-idwritefontfallback-mapcharacters) repeatedly, advancing the "head" of the string one character at a time, until we get a match. However, the documentation for `MapCharacters` says that it actually works by returning "the font that should be used to render the first *mappedLength* characters of the text"--that is, it returns a font that you can use to render the first bit of the string, then you advance and call it again on the next bit, repeat until all characters are mapped. This means that the way we do things, only *one* character in each sample (with preference given to earlier ones) needs to match in order for a fallback font to be selected.

If things worked more like the fontconfig backend seems to, where there's a whole list of fallback families, this would be fine, but the DirectWrite backend only ever returns *one* fallback which may not cover all characters in the given sample string. That's a less-hacky longer-term solution.