### PR TITLE
Fix text editing for layouts which contain inline boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ This release has an [MSRV] of 1.82.
 - Display selected newlines as whitespace in the selection highlight. ([#296][] by [@valadaptive][])
 - Make `BreakReason` public. ([#300][] by [@valadaptive][])
 
+### Fixed
+
+#### Parley
+
+- Fix text editing for layouts which contain inline boxes ([#299][] by [@valadaptive][])
+
 ## [0.3.0] - 2025-02-27
 
 This release has an [MSRV] of 1.82.
@@ -217,6 +223,7 @@ This release has an [MSRV] of 1.70.
 [#280]: https://github.com/linebender/parley/pull/280
 [#294]: https://github.com/linebender/parley/pull/294
 [#296]: https://github.com/linebender/parley/pull/296
+[#299]: https://github.com/linebender/parley/pull/299
 [#300]: https://github.com/linebender/parley/pull/300
 [#306]: https://github.com/linebender/parley/pull/306
 [#312]: https://github.com/linebender/parley/pull/312

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -33,6 +33,7 @@ pub use alignment::AlignmentOptions;
 pub use cluster::{Affinity, ClusterPath, ClusterSide};
 pub use cursor::{Cursor, Selection};
 pub use data::BreakReason;
+pub(crate) use line::LineItem;
 pub use line::greedy::BreakLines;
 pub use line::{GlyphRun, LineMetrics, PositionedInlineBox, PositionedLayoutItem};
 pub use run::RunMetrics;

--- a/parley/src/shape.rs
+++ b/parley/src/shape.rs
@@ -136,7 +136,9 @@ pub(crate) fn shape_text<'a, B: Brush>(
     }
 
     // Iterate over characters in the text
-    for ((char_index, ch), (info, style_index)) in text.chars().enumerate().zip(infos) {
+    for ((char_index, (byte_index, ch)), (info, style_index)) in
+        text.char_indices().enumerate().zip(infos)
+    {
         let mut break_run = false;
         let mut script = info.script();
         if !real_script(script) {
@@ -167,9 +169,9 @@ pub(crate) fn shape_text<'a, B: Brush>(
         //   - We do this *before* processing the text run because we need to know whether we should
         //     break the run due to the presence of an inline box.
         while let Some((box_idx, inline_box)) = current_box {
-            // println!("{} {}", char_index, inline_box.index);
+            // println!("{} {}", byte_index, inline_box.index);
 
-            if inline_box.index == char_index {
+            if inline_box.index == byte_index {
                 break_run = true;
                 deferred_boxes.push(box_idx);
                 // Update the current box to the next box


### PR DESCRIPTION
This PR includes https://github.com/linebender/parley/pull/296, since they both touch the selection-drawing code.

There were a couple issues preventing text cursor positioning and selection from working on lines with inline boxes:
- `Cluster::from_point` and `Cluster::from_byte_index` were setting the `run_index` in their cluster paths to the index of the nth line item *that is a run*. It should be set to the nth line item, regardless of whether the previous items are inline boxes.
- `Cluster::from_point` and `Selection::geometry_with` were ignoring inline boxes when accumulating the lines' advance widths.

It's not perfect yet. Cursor affinity should take inline boxes into account, but since we could have multiple inline boxes in a row, or inline boxes next to soft line breaks, the cursor affinity will need to be an index and not just an upstream/downstream state (how do other APIs handle this?) That's a much bigger undertaking for a later time.

There was also a discrepancy between the documentation for inline boxes and the implementation--`InlineBox::index` is documented as the byte index to insert the box at, whereas the shaping code treated it as a character index. I've changed the shaping code to treat it as a byte index, but I could change the documentation instead.