### PR TITLE
Add a `PlainEditor` function for accessing the current selection

### DIFF
--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -742,6 +742,11 @@ where
         }
     }
 
+    /// Returns the current selection.
+    pub fn selection(&self) -> &Selection {
+        &self.selection
+    }
+
     /// If the current selection is not collapsed, returns the text content of
     /// that selection.
     pub fn selected_text(&self) -> Option<&str> {


### PR DESCRIPTION
I'm pretty sure I need this in order to implement Android's `InputConnection` interface.