### PR TITLE
Add `raw_text` function to `PlainEditor`

### DIFF
--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -742,8 +742,11 @@ where
         }
     }
 
-    /// Returns the current selection.
-    pub fn selection(&self) -> &Selection {
+    /// Borrow the current selection. The indices returned by functions
+    /// such as [`Selection::text_range`] refer to the raw text buffer,
+    /// including the IME preedit region, which can be accessed via
+    /// [`PlainEditor::raw_text`].
+    pub fn raw_selection(&self) -> &Selection {
         &self.selection
     }
 

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -851,6 +851,10 @@ where
 
     /// Borrow the text content of the buffer, including the IME preedit
     /// region if any.
+    ///
+    /// Application authors should generally prefer [`text`](Self::text). That method excludes the
+    /// IME preedit contents, which are not meaningful for applications to access; the
+    /// in-progress IME content is not itself what the user intends to write.
     pub fn raw_text(&self) -> &str {
         &self.buffer
     }

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -846,6 +846,12 @@ where
         }
     }
 
+    /// Borrow the text content of the buffer, including the IME preedit
+    /// region if any.
+    pub fn raw_text(&self) -> &str {
+        &self.buffer
+    }
+
     /// Get the current `Generation` of the layout, to decide whether to draw.
     ///
     /// You should store the generation the editor was at when you last drew it, and then redraw


### PR DESCRIPTION
I'm not sure it's always a good idea to exclude the IME preedit region from the externally exposed `PlainEditor` text buffer. In any case, having access to the raw buffer will make it easier to implement `InputConnection` on Android. @DJMcNab if you'd rather wait and review that code when it's ready, to see if it suggests other changes that should be made to the `PlainEditor` API, that's fine with me; I'll go ahead and use this branch in the android-view demo/test app.