### PR TITLE
Don't reset cursor affinity on newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This release has an [MSRV] of 1.82.
 #### Parley
 
 - Fix text editing for layouts which contain inline boxes ([#299][] by [@valadaptive][])
+- Fix cursor navigation in RTL text sometimes getting stuck within a line ([#331][] by [@valadaptive][])
 
 ## [0.3.0] - 2025-02-27
 
@@ -230,6 +231,7 @@ This release has an [MSRV] of 1.70.
 [#312]: https://github.com/linebender/parley/pull/312
 [#315]: https://github.com/linebender/parley/pull/315
 [#318]: https://github.com/linebender/parley/pull/318
+[#331]: https://github.com/linebender/parley/pull/331
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/linebender/parley/releases/tag/v0.3.0

--- a/parley/src/layout/cursor.rs
+++ b/parley/src/layout/cursor.rs
@@ -25,8 +25,10 @@ impl Cursor {
     /// Creates a new cursor from the given byte index and affinity.
     pub fn from_byte_index<B: Brush>(layout: &Layout<B>, index: usize, affinity: Affinity) -> Self {
         if let Some(cluster) = Cluster::from_byte_index(layout, index) {
-            let index = cluster.text_range().start;
-            Self { index, affinity }
+            Self {
+                index: cluster.text_range().start,
+                affinity,
+            }
         } else {
             Self {
                 index: layout.data.text_len,

--- a/parley/src/layout/cursor.rs
+++ b/parley/src/layout/cursor.rs
@@ -26,11 +26,6 @@ impl Cursor {
     pub fn from_byte_index<B: Brush>(layout: &Layout<B>, index: usize, affinity: Affinity) -> Self {
         if let Some(cluster) = Cluster::from_byte_index(layout, index) {
             let index = cluster.text_range().start;
-            let affinity = if cluster.is_line_break() == Some(BreakReason::Explicit) {
-                Affinity::Downstream
-            } else {
-                affinity
-            };
             Self { index, affinity }
         } else {
             Self {


### PR DESCRIPTION
Resolves https://github.com/linebender/parley/issues/298.

This bit of code was apparently here to ensure the cursor moved down a line when you typed a newline, but I've tested it (with both cursor affinities, and around wrapped lines) and didn't observe any change in behavior with it removed.

Since having this code here breaks RTL text navigation, and doesn't seem to do anything else, I think it can be removed now.

~~There is some weird (probably incorrect) behavior around inserting newlines within an RTL span--as far as I can tell, all of that behavior is pre-existing, and occurs with or without this code present. I'll file a new issue about that.~~ (After testing how browsers behave in this scenario, this appears to just be how it works. Bidirectional text is weird.)