### PR TITLE
Add cursor tests for RTL text followed by newline

### DIFF
--- a/parley/src/tests/test_cursor.rs
+++ b/parley/src/tests/test_cursor.rs
@@ -29,3 +29,35 @@ fn cursor_next_visual() {
 
     layout.assert_cursor_is_after("ipsum d", cursor);
 }
+
+// Currently fails
+#[ignore]
+#[test]
+fn cursor_rtl_newline_by_character() {
+    let (mut lcx, mut fcx) = (LayoutContext::new(), FontContext::new());
+    let text = "abcאבג\nde";
+    let layout = CursorTest::single_line(text, &mut lcx, &mut fcx);
+
+    let mut cursor: Cursor = layout.cursor_after("אבג");
+    layout.print_cursor(cursor);
+    cursor = cursor.previous_visual(layout.layout());
+
+    layout.assert_cursor_is_after("abcא", cursor);
+    cursor = cursor.previous_visual(layout.layout());
+    cursor = cursor.previous_visual(layout.layout());
+    layout.assert_cursor_is_after("abc", cursor);
+}
+
+// Currently goes into an infinite loop
+#[ignore]
+#[test]
+fn cursor_rtl_newline_by_word() {
+    let (mut lcx, mut fcx) = (LayoutContext::new(), FontContext::new());
+    let text = "abcאבג\nde";
+    let layout = CursorTest::single_line(text, &mut lcx, &mut fcx);
+
+    let mut cursor: Cursor = layout.cursor_after("אבג");
+    layout.print_cursor(cursor);
+    cursor = cursor.previous_visual_word(layout.layout());
+    layout.assert_cursor_is_after("abc", cursor);
+}


### PR DESCRIPTION
As requested in https://github.com/linebender/parley/issues/298.

It turns out to be a bit worse than I originally thought--when I used ctrl+left arrow in the vello_editor example, it just put me back at the start of the word. But when I call `previous_visual_word` here, it actually hangs and loops infinitely!

I'm not confident that the assertions for the expected behavior are correct--the assertion helpers seem to be a bit weird. As such, anyone fixing this should not necessarily expect the tests to pass once they've done so.