### PR TITLE
Pass the line index to the `Selection`'s geometry methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ You can find its changes [documented below](#030---2025-02-27).
 
 This release has an [MSRV] of 1.82.
 
+### Added
+
+#### Parley
+
+- `PlainEditor::selection_geometry_with`, the equivalent of `Selection::geometry_with` method
+
 ### Changed
 
 #### Fontique
@@ -25,6 +31,8 @@ This release has an [MSRV] of 1.82.
 
 #### Parley
 
+- Breaking change: `Selection::geometry`, `Selection::geometry_with`, and `PlainEditor::selection_geometry` now include
+  the line indices that the selection rectangles belong to. ([#318][] by [@valadaptive][])
 - Update to `accesskit` 0.18. ([#294][] by [@waywardmonkeys][]))
 - Display selected newlines as whitespace in the selection highlight. ([#296][] by [@valadaptive][])
 - Make `BreakReason` public. ([#300][] by [@valadaptive][])
@@ -212,6 +220,7 @@ This release has an [MSRV] of 1.70.
 [#300]: https://github.com/linebender/parley/pull/300
 [#306]: https://github.com/linebender/parley/pull/306
 [#312]: https://github.com/linebender/parley/pull/312
+[#318]: https://github.com/linebender/parley/pull/318
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/linebender/parley/releases/tag/v0.3.0

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -357,7 +357,7 @@ impl Editor {
     /// Returns drawn `Generation`.
     pub fn draw(&mut self, scene: &mut Scene) -> Generation {
         let transform = Affine::translate((INSET as f64, INSET as f64));
-        for rect in self.editor.selection_geometry().iter() {
+        self.editor.selection_geometry_with(|rect, _| {
             scene.fill(
                 Fill::NonZero,
                 transform,
@@ -365,7 +365,7 @@ impl Editor {
                 None,
                 &rect,
             );
-        }
+        });
         if self.cursor_visible {
             if let Some(cursor) = self.editor.cursor_geometry(1.5) {
                 scene.fill(Fill::NonZero, transform, palette::css::WHITE, None, &cursor);

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -760,14 +760,16 @@ where
         }
     }
 
-    /// Get rectangles representing the selected portions of text.
+    /// Get rectangles, and their corresponding line indices, representing the selected portions of
+    /// text.
     pub fn selection_geometry(&self) -> Vec<(Rect, usize)> {
         // We do not check `self.show_cursor` here, as the IME handling code collapses the
         // selection to a caret in that case.
         self.selection.geometry(&self.layout)
     }
 
-    /// Invoke a callback for each rectangle representing the selected portions of text.
+    /// Invoke a callback with each rectangle representing the selected portions of text, and the
+    /// indices of the lines to which they belong.
     pub fn selection_geometry_with(&self, f: impl FnMut(Rect, usize)) {
         // We do not check `self.show_cursor` here, as the IME handling code collapses the
         // selection to a caret in that case.

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -761,10 +761,17 @@ where
     }
 
     /// Get rectangles representing the selected portions of text.
-    pub fn selection_geometry(&self) -> Vec<Rect> {
+    pub fn selection_geometry(&self) -> Vec<(Rect, usize)> {
         // We do not check `self.show_cursor` here, as the IME handling code collapses the
         // selection to a caret in that case.
         self.selection.geometry(&self.layout)
+    }
+
+    /// Invoke a callback for each rectangle representing the selected portions of text.
+    pub fn selection_geometry_with(&self, f: impl FnMut(Rect, usize)) {
+        // We do not check `self.show_cursor` here, as the IME handling code collapses the
+        // selection to a caret in that case.
+        self.selection.geometry_with(&self.layout, f);
     }
 
     /// Get a rectangle representing the current caret cursor position.
@@ -790,7 +797,7 @@ where
 
             // Bound the entire preedit text.
             let mut area = None;
-            selection.geometry_with(&self.layout, |rect| {
+            selection.geometry_with(&self.layout, |rect, _| {
                 let area = area.get_or_insert(rect);
                 *area = area.union(rect);
             });
@@ -803,7 +810,7 @@ where
             // Bound the selected parts of the focused line only.
             let focus = self.selection.focus().geometry(&self.layout, 0.);
             let mut area = focus;
-            self.selection.geometry_with(&self.layout, |rect| {
+            self.selection.geometry_with(&self.layout, |rect, _| {
                 if rect.y0 == focus.y0 {
                     area = area.union(rect);
                 }

--- a/parley/src/tests/utils/env.rs
+++ b/parley/src/tests/utils/env.rs
@@ -294,7 +294,7 @@ impl TestEnv {
         &mut self,
         layout: &Layout<ColorBrush>,
         cursor_rect: Option<Rect>,
-        selection_rects: &[Rect],
+        selection_rects: &[(Rect, usize)],
     ) {
         let test_case_name = std::mem::take(&mut self.next_test_case_name);
         let current_img =

--- a/parley/src/tests/utils/renderer.rs
+++ b/parley/src/tests/utils/renderer.rs
@@ -55,7 +55,7 @@ pub(crate) fn render_layout(
     config: &RenderingConfig,
     layout: &Layout<ColorBrush>,
     cursor_rect: Option<crate::Rect>,
-    selection_rects: &[crate::Rect],
+    selection_rects: &[(crate::Rect, usize)],
 ) -> Pixmap {
     let padding = 20;
     let width = config
@@ -87,7 +87,7 @@ pub(crate) fn render_layout(
         config.background_color,
     );
 
-    for rect in selection_rects {
+    for (rect, _) in selection_rects {
         draw_rect(
             &mut pen,
             fpadding + rect.x0 as f32,


### PR DESCRIPTION
In order to render text with a background in a way that matches CSS, one needs to draw it a line at a time, background then selection then foreground:

![image](https://github.com/user-attachments/assets/d00e9ee5-25b2-4222-af19-25cf424002e8)

If you don't know which line a selection rectangle belongs to, you can't get the effect where each line is layered atop the one before it, since you can only draw the entire selection at once, and hence the entire background at once.

I've also added a `selection_geometry_with` function to `PlainEditor`--while updating the rest of the codebase, I noticed it was missing and could be useful (e.g. in the `vello_editor` example.