### PR TITLE
Make BreakReason public

### DIFF
--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -23,10 +23,7 @@ use alignment::unjustify;
 #[cfg(feature = "accesskit")]
 use alloc::vec::Vec;
 use core::{cmp::Ordering, ops::Range};
-use data::{
-    BreakReason, ClusterData, LayoutData, LayoutItem, LayoutItemKind, LineData, LineItemData,
-    RunData,
-};
+use data::{ClusterData, LayoutData, LayoutItem, LayoutItemKind, LineData, LineItemData, RunData};
 #[cfg(feature = "accesskit")]
 use hashbrown::{HashMap, HashSet};
 use swash::text::cluster::{Boundary, ClusterInfo};
@@ -35,6 +32,7 @@ use swash::{GlyphId, NormalizedCoord, Synthesis};
 pub use alignment::AlignmentOptions;
 pub use cluster::{Affinity, ClusterPath, ClusterSide};
 pub use cursor::{Cursor, Selection};
+pub use data::BreakReason;
 pub use line::greedy::BreakLines;
 pub use line::{GlyphRun, LineMetrics, PositionedInlineBox, PositionedLayoutItem};
 pub use run::RunMetrics;

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -84,7 +84,6 @@
 #![allow(missing_docs, reason = "We have many as-yet undocumented items.")]
 #![expect(
     missing_debug_implementations,
-    unnameable_types,
     clippy::allow_attributes_without_reason,
     clippy::cast_possible_truncation,
     clippy::missing_assert_message,


### PR DESCRIPTION
The `break_reason` accessor was public, but `BreakReason` was not, so nothing could be done with the accessor.