### PR TITLE
Allow specifying absolute line height

### DIFF
--- a/examples/swash_render/src/main.rs
+++ b/examples/swash_render/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
         let root_style = TextStyle {
             brush: text_brush,
             font_stack,
-            line_height: 1.3,
+            line_height: parley::LineHeight::Relative(1.3),
             font_size: 16.0,
             ..Default::default()
         };
@@ -137,7 +137,7 @@ fn main() {
 
         // Set default font family
         builder.push_default(font_stack);
-        builder.push_default(StyleProperty::LineHeight(1.3));
+        builder.push_default(StyleProperty::LineHeight(parley::LineHeight::Relative(1.3)));
         builder.push_default(StyleProperty::FontSize(16.0));
 
         // Set the first 4 characters to bold

--- a/examples/tiny_skia_render/src/main.rs
+++ b/examples/tiny_skia_render/src/main.rs
@@ -76,7 +76,7 @@ fn main() {
 
     // Set default font family
     builder.push_default(GenericFamily::SystemUi);
-    builder.push_default(StyleProperty::LineHeight(1.3));
+    builder.push_default(StyleProperty::LineHeight(parley::LineHeight::Relative(1.3)));
     builder.push_default(StyleProperty::FontSize(16.0));
 
     // Set the first 4 characters to bold

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -43,7 +43,7 @@ impl Editor {
         editor.set_text(text);
         editor.set_scale(1.0);
         let styles = editor.edit_styles();
-        styles.insert(StyleProperty::LineHeight(1.2));
+        styles.insert(StyleProperty::LineHeight(parley::LineHeight::Relative(1.2)));
         styles.insert(GenericFamily::SystemUi.into());
         styles.insert(StyleProperty::Brush(palette::css::WHITE.into()));
         Self {

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -24,7 +24,7 @@
 //! ```rust
 //! use parley::{
 //!    Alignment, AlignmentOptions, FontContext, FontWeight, InlineBox, Layout, LayoutContext,
-//!    PositionedLayoutItem, StyleProperty,
+//!    LineHeight, PositionedLayoutItem, StyleProperty,
 //! };
 //!
 //! // Create a FontContext (font database) and LayoutContext (scratch space).
@@ -38,7 +38,7 @@
 //! let mut builder = layout_cx.ranged_builder(&mut font_cx, &TEXT, DISPLAY_SCALE);
 //!
 //! // Set default styles that apply to the entire layout
-//! builder.push_default(StyleProperty::LineHeight(1.3));
+//! builder.push_default(StyleProperty::LineHeight(LineHeight::Relative(1.3)));
 //! builder.push_default(StyleProperty::FontSize(16.0));
 //!
 //! // Set a style that applies to the first 4 characters

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -22,6 +22,14 @@ pub enum WhiteSpaceCollapse {
     Preserve,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LineHeight {
+    /// Line height specified as a multiple of the font size.
+    Relative(f32),
+    /// Line height specified in absolute units.
+    Absolute(f32),
+}
+
 /// Properties that define a style.
 #[derive(Clone, PartialEq, Debug)]
 pub enum StyleProperty<'a, B: Brush> {
@@ -59,8 +67,8 @@ pub enum StyleProperty<'a, B: Brush> {
     StrikethroughSize(Option<f32>),
     /// Brush for rendering the strikethrough decoration.
     StrikethroughBrush(Option<B>),
-    /// Line height multiplier.
-    LineHeight(f32),
+    /// Line height.
+    LineHeight(LineHeight),
     /// Extra spacing between words.
     WordSpacing(f32),
     /// Extra spacing between letters.
@@ -104,8 +112,8 @@ pub struct TextStyle<'a, B: Brush> {
     pub strikethrough_size: Option<f32>,
     /// Brush for rendering the strikethrough decoration.
     pub strikethrough_brush: Option<B>,
-    /// Line height multiplier.
-    pub line_height: f32,
+    /// Line height.
+    pub line_height: LineHeight,
     /// Extra spacing between words.
     pub word_spacing: f32,
     /// Extra spacing between letters.
@@ -132,7 +140,7 @@ impl<B: Brush> Default for TextStyle<'_, B> {
             strikethrough_offset: Default::default(),
             strikethrough_size: Default::default(),
             strikethrough_brush: Default::default(),
-            line_height: 1.2,
+            line_height: LineHeight::Relative(1.2),
             word_spacing: Default::default(),
             letter_spacing: Default::default(),
         }

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -170,3 +170,9 @@ impl<B: Brush> From<GenericFamily> for StyleProperty<'_, B> {
         StyleProperty::FontStack(f.into())
     }
 }
+
+impl<B: Brush> From<LineHeight> for StyleProperty<'_, B> {
+    fn from(value: LineHeight) -> Self {
+        Self::LineHeight(value)
+    }
+}


### PR DESCRIPTION
Resolves #320.

Not sure if it's too annoying to always have to specify whether you want the line height to be relative or absolute, but I think this is nicer than the roundtrip of absolute -> relative -> absolute that happens currently if you need to specify absolute line height.