### PR TITLE
fontique: Fix panic on macOS in debug mode.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,7 @@ dependencies = [
  "icu_locid",
  "icu_properties",
  "memmap2",
+ "objc2 0.6.0",
  "objc2-core-foundation",
  "objc2-core-text",
  "objc2-foundation 0.3.0",

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -26,6 +26,7 @@ system = [
     "std",
     "dep:windows",
     "dep:windows-core",
+    "dep:objc2",
     "dep:objc2-core-foundation",
     "dep:objc2-core-text",
     "dep:objc2-foundation",
@@ -53,6 +54,10 @@ windows = { version = "0.58.0", features = [
 windows-core = { version = "0.58", optional = true }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
+# FIX: Enable relax-sign-encoding to prevent the bug described in this issue: https://github.com/madsmtm/objc2/issues/566
+objc2 = { version = "0.6.0", optional = true, features = ["std", "relax-sign-encoding"] }
+# NOTE: When updating objc2-foundation, objc2-core-foundation, or objc2-core-text make sure to use the version of objc2
+# that they reference to prevent crate duplication.
 objc2-foundation = { version = "0.3.0", optional = true, default-features = false, features = [
     "alloc",
     "NSArray",

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -61,3 +61,4 @@ pub use script::Script;
 pub use source::{SourceId, SourceInfo, SourceKind};
 
 pub use source_cache::{SourceCache, SourceCacheOptions};
+use objc2 as _;

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -61,4 +61,5 @@ pub use script::Script;
 pub use source::{SourceId, SourceInfo, SourceKind};
 
 pub use source_cache::{SourceCache, SourceCacheOptions};
+#[cfg(target_vendor = "apple")]
 use objc2 as _;

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -60,6 +60,6 @@ pub use generic::GenericFamily;
 pub use script::Script;
 pub use source::{SourceId, SourceInfo, SourceKind};
 
-pub use source_cache::{SourceCache, SourceCacheOptions};
-#[cfg(target_vendor = "apple")]
+#[cfg(all(feature = "system", target_vendor = "apple"))]
 use objc2 as _;
+pub use source_cache::{SourceCache, SourceCacheOptions};


### PR DESCRIPTION
This commit fixes a panic on macOS by enabling the "relax-sign-encoding" feature for the "objc2" crate.

Relevant issues in the objc2 crate:
https://github.com/madsmtm/objc2/issues/566
https://github.com/madsmtm/objc2/pull/567

I made sure to use version of objc2 that the current objc2-*  variations use, so that we don't duplicate the crate.
![Screenshot 2025-04-11 at 8 51 30 PM](https://github.com/user-attachments/assets/590301c3-4b08-47e6-8ac6-f81f39d8fea6)

---
Additional Info:


System Info: Mac Mini M4, 16 GB of RAM.

Before the fix, when running the vello-editor or any example:
![Screenshot 2025-04-11 at 9 12 02 PM](https://github.com/user-attachments/assets/45a98667-25a8-4da4-98e5-b5d414c0b9e3)

After the fix:
![Screenshot 2025-04-11 at 9 14 29 PM](https://github.com/user-attachments/assets/4864d4e1-5c54-47b2-bcd8-d0788fa76d07)


