### PR TITLE
Change `register_fonts` to take a `Blob`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This release has an [MSRV] of 1.85.
 
 #### Parley
 
-- Breaking change: `Collection::register_fonts` now takes a `Blob<u8>` instead of a `Vec<u8>` ([#306][] by [@valadaptive])
+- Breaking change: `Collection::register_fonts` now takes a `Blob<u8>` instead of a `Vec<u8>` ([#306][] by [@valadaptive][])
 
 ### Internals
 
@@ -149,6 +149,7 @@ This release has an [MSRV] of 1.70.
 [@nicoburns]: https://github.com/nicoburns
 [@spirali]: https://github.com/spirali
 [@tomcur]: https://github.com/tomcur
+[@valadaptive]: https://github.com/valadaptive
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 [@wfdewith]: https://github.com/wfdewith
 [@xorgy]: https://github.com/xorgy
@@ -202,6 +203,7 @@ This release has an [MSRV] of 1.70.
 [#268]: https://github.com/linebender/parley/pull/268
 [#271]: https://github.com/linebender/parley/pull/271
 [#280]: https://github.com/linebender/parley/pull/280
+[#306]: https://github.com/linebender/parley/pull/306
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/linebender/parley/releases/tag/v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ You can find its changes [documented below](#030---2025-02-27).
 
 This release has an [MSRV] of 1.85.
 
+### Changed
+
+#### Parley
+
+- Breaking change: `Collection::register_fonts` now takes a `Blob<u8>` instead of a `Vec<u8>` ([#306][] by [@valadaptive])
+
 ### Internals
 
 Switched to edition 2024.

--- a/parley/src/tests/utils/env.rs
+++ b/parley/src/tests/utils/env.rs
@@ -6,10 +6,11 @@ use crate::{
     FontContext, FontFamily, FontStack, Layout, LayoutContext, PlainEditor, PlainEditorDriver,
     RangedBuilder, Rect, StyleProperty, TextStyle, TreeBuilder,
 };
-use fontique::{Collection, CollectionOptions};
+use fontique::{Blob, Collection, CollectionOptions};
 use std::{
     borrow::Cow,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 use tiny_skia::{Color, Pixmap};
 
@@ -102,7 +103,7 @@ pub(crate) fn load_fonts(
                 continue;
             }
             let font_data = std::fs::read(&path)?;
-            collection.register_fonts(font_data);
+            collection.register_fonts(Blob::new(Arc::new(font_data)));
         }
     }
     Ok(())


### PR DESCRIPTION
As mentioned in https://github.com/linebender/parley/issues/101. This is nice because it lets us pass in static (or potentially static) font data that would otherwise take up twice the memory (one embedded in the executable, and one cloned from it).