### PR TITLE
Support repeated `align` calls without breaking lines again.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This release has an [MSRV] of 1.82.
 
 - Fix text editing for layouts which contain inline boxes ([#299][] by [@valadaptive][])
 - Fix cursor navigation in RTL text sometimes getting stuck within a line ([#331][] by [@valadaptive][])
+- Using `Layout::align` on an aligned layout without breaking lines again. ([#342][] by [@xStrom][])
 
 ## [0.3.0] - 2025-02-27
 
@@ -173,6 +174,7 @@ This release has an [MSRV] of 1.70.
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 [@wfdewith]: https://github.com/wfdewith
 [@xorgy]: https://github.com/xorgy
+[@xStrom]: https://github.com/xStrom
 
 [#54]: https://github.com/linebender/parley/pull/54
 [#55]: https://github.com/linebender/parley/pull/55
@@ -232,6 +234,7 @@ This release has an [MSRV] of 1.70.
 [#315]: https://github.com/linebender/parley/pull/315
 [#318]: https://github.com/linebender/parley/pull/318
 [#331]: https://github.com/linebender/parley/pull/331
+[#342]: https://github.com/linebender/parley/pull/342
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/linebender/parley/releases/tag/v0.3.0

--- a/parley/src/layout/alignment.rs
+++ b/parley/src/layout/alignment.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::style::Brush;
 
 /// Additional options to fine tune alignment
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct AlignmentOptions {
     /// If set to `true`, "end" and "center" alignment will apply even if the line contents are
     /// wider than the alignment width. If it is set to `false`, all overflowing lines will be
@@ -74,6 +74,8 @@ fn align_impl<B: Brush, const UNDO_JUSTIFICATION: bool>(
 
     // Apply alignment to line items
     for line in &mut layout.lines {
+        line.metrics.offset = 0.;
+
         if is_rtl {
             // In RTL text, trailing whitespace is on the left. As we hang that whitespace, offset
             // the line to the left.

--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -408,6 +408,7 @@ fn realign_all() {
                         let mut top_layout = layout.clone();
                         // Only break lines again if the max advance differs from base,
                         // because otherwise we already have the correct line breaks.
+                        // We want to specifically test the optimization of skipping it.
                         if max_advance != top_max_advance {
                             top_layout.break_all_lines(top_max_advance);
                         }


### PR DESCRIPTION
Xilem has an optimization where it doesn't ask Parley to redo line breaks when the result would be the same as last time. However, this revealed an issue with stacking alignment offsets in [xilem#933](https://github.com/linebender/xilem/issues/933).

The solution seems straightforward. We just reset the line offset to zero before adding the real one. This prevents repeated `align` calls from stacking the offset to infinity.

Thus most of this PR is actually a new test case that makes sure that every possible layout alignment can be converted into every other possible alignment.

Rendering 684 snapshots takes over 10 seconds on my 5950X and probably quite a bit longer on the GitHub VMs, so I wrote a simple assert function that makes sure the line offsets and cluster advances meet expectations.