### PR TITLE
Switch back to MSRV 1.82 & 2021 edition.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,
   # plus all the README.md files of the affected packages.
-  RUST_MIN_VER: "1.85"
+  RUST_MIN_VER: "1.82"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
   RUST_MIN_VER_PKGS: "-p parley -p fontique"

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,3 @@
+style_edition = "2024"
 use_field_init_shorthand = true
 newline_style = "Unix"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,13 @@ You can find its changes [documented below](#030---2025-02-27).
 
 ## [Unreleased]
 
-This release has an [MSRV] of 1.85.
+This release has an [MSRV] of 1.82.
 
 ### Changed
 
 #### Parley
 
 - Breaking change: `Collection::register_fonts` now takes a `Blob<u8>` instead of a `Vec<u8>` ([#306][] by [@valadaptive][])
-
-### Internals
-
-Switched to edition 2024.
 
 ## [0.3.0] - 2025-02-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ members = [
 ]
 
 [workspace.package]
-edition = "2024"
+edition = "2021"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
-rust-version = "1.85"
+rust-version = "1.82"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/parley"
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Besides what the other libraries do, this involves things like determining a gly
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Parley has been verified to compile with **Rust 1.85** and later.
+This version of Parley has been verified to compile with **Rust 1.82** and later.
 
 Future versions of Parley might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/fontique/README.md
+++ b/fontique/README.md
@@ -16,7 +16,7 @@ Fontique provides font enumeration and fallback.
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Fontique has been verified to compile with **Rust 1.85** and later.
+This version of Fontique has been verified to compile with **Rust 1.82** and later.
 
 Future versions of Fontique might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/fontique/src/collection/mod.rs
+++ b/fontique/src/collection/mod.rs
@@ -85,7 +85,7 @@ impl Collection {
     ///
     /// If `fontique` was compiled with the `"system"` feature, then it will
     /// include system fonts after the registered fonts.
-    pub fn family_names(&mut self) -> impl Iterator<Item = &str> + Clone {
+    pub fn family_names(&mut self) -> impl Iterator<Item = &str> + '_ + Clone {
         self.inner.family_names()
     }
 
@@ -114,7 +114,7 @@ impl Collection {
     pub fn generic_families(
         &mut self,
         family: GenericFamily,
-    ) -> impl Iterator<Item = FamilyId> + Clone {
+    ) -> impl Iterator<Item = FamilyId> + '_ + Clone {
         self.inner.generic_families(family)
     }
 
@@ -142,7 +142,7 @@ impl Collection {
     pub fn fallback_families(
         &mut self,
         key: impl Into<FallbackKey>,
-    ) -> impl Iterator<Item = FamilyId> + Clone {
+    ) -> impl Iterator<Item = FamilyId> + '_ + Clone {
         self.inner.fallback_families(key)
     }
 
@@ -214,7 +214,7 @@ impl Inner {
     /// Returns an iterator over all available family names in the collection.
     ///
     /// This includes both system and registered fonts.
-    pub fn family_names(&mut self) -> impl Iterator<Item = &str> + Clone {
+    pub fn family_names(&mut self) -> impl Iterator<Item = &str> + '_ + Clone {
         self.sync_shared();
         FamilyNames {
             ours: self.data.family_names.iter(),
@@ -286,7 +286,7 @@ impl Inner {
     pub fn generic_families(
         &mut self,
         family: GenericFamily,
-    ) -> impl Iterator<Item = FamilyId> + Clone {
+    ) -> impl Iterator<Item = FamilyId> + '_ + Clone {
         self.sync_shared();
         GenericFamilies {
             ours: self.data.generic_families.get(family).iter().copied(),
@@ -349,7 +349,7 @@ impl Inner {
     pub fn fallback_families(
         &mut self,
         key: impl Into<FallbackKey>,
-    ) -> impl Iterator<Item = FamilyId> + Clone {
+    ) -> impl Iterator<Item = FamilyId> + '_ + Clone {
         let selector = key.into();
         let script = selector.script();
         let lang_key = selector.locale();

--- a/parley/README.md
+++ b/parley/README.md
@@ -17,7 +17,7 @@ It is backed by [Swash](https://github.com/dfrg/swash).
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Parley has been verified to compile with **Rust 1.85** and later.
+This version of Parley has been verified to compile with **Rust 1.82** and later.
 
 Future versions of Parley might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -157,7 +157,7 @@ impl<'a, B: Brush> Cluster<'a, B> {
     }
 
     /// Returns an iterator over the glyphs in the cluster.
-    pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + Clone + use<'a, B> {
+    pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + 'a + Clone {
         if self.data.glyph_len == 0xFF {
             GlyphIter::Single(Some(Glyph {
                 id: self.data.glyph_offset,

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -51,7 +51,7 @@ pub struct SplitString<'source>([&'source str; 2]);
 
 impl<'source> SplitString<'source> {
     /// Get the characters of this string.
-    pub fn chars(self) -> impl Iterator<Item = char> + use<'source> {
+    pub fn chars(self) -> impl Iterator<Item = char> + 'source {
         self.into_iter().flat_map(str::chars)
     }
 }

--- a/parley/src/layout/line/mod.rs
+++ b/parley/src/layout/line/mod.rs
@@ -64,7 +64,7 @@ impl<'a, B: Brush> Line<'a, B> {
 
     /// Returns an iterator over the runs for the line.
     // TODO: provide iterator over inline_boxes and items
-    pub fn runs(&self) -> impl Iterator<Item = Run<'a, B>> + Clone {
+    pub fn runs(&self) -> impl Iterator<Item = Run<'a, B>> + 'a + Clone {
         let copy = self.clone();
         let line_items = &copy.layout.data.line_items[self.data.item_range.clone()];
         line_items
@@ -81,7 +81,7 @@ impl<'a, B: Brush> Line<'a, B> {
     }
 
     /// Returns an iterator over the glyph runs for the line.
-    pub fn items(&self) -> impl Iterator<Item = PositionedLayoutItem<'a, B>> + Clone {
+    pub fn items(&self) -> impl Iterator<Item = PositionedLayoutItem<'a, B>> + 'a + Clone {
         GlyphRunIter {
             line: self.clone(),
             item_index: 0,
@@ -186,7 +186,7 @@ impl<'a, B: Brush> GlyphRun<'a, B> {
     }
 
     /// Returns an iterator over the glyphs in the run.
-    pub fn glyphs(&'a self) -> impl Iterator<Item = Glyph> + Clone {
+    pub fn glyphs(&'a self) -> impl Iterator<Item = Glyph> + 'a + Clone {
         self.run
             .visual_clusters()
             .flat_map(|cluster| cluster.glyphs())
@@ -195,7 +195,7 @@ impl<'a, B: Brush> GlyphRun<'a, B> {
     }
 
     /// Returns an iterator over the fully positioned glyphs in the run.
-    pub fn positioned_glyphs(&'a self) -> impl Iterator<Item = Glyph> + Clone {
+    pub fn positioned_glyphs(&'a self) -> impl Iterator<Item = Glyph> + 'a + Clone {
         let mut offset = self.offset;
         let baseline = self.baseline;
         self.glyphs().map(move |mut g| {

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -150,7 +150,7 @@ impl<B: Brush> Layout<B> {
     }
 
     /// Returns an iterator over the lines in the layout.
-    pub fn lines(&self) -> impl Iterator<Item = Line<'_, B>> + Clone {
+    pub fn lines(&self) -> impl Iterator<Item = Line<'_, B>> + '_ + Clone {
         self.data
             .lines
             .iter()

--- a/parley/src/layout/run.rs
+++ b/parley/src/layout/run.rs
@@ -112,7 +112,7 @@ impl<'a, B: Brush> Run<'a, B> {
     }
 
     /// Returns an iterator over the clusters in logical order.
-    pub fn clusters(&'a self) -> impl Iterator<Item = Cluster<'a, B>> + Clone {
+    pub fn clusters(&'a self) -> impl Iterator<Item = Cluster<'a, B>> + 'a + Clone {
         let range = self.cluster_range();
         Clusters {
             run: self,

--- a/parley/src/style/font.rs
+++ b/parley/src/style/font.rs
@@ -74,7 +74,7 @@ impl<'a> FontFamily<'a> {
     ///
     /// assert_eq!(parsed_families, families);
     /// ```
-    pub fn parse_list(s: &'a str) -> impl Iterator<Item = FontFamily<'a>> + Clone {
+    pub fn parse_list(s: &'a str) -> impl Iterator<Item = FontFamily<'a>> + 'a + Clone {
         ParseList {
             source: s.as_bytes(),
             len: s.len(),


### PR DESCRIPTION
We keep the Rust Style Edition 2024, so the formatting changes previously done remain.

This reverts parts of commit 7e4aa0bab95369a62f0e1001b5f0fbc907f5599e.

This is in response to some feedback from potential community users who were concerned about an aggressive MSRV.