### PR TITLE
Move `workspace.dependencies` section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,17 @@ rust-version = "1.82"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/parley"
 
+[workspace.dependencies]
+accesskit = "0.18"
+bytemuck = { version = "1.21.0", default-features = false }
+fontique = { version = "0.3.0", default-features = false, path = "fontique" }
+hashbrown = "0.15.2"
+parley = { version = "0.3.0", default-features = false, path = "parley" }
+peniko = { version = "0.3.1", default-features = false }
+skrifa = { version = "0.26.6", default-features = false }
+read-fonts = { version = "0.25.3", default-features = false }
+swash = { version = "0.2.2", default-features = false }
+
 [workspace.lints]
 rust.unsafe_code = "deny"
 
@@ -64,14 +75,3 @@ clippy.negative_feature_names = "warn"
 clippy.redundant_feature_names = "warn"
 clippy.wildcard_dependencies = "warn"
 # END LINEBENDER LINT SET
-
-[workspace.dependencies]
-accesskit = "0.18"
-bytemuck = { version = "1.21.0", default-features = false }
-fontique = { version = "0.3.0", default-features = false, path = "fontique" }
-hashbrown = "0.15.2"
-parley = { version = "0.3.0", default-features = false, path = "parley" }
-peniko = { version = "0.3.1", default-features = false }
-skrifa = { version = "0.26.6", default-features = false }
-read-fonts = { version = "0.25.3", default-features = false }
-swash = { version = "0.2.2", default-features = false }


### PR DESCRIPTION
Trying this out on the various repos since the lints is big and unchanging and the same across most repos, so we don't need to have it in the middle of the interesting parts.