### PR TITLE
Add editor features required for Android IME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This release has an [MSRV] of 1.82.
 
 ### Added
 
+#### Parley
+
+- Editor features required by Android IME. ([#334][] by [@mwcampbell][]
+
 ### Changed
 
 ### Fixed
@@ -261,6 +265,7 @@ This release has an [MSRV][] of 1.70.
 [#318]: https://github.com/linebender/parley/pull/318
 [#319]: https://github.com/linebender/parley/pull/319
 [#331]: https://github.com/linebender/parley/pull/331
+[#334]: https://github.com/linebender/parley/pull/334
 [#335]: https://github.com/linebender/parley/pull/335
 [#342]: https://github.com/linebender/parley/pull/342
 [#344]: https://github.com/linebender/parley/pull/344

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -1030,6 +1030,9 @@ where
     }
 
     fn update_compose_for_replaced_range(&mut self, old_range: Range<usize>, new_len: usize) {
+        if new_len == old_range.len() {
+            return;
+        }
         let Some(compose) = &mut self.compose else {
             return;
         };
@@ -1037,8 +1040,13 @@ where
             return;
         }
         if compose.start >= old_range.end {
-            let diff = new_len - old_range.len();
-            *compose = compose.start + diff..compose.end + diff;
+            if new_len > old_range.len() {
+                let diff = new_len - old_range.len();
+                *compose = compose.start + diff..compose.end + diff;
+            } else {
+                let diff = old_range.len() - new_len;
+                *compose = compose.start - diff..compose.end - diff;
+            }
             return;
         }
         if new_len < old_range.len() {

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -347,6 +347,10 @@ where
     /// Set the IME preedit composing text.
     ///
     /// This starts composing. Composing is reset by calling [`clear_compose`](Self::clear_compose).
+    /// Alternatively, the preedit text can be committed by calling [`finish_compose`](Self::finish_compose).
+    ///
+    /// The selection and preedit region can be manipulated independently while composing
+    /// is active.
     ///
     /// The preedit text replaces the current selection if this call starts composing.
     ///
@@ -400,7 +404,8 @@ where
 
     /// Stop IME composing.
     ///
-    /// This removes the IME preedit text.
+    /// This removes the IME preedit text, shows the cursor if it was hidden,
+    /// and moves the cursor to the start of the former preedit region.
     pub fn clear_compose(&mut self) {
         if let Some(preedit_range) = self.editor.compose.take() {
             self.editor.buffer.replace_range(preedit_range.clone(), "");

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -206,16 +206,23 @@ where
         self.update_layout();
         let old_anchor = old_selection.anchor();
         let old_focus = old_selection.focus();
+        // When doing the equivalent of a backspace on a collapsed selection,
+        // always use downstream affinity, as `backdelete` does.
+        let (anchor_affinity, focus_affinity) = if old_selection.is_collapsed() {
+            (Affinity::Downstream, Affinity::Downstream)
+        } else {
+            (old_anchor.affinity(), old_focus.affinity())
+        };
         self.editor.set_selection(Selection::new(
             Cursor::from_byte_index(
                 &self.editor.layout,
                 old_anchor.index() - range.len(),
-                old_anchor.affinity(),
+                anchor_affinity,
             ),
             Cursor::from_byte_index(
                 &self.editor.layout,
                 old_focus.index() - range.len(),
-                old_focus.affinity(),
+                focus_affinity,
             ),
         ));
     }

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -177,23 +177,72 @@ where
     // --- MARK: Forced relayout ---
     /// Insert at cursor, or replace selection.
     pub fn insert_or_replace_selection(&mut self, s: &str) {
-        assert!(!self.editor.is_composing());
-
         self.editor
             .replace_selection(self.font_cx, self.layout_cx, s);
     }
 
     /// Delete the selection.
     pub fn delete_selection(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.insert_or_replace_selection("");
+    }
+
+    /// Delete the specified numbers of bytes before the selection.
+    /// The selection is moved to the left by that number of bytes
+    /// but otherwise unchanged.
+    ///
+    /// The deleted range is clamped to the start of the buffer.
+    /// No-op if the start of the range is not a char boundary.
+    pub fn delete_bytes_before_selection(&mut self, len: usize) {
+        debug_assert!(len > 0);
+        let selection_range = self.editor.selection.text_range();
+        let range = selection_range.start.saturating_sub(len)..selection_range.start;
+        if range.is_empty() || !self.editor.buffer.is_char_boundary(range.start) {
+            return;
+        }
+        self.editor.buffer.replace_range(range.clone(), "");
+        self.editor
+            .update_compose_for_replaced_range(range.clone(), 0);
+        self.update_layout();
+        let old_selection = self.editor.selection;
+        let old_anchor = old_selection.anchor();
+        let old_focus = old_selection.focus();
+        self.editor.set_selection(Selection::new(
+            Cursor::from_byte_index(
+                &self.editor.layout,
+                old_anchor.index() - range.len(),
+                old_anchor.affinity(),
+            ),
+            Cursor::from_byte_index(
+                &self.editor.layout,
+                old_focus.index() - range.len(),
+                old_focus.affinity(),
+            ),
+        ));
+    }
+
+    /// Delete the specified numbers of bytes after the selection.
+    /// The selection is unchanged.
+    ///
+    /// The deleted range is clamped to the end of the buffer.
+    /// No-op if the end of the range is not a char boundary.
+    pub fn delete_bytes_after_selection(&mut self, len: usize) {
+        debug_assert!(len > 0);
+        let selection_range = self.editor.selection.text_range();
+        let range = selection_range.end
+            ..selection_range
+                .end
+                .saturating_add(len)
+                .min(self.editor.buffer.len());
+        if range.is_empty() || !self.editor.buffer.is_char_boundary(range.end) {
+            return;
+        }
+        self.editor.buffer.replace_range(range.clone(), "");
+        self.editor.update_compose_for_replaced_range(range, 0);
+        self.update_layout();
     }
 
     /// Delete the selection or the next cluster (typical ‘delete’ behavior).
     pub fn delete(&mut self) {
-        assert!(!self.editor.is_composing());
-
         if self.editor.selection.is_collapsed() {
             // Upstream cluster range
             if let Some(range) = self
@@ -205,7 +254,8 @@ where
                 .map(|cluster| cluster.text_range())
                 .and_then(|range| (!range.is_empty()).then_some(range))
             {
-                self.editor.buffer.replace_range(range, "");
+                self.editor.buffer.replace_range(range.clone(), "");
+                self.editor.update_compose_for_replaced_range(range, 0);
                 self.update_layout();
             }
         } else {
@@ -215,14 +265,13 @@ where
 
     /// Delete the selection or up to the next word boundary (typical ‘ctrl + delete’ behavior).
     pub fn delete_word(&mut self) {
-        assert!(!self.editor.is_composing());
-
         if self.editor.selection.is_collapsed() {
             let focus = self.editor.selection.focus();
             let start = focus.index();
             let end = focus.next_logical_word(&self.editor.layout).index();
             if self.editor.buffer.get(start..end).is_some() {
                 self.editor.buffer.replace_range(start..end, "");
+                self.editor.update_compose_for_replaced_range(start..end, 0);
                 self.update_layout();
                 self.editor.set_selection(
                     Cursor::from_byte_index(&self.editor.layout, start, Affinity::Downstream)
@@ -236,8 +285,6 @@ where
 
     /// Delete the selection or the previous cluster (typical ‘backspace’ behavior).
     pub fn backdelete(&mut self) {
-        assert!(!self.editor.is_composing());
-
         if self.editor.selection.is_collapsed() {
             // Upstream cluster
             if let Some(cluster) = self
@@ -265,6 +312,7 @@ where
                     start
                 };
                 self.editor.buffer.replace_range(start..end, "");
+                self.editor.update_compose_for_replaced_range(start..end, 0);
                 self.update_layout();
                 self.editor.set_selection(
                     Cursor::from_byte_index(&self.editor.layout, start, Affinity::Downstream)
@@ -278,14 +326,13 @@ where
 
     /// Delete the selection or back to the previous word boundary (typical ‘ctrl + backspace’ behavior).
     pub fn backdelete_word(&mut self) {
-        assert!(!self.editor.is_composing());
-
         if self.editor.selection.is_collapsed() {
             let focus = self.editor.selection.focus();
             let end = focus.index();
             let start = focus.previous_logical_word(&self.editor.layout).index();
             if self.editor.buffer.get(start..end).is_some() {
                 self.editor.buffer.replace_range(start..end, "");
+                self.editor.update_compose_for_replaced_range(start..end, 0);
                 self.update_layout();
                 self.editor.set_selection(
                     Cursor::from_byte_index(&self.editor.layout, start, Affinity::Downstream)
@@ -301,8 +348,6 @@ where
     /// Set the IME preedit composing text.
     ///
     /// This starts composing. Composing is reset by calling [`clear_compose`](Self::clear_compose).
-    /// While composing, it is a logic error to call anything other than
-    /// [`Self::set_compose`] or [`Self::clear_compose`].
     ///
     /// The preedit text replaces the current selection if this call starts composing.
     ///
@@ -343,6 +388,17 @@ where
         ));
     }
 
+    /// Set the preedit range to a range of byte indices.
+    /// This leaves the selection and cursor unchanged.
+    ///
+    /// No-op if either index is not a char boundary.
+    pub fn set_compose_byte_range(&mut self, start: usize, end: usize) {
+        if self.editor.buffer.is_char_boundary(start) && self.editor.buffer.is_char_boundary(end) {
+            self.editor.compose = Some(start..end);
+            self.update_layout();
+        }
+    }
+
     /// Stop IME composing.
     ///
     /// This removes the IME preedit text.
@@ -357,11 +413,20 @@ where
         }
     }
 
+    /// Commit the IME preedit text, if any.
+    ///
+    /// This doesn't change the selection, but shows the cursor if
+    /// it was hidden.
+    pub fn finish_compose(&mut self) {
+        if self.editor.compose.take().is_some() {
+            self.editor.show_cursor = true;
+            self.update_layout();
+        }
+    }
+
     // --- MARK: Cursor Movement ---
     /// Move the cursor to the cluster boundary nearest this point in the layout.
     pub fn move_to_point(&mut self, x: f32, y: f32) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor
             .set_selection(Selection::from_point(&self.editor.layout, x, y));
@@ -371,8 +436,6 @@ where
     ///
     /// No-op if index is not a char boundary.
     pub fn move_to_byte(&mut self, index: usize) {
-        assert!(!self.editor.is_composing());
-
         if self.editor.buffer.is_char_boundary(index) {
             self.refresh_layout();
             self.editor
@@ -382,8 +445,6 @@ where
 
     /// Move the cursor to the start of the buffer.
     pub fn move_to_text_start(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
@@ -394,8 +455,6 @@ where
 
     /// Move the cursor to the start of the physical line.
     pub fn move_to_line_start(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.line_start(&self.editor.layout, false));
@@ -403,8 +462,6 @@ where
 
     /// Move the cursor to the end of the buffer.
     pub fn move_to_text_end(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
@@ -415,8 +472,6 @@ where
 
     /// Move the cursor to the end of the physical line.
     pub fn move_to_line_end(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.line_end(&self.editor.layout, false));
@@ -424,8 +479,6 @@ where
 
     /// Move up to the closest physical cluster boundary on the previous line, preserving the horizontal position for repeated movements.
     pub fn move_up(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(
             self.editor
@@ -436,8 +489,6 @@ where
 
     /// Move down to the closest physical cluster boundary on the next line, preserving the horizontal position for repeated movements.
     pub fn move_down(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.next_line(&self.editor.layout, false));
@@ -445,8 +496,6 @@ where
 
     /// Move to the next cluster left in visual order.
     pub fn move_left(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(
             self.editor
@@ -457,8 +506,6 @@ where
 
     /// Move to the next cluster right in visual order.
     pub fn move_right(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(
             self.editor
@@ -469,8 +516,6 @@ where
 
     /// Move to the next word boundary left.
     pub fn move_word_left(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(
             self.editor
@@ -481,8 +526,6 @@ where
 
     /// Move to the next word boundary right.
     pub fn move_word_right(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(
             self.editor
@@ -493,8 +536,6 @@ where
 
     /// Select the whole buffer.
     pub fn select_all(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(
             Selection::from_byte_index(&self.editor.layout, 0_usize, Affinity::default())
@@ -504,15 +545,11 @@ where
 
     /// Collapse selection into caret.
     pub fn collapse_selection(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.editor.set_selection(self.editor.selection.collapse());
     }
 
     /// Move the selection focus point to the start of the buffer.
     pub fn select_to_text_start(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
@@ -523,8 +560,6 @@ where
 
     /// Move the selection focus point to the start of the physical line.
     pub fn select_to_line_start(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.line_start(&self.editor.layout, true));
@@ -532,8 +567,6 @@ where
 
     /// Move the selection focus point to the end of the buffer.
     pub fn select_to_text_end(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
@@ -544,8 +577,6 @@ where
 
     /// Move the selection focus point to the end of the physical line.
     pub fn select_to_line_end(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.line_end(&self.editor.layout, true));
@@ -553,8 +584,6 @@ where
 
     /// Move the selection focus point up to the nearest cluster boundary on the previous line, preserving the horizontal position for repeated movements.
     pub fn select_up(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(
             self.editor
@@ -565,8 +594,6 @@ where
 
     /// Move the selection focus point down to the nearest cluster boundary on the next line, preserving the horizontal position for repeated movements.
     pub fn select_down(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.next_line(&self.editor.layout, true));
@@ -574,8 +601,6 @@ where
 
     /// Move the selection focus point to the next cluster left in visual order.
     pub fn select_left(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(
             self.editor
@@ -586,8 +611,6 @@ where
 
     /// Move the selection focus point to the next cluster right in visual order.
     pub fn select_right(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor
             .set_selection(self.editor.selection.next_visual(&self.editor.layout, true));
@@ -595,8 +618,6 @@ where
 
     /// Move the selection focus point to the next word boundary left.
     pub fn select_word_left(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(
             self.editor
@@ -607,8 +628,6 @@ where
 
     /// Move the selection focus point to the next word boundary right.
     pub fn select_word_right(&mut self) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor.set_selection(
             self.editor
@@ -619,8 +638,6 @@ where
 
     /// Select the word at the point.
     pub fn select_word_at_point(&mut self, x: f32, y: f32) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         self.editor
             .set_selection(Selection::word_from_point(&self.editor.layout, x, y));
@@ -628,8 +645,6 @@ where
 
     /// Select the physical line at the point.
     pub fn select_line_at_point(&mut self, x: f32, y: f32) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         let line = Selection::line_from_point(&self.editor.layout, x, y);
         self.editor.set_selection(line);
@@ -637,8 +652,6 @@ where
 
     /// Move the selection focus point to the cluster boundary closest to point.
     pub fn extend_selection_to_point(&mut self, x: f32, y: f32) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         // FIXME: This is usually the wrong way to handle selection extension for mouse moves, but not a regression.
         self.editor.set_selection(
@@ -652,8 +665,6 @@ where
     ///
     /// No-op if index is not a char boundary.
     pub fn extend_selection_to_byte(&mut self, index: usize) {
-        assert!(!self.editor.is_composing());
-
         if self.editor.buffer.is_char_boundary(index) {
             self.refresh_layout();
             self.editor
@@ -665,8 +676,6 @@ where
     ///
     /// No-op if either index is not a char boundary.
     pub fn select_byte_range(&mut self, start: usize, end: usize) {
-        assert!(!self.editor.is_composing());
-
         if self.editor.buffer.is_char_boundary(start) && self.editor.buffer.is_char_boundary(end) {
             self.refresh_layout();
             self.editor.set_selection(Selection::new(
@@ -679,8 +688,6 @@ where
     #[cfg(feature = "accesskit")]
     /// Select inside the editor based on the selection provided by accesskit.
     pub fn select_from_accesskit(&mut self, selection: &accesskit::TextSelection) {
-        assert!(!self.editor.is_composing());
-
         self.refresh_layout();
         if let Some(selection) = Selection::from_access_selection(
             selection,
@@ -881,11 +888,10 @@ where
 
     /// Replace the whole text buffer.
     pub fn set_text(&mut self, is: &str) {
-        assert!(!self.is_composing());
-
         self.buffer.clear();
         self.buffer.push_str(is);
         self.layout_dirty = true;
+        self.compose = None;
     }
 
     /// Set the width of the layout.
@@ -1018,6 +1024,27 @@ where
         }
     }
 
+    fn update_compose_for_replaced_range(&mut self, old_range: Range<usize>, new_len: usize) {
+        let Some(compose) = &mut self.compose else {
+            return;
+        };
+        if compose.end <= old_range.start {
+            return;
+        }
+        if compose.start >= old_range.end {
+            let diff = new_len - old_range.len();
+            *compose = compose.start + diff..compose.end + diff;
+            return;
+        }
+        if new_len < old_range.len() {
+            if compose.start >= (old_range.start + new_len) {
+                self.compose = None;
+                return;
+            }
+            compose.end = compose.end.min(old_range.start + new_len);
+        }
+    }
+
     fn replace_selection(
         &mut self,
         font_cx: &mut FontContext,
@@ -1029,8 +1056,9 @@ where
         if self.selection.is_collapsed() {
             self.buffer.insert_str(start, s);
         } else {
-            self.buffer.replace_range(range, s);
+            self.buffer.replace_range(range.clone(), s);
         }
+        self.update_compose_for_replaced_range(range, s.len());
 
         self.update_layout(font_cx, layout_cx);
         let new_index = start.saturating_add(s.len());

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -194,7 +194,8 @@ where
     /// The deleted range is clamped to the start of the buffer.
     /// No-op if the start of the range is not a char boundary.
     pub fn delete_bytes_before_selection(&mut self, len: NonZeroUsize) {
-        let selection_range = self.editor.selection.text_range();
+        let old_selection = self.editor.selection;
+        let selection_range = old_selection.text_range();
         let range = selection_range.start.saturating_sub(len.get())..selection_range.start;
         if range.is_empty() || !self.editor.buffer.is_char_boundary(range.start) {
             return;
@@ -203,7 +204,6 @@ where
         self.editor
             .update_compose_for_replaced_range(range.clone(), 0);
         self.update_layout();
-        let old_selection = self.editor.selection;
         let old_anchor = old_selection.anchor();
         let old_focus = old_selection.focus();
         self.editor.set_selection(Selection::new(

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -17,6 +17,7 @@ use core::{
     cmp::PartialEq,
     default::Default,
     fmt::{Debug, Display},
+    num::NonZeroUsize,
     ops::Range,
 };
 
@@ -192,10 +193,9 @@ where
     ///
     /// The deleted range is clamped to the start of the buffer.
     /// No-op if the start of the range is not a char boundary.
-    pub fn delete_bytes_before_selection(&mut self, len: usize) {
-        debug_assert!(len > 0);
+    pub fn delete_bytes_before_selection(&mut self, len: NonZeroUsize) {
         let selection_range = self.editor.selection.text_range();
-        let range = selection_range.start.saturating_sub(len)..selection_range.start;
+        let range = selection_range.start.saturating_sub(len.get())..selection_range.start;
         if range.is_empty() || !self.editor.buffer.is_char_boundary(range.start) {
             return;
         }
@@ -225,13 +225,12 @@ where
     ///
     /// The deleted range is clamped to the end of the buffer.
     /// No-op if the end of the range is not a char boundary.
-    pub fn delete_bytes_after_selection(&mut self, len: usize) {
-        debug_assert!(len > 0);
+    pub fn delete_bytes_after_selection(&mut self, len: NonZeroUsize) {
         let selection_range = self.editor.selection.text_range();
         let range = selection_range.end
             ..selection_range
                 .end
-                .saturating_add(len)
+                .saturating_add(len.get())
                 .min(self.editor.buffer.len());
         if range.is_empty() || !self.editor.buffer.is_char_boundary(range.end) {
             return;

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -760,6 +760,12 @@ where
         &self.selection
     }
 
+    /// Borrow the current IME preedit range, if any. These indices refer
+    /// to the raw text buffer, which can be accessed via [`PlainEditor::raw_text`].
+    pub fn raw_compose(&self) -> &Option<Range<usize>> {
+        &self.compose
+    }
+
     /// If the current selection is not collapsed, returns the text content of
     /// that selection.
     pub fn selected_text(&self) -> Option<&str> {


### PR DESCRIPTION
* The compose region and selection can now be updated independently. Whenever text is inserted, replaced, or deleted, the editor ensures that the compose region is either still valid or cleared.
* Existing preedit text can now be committed, without touching the selection.
* Added driver methods to delete text before and after the selection, as required by `deleteSurroundingText` on Android's `InputConnection`.

I haven't yet tested these changes. My next task is to complete the `InputConnection` implementation in the android-view demo. But I figured this PR can be reviewed for logic errors anyway.