### PR TITLE
Add `is_done` method to `BreakLines`

### DIFF
--- a/parley/src/layout/line/greedy.rs
+++ b/parley/src/layout/line/greedy.rs
@@ -136,6 +136,11 @@ impl<'a, B: Brush> BreakLines<'a, B> {
         Some((line.metrics.advance, line.size()))
     }
 
+    /// Returns true if all the text has been placed into lines.
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
     /// Computes the next line in the paragraph. Returns the advance and size
     /// (width and height for horizontal layouts) of the line.
     pub fn break_next(&mut self, max_advance: f32) -> Option<(f32, f32)> {


### PR DESCRIPTION
With the text wrapping styles implemented, I can implement ellipsis truncation in egui by simply creating another layout for the ellipsis. However, to know whether to show the ellipsis, I need to know if there's any text left to wrap. It would be nice to be able to do that without having to actually break another line and then revert it.