### PR TITLE
Add APIs for overriding fonts' metadata at registration time and unregistering fonts

### DIFF
--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -55,7 +55,7 @@ pub use attributes::{Attributes, FontStyle, FontWeight, FontWidth};
 pub use collection::{Collection, CollectionOptions, Query, QueryFamily, QueryFont, QueryStatus};
 pub use fallback::FallbackKey;
 pub use family::{FamilyId, FamilyInfo};
-pub use font::{AxisInfo, FontInfo, Synthesis};
+pub use font::{AxisInfo, FontInfo, FontInfoOverride, Synthesis};
 pub use generic::GenericFamily;
 pub use script::Script;
 pub use source::{SourceId, SourceInfo, SourceKind};

--- a/parley/src/tests/utils/env.rs
+++ b/parley/src/tests/utils/env.rs
@@ -103,7 +103,7 @@ pub(crate) fn load_fonts(
                 continue;
             }
             let font_data = std::fs::read(&path)?;
-            collection.register_fonts(Blob::new(Arc::new(font_data)));
+            collection.register_fonts(Blob::new(Arc::new(font_data)), None);
         }
     }
     Ok(())


### PR DESCRIPTION
Resolves https://github.com/linebender/parley/issues/117, implementing the APIs requested there.

The first API added is `Collection::clear`, which resets the list of registered fonts and associated data (custom generic families and fallbacks, etc).

The second API addition is a helper struct which can be passed as a parameter to `Collection::register_fonts`, which allows the caller to override the font's family name and other metadata. I originally thought about passing a callback which could be called once per font in the provided data, but I think that's overkill and makes the most common use case a lot more cumbersome.

This is necessary for the egui work, since egui lets users specify the names of registered fonts.