### PR TITLE
Implement word-break and overflow-wrap style properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,14 @@ This release has an [MSRV] of 1.82.
 #### Parley
 
 - `PlainEditor::selection_geometry_with`, the equivalent of `Selection::geometry_with` method
+- The `WordBreak` and `OverflowWrap` style properties for controlling line wrapping, ([#315][] by [@valadaptive][])
 
 ### Changed
 
 #### Fontique
 
 - Breaking change: `Collection::register_fonts` now takes a `Blob<u8>` instead of a `Vec<u8>` ([#306][] by [@valadaptive][])
-- Breaking change: `Collection::register_fonts` now takes an optional second parameter which allows overriding the metadata 
+- Breaking change: `Collection::register_fonts` now takes an optional second parameter which allows overriding the metadata
   used for matching the font ([#312][] by [@valadaptive][])
 
 #### Parley
@@ -227,6 +228,7 @@ This release has an [MSRV] of 1.70.
 [#300]: https://github.com/linebender/parley/pull/300
 [#306]: https://github.com/linebender/parley/pull/306
 [#312]: https://github.com/linebender/parley/pull/312
+[#315]: https://github.com/linebender/parley/pull/315
 [#318]: https://github.com/linebender/parley/pull/318
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.3.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This release has an [MSRV] of 1.82.
 #### Parley
 
 - `PlainEditor::selection_geometry_with`, the equivalent of `Selection::geometry_with` method
-- The `WordBreak` and `OverflowWrap` style properties for controlling line wrapping, ([#315][] by [@valadaptive][])
+- The `WordBreak` and `OverflowWrap` style properties for controlling line wrapping. ([#315][] by [@valadaptive][])
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,9 +2447,8 @@ checksum = "ce5d813d71d82c4cbc1742135004e4a79fd870214c155443451c139c9470a0aa"
 
 [[package]]
 name = "swash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e25b48fd1c222c9fdb61148e2203b750f9840c07922fd61b87c6015560b8f6"
+version = "0.2.1"
+source = "git+https://github.com/valadaptive/swash?branch=word-break-setting#83d62ccf09a115001ebca3bd92cbc077f2274c98"
 dependencies = [
  "core_maths",
  "skrifa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,7 +2448,7 @@ checksum = "ce5d813d71d82c4cbc1742135004e4a79fd870214c155443451c139c9470a0aa"
 [[package]]
 name = "swash"
 version = "0.2.1"
-source = "git+https://github.com/valadaptive/swash?branch=word-break-setting#83d62ccf09a115001ebca3bd92cbc077f2274c98"
+source = "git+https://github.com/valadaptive/swash?branch=word-break-setting#1c0431d44e5dfcc52a3469df3cf82cc73c9dce05"
 dependencies = [
  "core_maths",
  "skrifa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,8 +2447,9 @@ checksum = "ce5d813d71d82c4cbc1742135004e4a79fd870214c155443451c139c9470a0aa"
 
 [[package]]
 name = "swash"
-version = "0.2.1"
-source = "git+https://github.com/valadaptive/swash?branch=word-break-setting#1c0431d44e5dfcc52a3469df3cf82cc73c9dce05"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fae9a562c7b46107d9c78cd78b75bbe1e991c16734c0aee8ff0ee711fb8b620a"
 dependencies = [
  "core_maths",
  "skrifa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,4 +74,4 @@ parley = { version = "0.3.0", default-features = false, path = "parley" }
 peniko = { version = "0.3.1", default-features = false }
 skrifa = { version = "0.26.6", default-features = false }
 read-fonts = { version = "0.25.3", default-features = false }
-swash = { version = "0.2.0", default-features = false }
+swash = { git = "https://github.com/valadaptive/swash", branch = "word-break-setting", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,4 +74,4 @@ parley = { version = "0.3.0", default-features = false, path = "parley" }
 peniko = { version = "0.3.1", default-features = false }
 skrifa = { version = "0.26.6", default-features = false }
 read-fonts = { version = "0.25.3", default-features = false }
-swash = { git = "https://github.com/valadaptive/swash", branch = "word-break-setting", default-features = false }
+swash = { version = "0.2.2", default-features = false }

--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -121,8 +121,6 @@ impl<B: Brush> TreeBuilder<'_, B> {
         // Apply TreeStyleBuilder styles to LayoutContext
         let text = self.lcx.tree_style_builder.finish(&mut self.lcx.styles);
 
-        self.lcx.analyze_text(&text);
-
         // Call generic layout builder method
         build_into_layout(layout, self.scale, &text, self.lcx, self.fcx);
 
@@ -143,6 +141,8 @@ fn build_into_layout<B: Brush>(
     lcx: &mut LayoutContext<B>,
     fcx: &mut FontContext,
 ) {
+    lcx.analyze_text(text);
+
     layout.data.clear();
     layout.data.scale = scale;
     layout.data.has_bidi = !lcx.bidi.levels().is_empty();

--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -120,7 +120,7 @@ impl<B: Brush> LayoutContext<B> {
                 }
                 style_idx += 1;
             }
-            a.set_break_strength(word_break.as_swash());
+            a.set_break_strength(word_break);
 
             let Some((properties, boundary)) = a.next() else {
                 break;

--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -107,9 +107,7 @@ impl<B: Brush> LayoutContext<B> {
 
         let mut char_indices = text.char_indices();
         loop {
-            let (Some((properties, boundary)), Some((char_idx, _))) =
-                (a.next(), char_indices.next())
-            else {
+            let Some((char_idx, _)) = char_indices.next() else {
                 break;
             };
 
@@ -122,8 +120,12 @@ impl<B: Brush> LayoutContext<B> {
                 }
                 style_idx += 1;
             }
-            // Set the word break strength for the *next* character, which seems to be what Chrome does.
             a.set_break_strength(word_break.as_swash());
+
+            let Some((properties, boundary)) = a.next() else {
+                break;
+            };
+
             self.info.push((CharInfo::new(properties, boundary), 0));
         }
         if a.needs_bidi_resolution() {

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -1,11 +1,11 @@
 // Copyright 2021 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::Font;
 use crate::inline_box::InlineBox;
 use crate::layout::{ContentWidths, Glyph, LineMetrics, RunMetrics, Style};
 use crate::style::Brush;
 use crate::util::nearly_zero;
+use crate::{Font, OverflowWrap};
 use core::cell::OnceCell;
 use core::ops::Range;
 use swash::Synthesis;
@@ -522,7 +522,10 @@ impl<B: Brush> LayoutData<B> {
                     }
                     for cluster in clusters {
                         let boundary = cluster.info.boundary();
-                        if matches!(boundary, Boundary::Line | Boundary::Mandatory) {
+                        let style = &self.styles[cluster.style_index as usize];
+                        if matches!(boundary, Boundary::Line | Boundary::Mandatory)
+                            || style.overflow_wrap == OverflowWrap::Anywhere
+                        {
                             let trailing_whitespace = whitespace_advance(prev_cluster);
                             min_width = min_width.max(running_min_width - trailing_whitespace);
                             running_min_width = 0.0;

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -16,7 +16,7 @@ pub mod editor;
 use self::alignment::align;
 
 use super::style::Brush;
-use crate::{Font, InlineBox};
+use crate::{Font, InlineBox, OverflowWrap};
 #[cfg(feature = "accesskit")]
 use accesskit::{Node, NodeId, Role, TextDirection, TreeUpdate};
 use alignment::unjustify;
@@ -300,6 +300,8 @@ pub struct Style<B: Brush> {
     pub strikethrough: Option<Decoration<B>>,
     /// Absolute line height in layout units (style line height * font size)
     pub(crate) line_height: f32,
+    /// Per-cluster overflow-wrap setting
+    pub(crate) overflow_wrap: OverflowWrap,
 }
 
 /// Underline or strikethrough decoration.

--- a/parley/src/resolve/mod.rs
+++ b/parley/src/resolve/mod.rs
@@ -17,7 +17,7 @@ use super::style::{
 use crate::font::FontContext;
 use crate::style::TextStyle;
 use crate::util::nearly_eq;
-use crate::{OverflowWrap, WordBreak, layout};
+use crate::{OverflowWrap, WordBreakStrength, layout};
 use core::borrow::Borrow;
 use core::ops::Range;
 use fontique::FamilyId;
@@ -371,7 +371,7 @@ pub(crate) enum ResolvedProperty<B: Brush> {
     /// Extra spacing between letters.
     LetterSpacing(f32),
     /// Control over where words can wrap.
-    WordBreak(WordBreak),
+    WordBreak(WordBreakStrength),
     /// Control over "emergency" line-breaking.
     OverflowWrap(OverflowWrap),
 }
@@ -408,7 +408,7 @@ pub(crate) struct ResolvedStyle<B: Brush> {
     /// Extra spacing between letters.
     pub(crate) letter_spacing: f32,
     /// Control over where words can wrap.
-    pub(crate) word_break: WordBreak,
+    pub(crate) word_break: WordBreakStrength,
     /// Control over "emergency" line-breaking.
     pub(crate) overflow_wrap: OverflowWrap,
 }

--- a/parley/src/resolve/mod.rs
+++ b/parley/src/resolve/mod.rs
@@ -15,9 +15,9 @@ use super::style::{
     FontWidth, StyleProperty,
 };
 use crate::font::FontContext;
-use crate::layout;
 use crate::style::TextStyle;
 use crate::util::nearly_eq;
+use crate::{OverflowWrap, WordBreak, layout};
 use core::borrow::Borrow;
 use core::ops::Range;
 use fontique::FamilyId;
@@ -155,6 +155,8 @@ impl ResolveContext {
             StyleProperty::LineHeight(value) => LineHeight(*value),
             StyleProperty::WordSpacing(value) => WordSpacing(*value * scale),
             StyleProperty::LetterSpacing(value) => LetterSpacing(*value * scale),
+            StyleProperty::WordBreak(value) => WordBreak(*value),
+            StyleProperty::OverflowWrap(value) => OverflowWrap(*value),
         }
     }
 
@@ -189,6 +191,8 @@ impl ResolveContext {
             line_height: raw_style.line_height,
             word_spacing: raw_style.word_spacing * scale,
             letter_spacing: raw_style.letter_spacing * scale,
+            word_break: raw_style.word_break,
+            overflow_wrap: raw_style.overflow_wrap,
         }
     }
 
@@ -366,6 +370,10 @@ pub(crate) enum ResolvedProperty<B: Brush> {
     WordSpacing(f32),
     /// Extra spacing between letters.
     LetterSpacing(f32),
+    /// Control over where words can wrap.
+    WordBreak(WordBreak),
+    /// Control over "emergency" line-breaking.
+    OverflowWrap(OverflowWrap),
 }
 
 /// Flattened group of style properties.
@@ -399,6 +407,10 @@ pub(crate) struct ResolvedStyle<B: Brush> {
     pub(crate) word_spacing: f32,
     /// Extra spacing between letters.
     pub(crate) letter_spacing: f32,
+    /// Control over where words can wrap.
+    pub(crate) word_break: WordBreak,
+    /// Control over "emergency" line-breaking.
+    pub(crate) overflow_wrap: OverflowWrap,
 }
 
 impl<B: Brush> Default for ResolvedStyle<B> {
@@ -418,6 +430,8 @@ impl<B: Brush> Default for ResolvedStyle<B> {
             line_height: 1.,
             word_spacing: 0.,
             letter_spacing: 0.,
+            word_break: Default::default(),
+            overflow_wrap: Default::default(),
         }
     }
 }
@@ -447,6 +461,8 @@ impl<B: Brush> ResolvedStyle<B> {
             LineHeight(value) => self.line_height = value,
             WordSpacing(value) => self.word_spacing = value,
             LetterSpacing(value) => self.letter_spacing = value,
+            WordBreak(value) => self.word_break = value,
+            OverflowWrap(value) => self.overflow_wrap = value,
         }
     }
 
@@ -473,6 +489,8 @@ impl<B: Brush> ResolvedStyle<B> {
             LineHeight(value) => nearly_eq(self.line_height, *value),
             WordSpacing(value) => nearly_eq(self.word_spacing, *value),
             LetterSpacing(value) => nearly_eq(self.letter_spacing, *value),
+            WordBreak(value) => self.word_break == *value,
+            OverflowWrap(value) => self.overflow_wrap == *value,
         }
     }
 
@@ -482,6 +500,7 @@ impl<B: Brush> ResolvedStyle<B> {
             underline: self.underline.as_layout_decoration(&self.brush),
             strikethrough: self.strikethrough.as_layout_decoration(&self.brush),
             line_height: self.line_height * self.font_size,
+            overflow_wrap: self.overflow_wrap,
         }
     }
 }

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -15,36 +15,12 @@ pub use font::{
     FontWidth, GenericFamily,
 };
 pub use styleset::StyleSet;
+pub use swash::text::WordBreakStrength;
 
 #[derive(Debug, Clone, Copy)]
 pub enum WhiteSpaceCollapse {
     Collapse,
     Preserve,
-}
-
-/// Control over where words can wrap.
-///
-/// See <https://drafts.csswg.org/css-text/#propdef-word-break> for more information.
-#[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
-#[repr(u8)]
-pub enum WordBreak {
-    /// Words can be broken according to their normal Unicode rules.
-    #[default]
-    Normal,
-    /// Breaking is allowed within words. This does not affect breaking around punctuation.
-    BreakAll,
-    /// Breaking is forbidden within words.
-    KeepAll,
-}
-
-impl WordBreak {
-    pub(crate) fn as_swash(&self) -> swash::text::WordBreakStrength {
-        match self {
-            Self::Normal => swash::text::WordBreakStrength::Normal,
-            Self::BreakAll => swash::text::WordBreakStrength::BreakAll,
-            Self::KeepAll => swash::text::WordBreakStrength::KeepAll,
-        }
-    }
 }
 
 /// Control over "emergency" line-breaking.
@@ -53,7 +29,8 @@ impl WordBreak {
 #[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
 #[repr(u8)]
 pub enum OverflowWrap {
-    /// Even with extremely long words, lines can only break at places specified in [`WordBreak`].
+    /// Even with extremely long words, lines can only break at places specified in
+    /// [`WordBreakStrength`].
     #[default]
     Normal,
     /// Words may be broken at an arbitrary point if there are no other places in the line to break
@@ -108,7 +85,7 @@ pub enum StyleProperty<'a, B: Brush> {
     /// Extra spacing between letters.
     LetterSpacing(f32),
     /// Control over where words can wrap.
-    WordBreak(WordBreak),
+    WordBreak(WordBreakStrength),
     /// Control over "emergency" line-breaking.
     OverflowWrap(OverflowWrap),
 }
@@ -157,7 +134,7 @@ pub struct TextStyle<'a, B: Brush> {
     /// Extra spacing between letters.
     pub letter_spacing: f32,
     /// Control over where words can wrap.
-    pub word_break: WordBreak,
+    pub word_break: WordBreakStrength,
     /// Control over "emergency" line-breaking.
     pub overflow_wrap: OverflowWrap,
 }

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -22,6 +22,48 @@ pub enum WhiteSpaceCollapse {
     Preserve,
 }
 
+/// Control over where words can wrap.
+///
+/// See <https://drafts.csswg.org/css-text/#propdef-word-break> for more information.
+#[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
+#[repr(u8)]
+pub enum WordBreak {
+    /// Words can be broken according to their normal Unicode rules.
+    #[default]
+    Normal,
+    /// Breaking is allowed within words. This does not affect breaking around punctuation.
+    BreakAll,
+    /// Breaking is forbidden within words.
+    KeepAll,
+}
+
+impl WordBreak {
+    pub(crate) fn as_swash(&self) -> swash::text::WordBreakStrength {
+        match self {
+            Self::Normal => swash::text::WordBreakStrength::Normal,
+            Self::BreakAll => swash::text::WordBreakStrength::BreakAll,
+            Self::KeepAll => swash::text::WordBreakStrength::KeepAll,
+        }
+    }
+}
+
+/// Control over "emergency" line-breaking.
+///
+/// See <https://drafts.csswg.org/css-text/#overflow-wrap-property> for more information.
+#[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
+#[repr(u8)]
+pub enum OverflowWrap {
+    /// Even with extremely long words, lines can only break at places specified in [`WordBreak`].
+    #[default]
+    Normal,
+    /// Words may be broken at an arbitrary point if there are no other places in the line to break
+    /// them.
+    Anywhere,
+    /// Like [`OverflowWrap::Anywhere`], except arbitrary wrapping opportunities are not considered
+    /// when calculating the minimum content width (see [`crate::Layout::min_content_width`]).
+    BreakWord,
+}
+
 /// Properties that define a style.
 #[derive(Clone, PartialEq, Debug)]
 pub enum StyleProperty<'a, B: Brush> {
@@ -65,6 +107,10 @@ pub enum StyleProperty<'a, B: Brush> {
     WordSpacing(f32),
     /// Extra spacing between letters.
     LetterSpacing(f32),
+    /// Control over where words can wrap.
+    WordBreak(WordBreak),
+    /// Control over "emergency" line-breaking.
+    OverflowWrap(OverflowWrap),
 }
 
 /// Unresolved styles.
@@ -110,6 +156,10 @@ pub struct TextStyle<'a, B: Brush> {
     pub word_spacing: f32,
     /// Extra spacing between letters.
     pub letter_spacing: f32,
+    /// Control over where words can wrap.
+    pub word_break: WordBreak,
+    /// Control over "emergency" line-breaking.
+    pub overflow_wrap: OverflowWrap,
 }
 
 impl<B: Brush> Default for TextStyle<'_, B> {
@@ -135,6 +185,8 @@ impl<B: Brush> Default for TextStyle<'_, B> {
             line_height: 1.2,
             word_spacing: Default::default(),
             letter_spacing: Default::default(),
+            word_break: Default::default(),
+            overflow_wrap: Default::default(),
         }
     }
 }

--- a/parley/src/tests/mod.rs
+++ b/parley/src/tests/mod.rs
@@ -4,4 +4,5 @@
 mod test_basic;
 mod test_cursor;
 mod test_editor;
+mod test_wrap;
 mod utils;

--- a/parley/src/tests/test_wrap.rs
+++ b/parley/src/tests/test_wrap.rs
@@ -1,0 +1,236 @@
+// Copyright 2025 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::{Alignment, AlignmentOptions, OverflowWrap, StyleProperty, WordBreak, testenv};
+
+use super::utils::{ColorBrush, TestEnv};
+
+fn test_wrap(
+    env: &mut TestEnv,
+    pattern: Option<&str>,
+    wrap_property: StyleProperty<'_, ColorBrush>,
+    color: ColorBrush,
+    wrap_width: f32,
+) {
+    let text = "Most words are short. But Antidisestablishmentarianism is long and needs to wrap.";
+    let mut builder = env.ranged_builder(text);
+    builder.push_default(StyleProperty::Brush(ColorBrush::new(255, 0, 0, 255)));
+
+    if let Some(pattern) = pattern {
+        let start = text.find(pattern).unwrap();
+        let range = start..start + pattern.len();
+        builder.push(StyleProperty::Brush(color), range.clone());
+        builder.push(StyleProperty::Underline(true), range.clone());
+        builder.push(wrap_property, range.clone());
+    }
+
+    let mut layout = builder.build(text);
+    layout.break_all_lines(Some(wrap_width));
+    layout.align(None, Alignment::Start, AlignmentOptions::default());
+
+    env.check_layout_snapshot(&layout);
+}
+
+#[test]
+fn overflow_wrap_off() {
+    let mut env = testenv!();
+
+    test_wrap(
+        &mut env,
+        None,
+        StyleProperty::OverflowWrap(Default::default()),
+        ColorBrush::default(),
+        120.0,
+    );
+}
+
+#[test]
+fn overflow_wrap_first_half() {
+    let mut env = testenv!();
+
+    test_wrap(
+        &mut env,
+        Some("Antidis"),
+        StyleProperty::OverflowWrap(OverflowWrap::Anywhere),
+        ColorBrush::new(0, 0, 255, 255),
+        120.0,
+    );
+}
+
+#[test]
+fn overflow_wrap_second_half() {
+    let mut env = testenv!();
+
+    test_wrap(
+        &mut env,
+        Some("anism"),
+        StyleProperty::OverflowWrap(OverflowWrap::Anywhere),
+        ColorBrush::new(0, 0, 255, 255),
+        120.0,
+    );
+}
+
+#[test]
+fn overflow_wrap_during() {
+    let mut env = testenv!();
+
+    test_wrap(
+        &mut env,
+        Some("establishment"),
+        StyleProperty::OverflowWrap(OverflowWrap::Anywhere),
+        ColorBrush::new(0, 0, 255, 255),
+        120.0,
+    );
+}
+
+#[test]
+fn overflow_wrap_everywhere() {
+    let mut env = testenv!();
+
+    test_wrap(
+        &mut env,
+        Some("Most words are short. But Antidisestablishmentarianism is long and needs to wrap."),
+        StyleProperty::OverflowWrap(OverflowWrap::Anywhere),
+        ColorBrush::new(0, 0, 255, 255),
+        120.0,
+    );
+}
+
+#[test]
+fn overflow_wrap_narrow() {
+    let mut env = testenv!();
+
+    test_wrap(
+        &mut env,
+        Some("Most words are short. But Antidisestablishmentarianism is long and needs to wrap."),
+        StyleProperty::OverflowWrap(OverflowWrap::Anywhere),
+        ColorBrush::new(0, 0, 255, 255),
+        5.0,
+    );
+}
+
+#[test]
+fn overflow_wrap_anywhere_min_content_width() {
+    let mut env = testenv!();
+
+    let text = "Hello world!\nLonger line with a looooooooong word.";
+    let mut builder = env.ranged_builder(text);
+    builder.push_default(StyleProperty::OverflowWrap(OverflowWrap::Anywhere));
+
+    let mut layout = builder.build(text);
+
+    layout.break_all_lines(Some(layout.min_content_width()));
+    layout.align(None, Alignment::Start, AlignmentOptions::default());
+    env.check_layout_snapshot(&layout);
+}
+
+#[test]
+fn overflow_wrap_break_word_min_content_width() {
+    let mut env = testenv!();
+
+    let text = "Hello world!\nLonger line with a looooooooong word.";
+    let mut builder = env.ranged_builder(text);
+    builder.push_default(StyleProperty::OverflowWrap(OverflowWrap::BreakWord));
+
+    let mut layout = builder.build(text);
+
+    layout.break_all_lines(Some(layout.min_content_width()));
+    layout.align(None, Alignment::Start, AlignmentOptions::default());
+    env.check_layout_snapshot(&layout);
+}
+
+#[test]
+fn word_break_break_all_first_half() {
+    let mut env = testenv!();
+
+    test_wrap(
+        &mut env,
+        Some("Antidis"),
+        StyleProperty::WordBreak(WordBreak::BreakAll),
+        ColorBrush::new(0, 128, 0, 255),
+        120.0,
+    );
+}
+
+#[test]
+fn word_break_break_all_second_half() {
+    let mut env = testenv!();
+
+    test_wrap(
+        &mut env,
+        Some("anism"),
+        StyleProperty::WordBreak(WordBreak::BreakAll),
+        ColorBrush::new(0, 128, 0, 255),
+        120.0,
+    );
+}
+
+#[test]
+fn word_break_break_all_during() {
+    let mut env = testenv!();
+
+    test_wrap(
+        &mut env,
+        Some("establishment"),
+        StyleProperty::WordBreak(WordBreak::BreakAll),
+        ColorBrush::new(0, 128, 0, 255),
+        120.0,
+    );
+}
+
+#[test]
+fn word_break_break_all_everywhere() {
+    let mut env = testenv!();
+
+    test_wrap(
+        &mut env,
+        Some("Most words are short. But Antidisestablishmentarianism is long and needs to wrap."),
+        StyleProperty::WordBreak(WordBreak::BreakAll),
+        ColorBrush::new(0, 128, 0, 255),
+        120.0,
+    );
+}
+
+#[test]
+fn word_break_break_all_min_content_width() {
+    let mut env = testenv!();
+
+    let text = "Hello world!\nLonger line with a looooooooong word.";
+    let mut builder = env.ranged_builder(text);
+    builder.push_default(StyleProperty::WordBreak(WordBreak::BreakAll));
+
+    let mut layout = builder.build(text);
+
+    layout.break_all_lines(Some(layout.min_content_width()));
+    layout.align(None, Alignment::Start, AlignmentOptions::default());
+    // This snapshot will have slightly different line wrapping than the corresponding overflow-wrap test. This is to be
+    // expected and matches browser/CSS behavior.
+    env.check_layout_snapshot(&layout);
+}
+
+#[test]
+fn word_break_keep_all() {
+    let mut env = testenv!();
+
+    let mut test_text = |text, name, wrap_width| {
+        let mut builder = env.ranged_builder(text);
+        builder.push_default(StyleProperty::WordBreak(WordBreak::KeepAll));
+
+        let mut layout = builder.build(text);
+
+        layout.break_all_lines(Some(wrap_width));
+        layout.align(None, Alignment::Start, AlignmentOptions::default());
+        env.with_name(name).check_layout_snapshot(&layout);
+    };
+
+    test_text("Latin latin latin latin", "latin", 120.0);
+    // These will all show up as boxes because CJK fonts are quite large (several megabytes per language) and could
+    // bloat the repository. Line break analysis should work the same regardless of font, however.
+    test_text("日本語 日本語 日本語", "japanese", 60.0);
+    test_text("한글이 한글이 한글이", "korean", 60.0);
+    // TODO: we fail this test; so does Safari
+    // https://wpt.fyi/results/css/css-text/word-break/word-break-keep-all-003.html
+    // test_text("และ และและ", "thai", 65.0);
+    test_text("フォ フォ", "ID_and_CJ", 30.0);
+    test_text("애기판다 애기판다", "korean_hangul_jamos", 90.0);
+}

--- a/parley/src/tests/test_wrap.rs
+++ b/parley/src/tests/test_wrap.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::{Alignment, AlignmentOptions, OverflowWrap, StyleProperty, WordBreak, testenv};
+use crate::{Alignment, AlignmentOptions, OverflowWrap, StyleProperty, WordBreakStrength, testenv};
 
 use super::utils::{ColorBrush, TestEnv};
 
@@ -163,7 +163,7 @@ fn word_break_break_all_first_half() {
     test_wrap(
         &mut env,
         Some("Antidis"),
-        StyleProperty::WordBreak(WordBreak::BreakAll),
+        StyleProperty::WordBreak(WordBreakStrength::BreakAll),
         ColorBrush::new(0, 128, 0, 255),
         120.0,
     );
@@ -176,7 +176,7 @@ fn word_break_break_all_second_half() {
     test_wrap(
         &mut env,
         Some("anism"),
-        StyleProperty::WordBreak(WordBreak::BreakAll),
+        StyleProperty::WordBreak(WordBreakStrength::BreakAll),
         ColorBrush::new(0, 128, 0, 255),
         120.0,
     );
@@ -189,7 +189,7 @@ fn word_break_break_all_during() {
     test_wrap(
         &mut env,
         Some("establishment"),
-        StyleProperty::WordBreak(WordBreak::BreakAll),
+        StyleProperty::WordBreak(WordBreakStrength::BreakAll),
         ColorBrush::new(0, 128, 0, 255),
         120.0,
     );
@@ -202,7 +202,7 @@ fn word_break_break_all_everywhere() {
     test_wrap(
         &mut env,
         Some("Most words are short. But Antidisestablishmentarianism is long and needs to wrap."),
-        StyleProperty::WordBreak(WordBreak::BreakAll),
+        StyleProperty::WordBreak(WordBreakStrength::BreakAll),
         ColorBrush::new(0, 128, 0, 255),
         120.0,
     );
@@ -214,7 +214,7 @@ fn word_break_break_all_min_content_width() {
 
     let text = "Hello world!\nLonger line with a looooooooong word.";
     let mut builder = env.ranged_builder(text);
-    builder.push_default(StyleProperty::WordBreak(WordBreak::BreakAll));
+    builder.push_default(StyleProperty::WordBreak(WordBreakStrength::BreakAll));
 
     let mut layout = builder.build(text);
 
@@ -237,7 +237,7 @@ fn word_break_wpt007() {
         &mut env,
         "aaaaaaabbbbbbbcccccc",
         Some("bbbbbbb"),
-        StyleProperty::WordBreak(WordBreak::BreakAll),
+        StyleProperty::WordBreak(WordBreakStrength::BreakAll),
         ColorBrush::new(0, 128, 0, 255),
         55.0,
     );
@@ -249,7 +249,7 @@ fn word_break_keep_all() {
 
     let mut test_text = |text, name, wrap_width| {
         let mut builder = env.ranged_builder(text);
-        builder.push_default(StyleProperty::WordBreak(WordBreak::KeepAll));
+        builder.push_default(StyleProperty::WordBreak(WordBreakStrength::KeepAll));
 
         let mut layout = builder.build(text);
 

--- a/parley/src/tests/test_wrap.rs
+++ b/parley/src/tests/test_wrap.rs
@@ -12,7 +12,24 @@ fn test_wrap(
     color: ColorBrush,
     wrap_width: f32,
 ) {
-    let text = "Most words are short. But Antidisestablishmentarianism is long and needs to wrap.";
+    test_wrap_with_custom_text(
+        env,
+        "Most words are short. But Antidisestablishmentarianism is long and needs to wrap.",
+        pattern,
+        wrap_property,
+        color,
+        wrap_width,
+    );
+}
+
+fn test_wrap_with_custom_text(
+    env: &mut TestEnv,
+    text: &str,
+    pattern: Option<&str>,
+    wrap_property: StyleProperty<'_, ColorBrush>,
+    color: ColorBrush,
+    wrap_width: f32,
+) {
     let mut builder = env.ranged_builder(text);
     builder.push_default(StyleProperty::Brush(ColorBrush::new(255, 0, 0, 255)));
 
@@ -209,6 +226,24 @@ fn word_break_break_all_min_content_width() {
 }
 
 #[test]
+fn word_break_wpt007() {
+    // See http://wpt.live/css/css-text/word-break/word-break-break-all-inline-007.tentative.html
+    //
+    // All browsers fail this currently, but we pass it. This means that word_break_break_all_first_half doesn't match
+    // what any browsers do currently, but should be theoretically correct.
+    let mut env = testenv!();
+
+    test_wrap_with_custom_text(
+        &mut env,
+        "aaaaaaabbbbbbbcccccc",
+        Some("bbbbbbb"),
+        StyleProperty::WordBreak(WordBreak::BreakAll),
+        ColorBrush::new(0, 128, 0, 255),
+        55.0,
+    );
+}
+
+#[test]
 fn word_break_keep_all() {
     let mut env = testenv!();
 
@@ -223,6 +258,8 @@ fn word_break_keep_all() {
         env.with_name(name).check_layout_snapshot(&layout);
     };
 
+    // These are the word-break-keep-all tests from WPT:
+    // https://wpt.fyi/results/css/css-text/word-break?label=experimental&label=master&aligned
     test_text("Latin latin latin latin", "latin", 120.0);
     // These will all show up as boxes because CJK fonts are quite large (several megabytes per language) and could
     // bloat the repository. Line break analysis should work the same regardless of font, however.

--- a/parley/src/tests/test_wrap.rs
+++ b/parley/src/tests/test_wrap.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use peniko::color::palette::css;
+
 use crate::{Alignment, AlignmentOptions, OverflowWrap, StyleProperty, WordBreakStrength, testenv};
 
 use super::utils::{ColorBrush, TestEnv};
@@ -31,7 +33,7 @@ fn test_wrap_with_custom_text(
     wrap_width: f32,
 ) {
     let mut builder = env.ranged_builder(text);
-    builder.push_default(StyleProperty::Brush(ColorBrush::new(255, 0, 0, 255)));
+    builder.push_default(StyleProperty::Brush(ColorBrush::new(css::RED)));
 
     if let Some(pattern) = pattern {
         let start = text.find(pattern).unwrap();
@@ -69,7 +71,7 @@ fn overflow_wrap_first_half() {
         &mut env,
         Some("Antidis"),
         StyleProperty::OverflowWrap(OverflowWrap::Anywhere),
-        ColorBrush::new(0, 0, 255, 255),
+        ColorBrush::new(css::BLUE),
         120.0,
     );
 }
@@ -82,7 +84,7 @@ fn overflow_wrap_second_half() {
         &mut env,
         Some("anism"),
         StyleProperty::OverflowWrap(OverflowWrap::Anywhere),
-        ColorBrush::new(0, 0, 255, 255),
+        ColorBrush::new(css::BLUE),
         120.0,
     );
 }
@@ -95,7 +97,7 @@ fn overflow_wrap_during() {
         &mut env,
         Some("establishment"),
         StyleProperty::OverflowWrap(OverflowWrap::Anywhere),
-        ColorBrush::new(0, 0, 255, 255),
+        ColorBrush::new(css::BLUE),
         120.0,
     );
 }
@@ -108,7 +110,7 @@ fn overflow_wrap_everywhere() {
         &mut env,
         Some("Most words are short. But Antidisestablishmentarianism is long and needs to wrap."),
         StyleProperty::OverflowWrap(OverflowWrap::Anywhere),
-        ColorBrush::new(0, 0, 255, 255),
+        ColorBrush::new(css::BLUE),
         120.0,
     );
 }
@@ -121,7 +123,7 @@ fn overflow_wrap_narrow() {
         &mut env,
         Some("Most words are short. But Antidisestablishmentarianism is long and needs to wrap."),
         StyleProperty::OverflowWrap(OverflowWrap::Anywhere),
-        ColorBrush::new(0, 0, 255, 255),
+        ColorBrush::new(css::BLUE),
         5.0,
     );
 }
@@ -164,7 +166,7 @@ fn word_break_break_all_first_half() {
         &mut env,
         Some("Antidis"),
         StyleProperty::WordBreak(WordBreakStrength::BreakAll),
-        ColorBrush::new(0, 128, 0, 255),
+        ColorBrush::new(css::GREEN),
         120.0,
     );
 }
@@ -177,7 +179,7 @@ fn word_break_break_all_second_half() {
         &mut env,
         Some("anism"),
         StyleProperty::WordBreak(WordBreakStrength::BreakAll),
-        ColorBrush::new(0, 128, 0, 255),
+        ColorBrush::new(css::GREEN),
         120.0,
     );
 }
@@ -190,7 +192,7 @@ fn word_break_break_all_during() {
         &mut env,
         Some("establishment"),
         StyleProperty::WordBreak(WordBreakStrength::BreakAll),
-        ColorBrush::new(0, 128, 0, 255),
+        ColorBrush::new(css::GREEN),
         120.0,
     );
 }
@@ -203,7 +205,7 @@ fn word_break_break_all_everywhere() {
         &mut env,
         Some("Most words are short. But Antidisestablishmentarianism is long and needs to wrap."),
         StyleProperty::WordBreak(WordBreakStrength::BreakAll),
-        ColorBrush::new(0, 128, 0, 255),
+        ColorBrush::new(css::GREEN),
         120.0,
     );
 }
@@ -238,7 +240,7 @@ fn word_break_wpt007() {
         "aaaaaaabbbbbbbcccccc",
         Some("bbbbbbb"),
         StyleProperty::WordBreak(WordBreakStrength::BreakAll),
-        ColorBrush::new(0, 128, 0, 255),
+        ColorBrush::new(css::GREEN),
         55.0,
     );
 }

--- a/parley/src/tests/test_wrap.rs
+++ b/parley/src/tests/test_wrap.rs
@@ -264,10 +264,12 @@ fn word_break_keep_all() {
     // These will all show up as boxes because CJK fonts are quite large (several megabytes per language) and could
     // bloat the repository. Line break analysis should work the same regardless of font, however.
     test_text("日本語 日本語 日本語", "japanese", 60.0);
+    // Jamo decomposed on purpose
     test_text("한글이 한글이 한글이", "korean", 60.0);
     // TODO: we fail this test; so does Safari
     // https://wpt.fyi/results/css/css-text/word-break/word-break-keep-all-003.html
     // test_text("และ และและ", "thai", 65.0);
     test_text("フォ フォ", "ID_and_CJ", 30.0);
+    // Jamo decomposed on purpose
     test_text("애기판다 애기판다", "korean_hangul_jamos", 90.0);
 }

--- a/parley/src/tests/utils/mod.rs
+++ b/parley/src/tests/utils/mod.rs
@@ -7,3 +7,4 @@ mod renderer;
 
 pub(crate) use cursor_test::CursorTest;
 pub(crate) use env::TestEnv;
+pub(crate) use renderer::ColorBrush;

--- a/parley/src/tests/utils/renderer.rs
+++ b/parley/src/tests/utils/renderer.rs
@@ -19,7 +19,15 @@ use tiny_skia::{Color, FillRule, Paint, PathBuilder, Pixmap, PixmapMut, Rect, Tr
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct ColorBrush {
-    pub(crate) color: Color,
+    pub(super) color: Color,
+}
+
+impl ColorBrush {
+    pub(crate) fn new(r: u8, g: u8, b: u8, a: u8) -> Self {
+        Self {
+            color: Color::from_rgba8(r, g, b, a),
+        }
+    }
 }
 
 impl Default for ColorBrush {

--- a/parley/src/tests/utils/renderer.rs
+++ b/parley/src/tests/utils/renderer.rs
@@ -19,13 +19,14 @@ use tiny_skia::{Color, FillRule, Paint, PathBuilder, Pixmap, PixmapMut, Rect, Tr
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct ColorBrush {
-    pub(super) color: Color,
+    pub(crate) color: Color,
 }
 
 impl ColorBrush {
-    pub(crate) fn new(r: u8, g: u8, b: u8, a: u8) -> Self {
+    pub(crate) fn new(color: peniko::Color) -> Self {
+        let rgba8 = color.to_rgba8();
         Self {
-            color: Color::from_rgba8(r, g, b, a),
+            color: Color::from_rgba8(rgba8.r, rgba8.g, rgba8.b, rgba8.a),
         }
     }
 }

--- a/parley/tests/snapshots/overflow_wrap_anywhere_min_content_width-0.png
+++ b/parley/tests/snapshots/overflow_wrap_anywhere_min_content_width-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:705fc0e15af25999be3f82b32f1c5b1b0698e35bb939016f8bbaabb46df5d45c
+size 22105

--- a/parley/tests/snapshots/overflow_wrap_break_word_min_content_width-0.png
+++ b/parley/tests/snapshots/overflow_wrap_break_word_min_content_width-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78d25ca644650161df0aa0561ac8ac9266f1ebac4036e813ab9ab2ff647c8810
+size 12769

--- a/parley/tests/snapshots/overflow_wrap_during-0.png
+++ b/parley/tests/snapshots/overflow_wrap_during-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7169a3178d1b14bd481bb5d03c3899854cdcb6e0c5f0a318146b25af5c582977
+size 16300

--- a/parley/tests/snapshots/overflow_wrap_everywhere-0.png
+++ b/parley/tests/snapshots/overflow_wrap_everywhere-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:299a3f56c865f23bc7f52423cd53836c02f2e3e2b9501f0da447075ebb92e1ba
+size 16310

--- a/parley/tests/snapshots/overflow_wrap_first_half-0.png
+++ b/parley/tests/snapshots/overflow_wrap_first_half-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58fa47ed618a508dc6e635949a0127cfaa89a844a62cfea73ef063633f7f0904
+size 16327

--- a/parley/tests/snapshots/overflow_wrap_narrow-0.png
+++ b/parley/tests/snapshots/overflow_wrap_narrow-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06d6c77532aa5d45c1ae840275bc10c9a06ba57df0d941a18c22eb8977b1d85d
+size 34383

--- a/parley/tests/snapshots/overflow_wrap_off-0.png
+++ b/parley/tests/snapshots/overflow_wrap_off-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e92dfbcc4fd0ceafd235c532e1ec74325f550f5abf44c947c424335771055839
+size 16171

--- a/parley/tests/snapshots/overflow_wrap_second_half-0.png
+++ b/parley/tests/snapshots/overflow_wrap_second_half-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:160dd2e58db3f83f0a32666c578cf56a2654e87d97b5b8d5858b0b637e00c7e2
+size 16616

--- a/parley/tests/snapshots/word_break_break_all_during-0.png
+++ b/parley/tests/snapshots/word_break_break_all_during-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6771d5760c3aab4b8905321b56b6308c48ee54e7066b17400263c090ab809612
+size 17135

--- a/parley/tests/snapshots/word_break_break_all_everywhere-0.png
+++ b/parley/tests/snapshots/word_break_break_all_everywhere-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed2d3ef26e685bb417268b0973e6152b6ee945fb3aa8a4da502f2db399384224
+size 20381

--- a/parley/tests/snapshots/word_break_break_all_first_half-0.png
+++ b/parley/tests/snapshots/word_break_break_all_first_half-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:997a5de3d89823e89d37b1e23254e0ab5ec89c5440c75745cea38f385c956907
-size 17131
+oid sha256:842d32ac4b21b565e576ea4c2e45670651239d17120e6d46cac71df1f515e0de
+size 16381

--- a/parley/tests/snapshots/word_break_break_all_first_half-0.png
+++ b/parley/tests/snapshots/word_break_break_all_first_half-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:997a5de3d89823e89d37b1e23254e0ab5ec89c5440c75745cea38f385c956907
+size 17131

--- a/parley/tests/snapshots/word_break_break_all_min_content_width-0.png
+++ b/parley/tests/snapshots/word_break_break_all_min_content_width-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3639a38ec77a3334a61e5b3381729ee87bb2c499f011cdadce9eff8d0b807c3
+size 20500

--- a/parley/tests/snapshots/word_break_break_all_second_half-0.png
+++ b/parley/tests/snapshots/word_break_break_all_second_half-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4da47b4ed9b1e6f2c4755e1a525e5a527e28ccb2daf9316511ff96f1e1d0cd1f
+size 16359

--- a/parley/tests/snapshots/word_break_break_all_second_half-0.png
+++ b/parley/tests/snapshots/word_break_break_all_second_half-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4da47b4ed9b1e6f2c4755e1a525e5a527e28ccb2daf9316511ff96f1e1d0cd1f
-size 16359
+oid sha256:11c76fee8fec918fa495d646a4f91cb440c9071277da749caf7616be45965cc7
+size 17001

--- a/parley/tests/snapshots/word_break_keep_all-ID_and_CJ.png
+++ b/parley/tests/snapshots/word_break_keep_all-ID_and_CJ.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef0e54caac94ec5119c10cbf737d2bdeae959d556bee7f041c55d4f817ccb203
+size 2295

--- a/parley/tests/snapshots/word_break_keep_all-japanese.png
+++ b/parley/tests/snapshots/word_break_keep_all-japanese.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62126a81b13f30e3178b12d18a07a69f54a822f4df63d8e4803924d0891972b9
+size 4094

--- a/parley/tests/snapshots/word_break_keep_all-korean.png
+++ b/parley/tests/snapshots/word_break_keep_all-korean.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62126a81b13f30e3178b12d18a07a69f54a822f4df63d8e4803924d0891972b9
+size 4094

--- a/parley/tests/snapshots/word_break_keep_all-korean_hangul_jamos.png
+++ b/parley/tests/snapshots/word_break_keep_all-korean_hangul_jamos.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1986951b2139a34843dd160ebbd79e07cbec61607b040f7ccfc5f623b6283f75
+size 7062

--- a/parley/tests/snapshots/word_break_keep_all-latin.png
+++ b/parley/tests/snapshots/word_break_keep_all-latin.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c814b7c709370f0fc33b29f27b425c70d30300d0aeff80e20a58a8c32fd9e093
+size 5467

--- a/parley/tests/snapshots/word_break_wpt007-0.png
+++ b/parley/tests/snapshots/word_break_wpt007-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49a9289816ec6421d8a4ae3cfe47d3b8a21359d7be7d05ad0f45938a90b2674d
+size 6381


### PR DESCRIPTION
Requires upstream support in Swash (https://github.com/dfrg/swash/pull/89).

This implements the CSS `word-break` and `overflow-wrap` style properties (including the latter's influence on the layout's min-content size).

This replaces the "emergency break" logic with something that should be simpler.

Different browsers seem to disagree on exactly which ranges of text the properties apply to. The behavior implemented here should be reasonable.

In the table below, red is the default wrapping settings, blue is `overflow-wrap: anywhere`, and green is `word-break: break-all`:

| Gecko | Blink | WebKit | Parley |
| - | - | - | - |
![image](https://github.com/user-attachments/assets/044339f7-2685-42c7-bd83-a20ef48ad9a6) | ![image](https://github.com/user-attachments/assets/3d5613cd-0393-471e-97f5-590ecaffb7c4) | ![image](https://github.com/user-attachments/assets/31102883-0081-4788-a5f0-b13413434d1d) | ![image](https://github.com/user-attachments/assets/a8f68cb7-579f-442a-a60f-37aacc794b42)
![image](https://github.com/user-attachments/assets/355be2fd-8c12-466a-ac10-c87a7ed76e3c) | ![image](https://github.com/user-attachments/assets/0c28b246-6048-43e5-9b93-861e38a21e62) | ![image](https://github.com/user-attachments/assets/661f362c-ecff-47d4-894e-c1508b9ddd0f) | ![image](https://github.com/user-attachments/assets/fac5d47f-ba24-4611-9b80-6c39528d34bf)
![image](https://github.com/user-attachments/assets/1a8921cf-70ff-4b77-abc5-648f5bc95b76) | ![image](https://github.com/user-attachments/assets/f9b6b79a-fd01-4402-b3e7-ec5fe97250e7) | ![image](https://github.com/user-attachments/assets/7d5f81b1-c602-4f64-b328-0a3e429ea327) | ![image](https://github.com/user-attachments/assets/fef979e8-b55a-46ca-b074-dd7649c06316)
![image](https://github.com/user-attachments/assets/e927b6f9-a993-4085-a695-59f0a4001639)| ![image](https://github.com/user-attachments/assets/38c548ee-45a7-474f-91b4-3e95ebc36060) | ![image](https://github.com/user-attachments/assets/d052f5ac-5d08-4fe5-abf8-4831dafe974a) | ![image](https://github.com/user-attachments/assets/6e4984b0-58c7-4bb8-84b9-dbbad1414306)
![image](https://github.com/user-attachments/assets/f2b6e871-acc6-4396-ab6f-34e92eea38d2) | ![image](https://github.com/user-attachments/assets/4069c51c-4b0b-4fe6-aa45-cce26e4603be) | ![image](https://github.com/user-attachments/assets/5f4ecd2b-0adb-4ddb-b7a5-4980ec4e40d0) | ![image](https://github.com/user-attachments/assets/c2b750a7-f92e-4b67-b540-91c02c9745e2)
![image](https://github.com/user-attachments/assets/959ac5c3-bd67-4075-bb58-a35501a7b378) | ![image](https://github.com/user-attachments/assets/6b105308-dbe8-4049-9bc7-4fb10662d951) | ![image](https://github.com/user-attachments/assets/b2e9d1cf-3601-4232-8304-80123db546b7) | ![image](https://github.com/user-attachments/assets/3a717e75-7c3a-48d5-97cd-6fb27574de69) \*
![image](https://github.com/user-attachments/assets/ad92d9d1-625c-4722-9ffe-d696b7559a7e) | ![image](https://github.com/user-attachments/assets/d3bbfb25-52f1-4785-b972-104889534ece) | ![image](https://github.com/user-attachments/assets/9a16f48e-9208-4140-8f57-a224103e60fd) | ![word_break_break_all_second_half-0](https://github.com/user-attachments/assets/0b59508d-e38f-4a8d-99f3-bfa46caf9d8b)

\* *This doesn't match browsers, but the behavior is officially unspecified per https://github.com/w3c/csswg-drafts/issues/3897*