### PR TITLE
Prepare to release 0.4.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ You can find its changes [documented below](#040---2025-05-08).
 
 ## [Unreleased]
 
+This release has an [MSRV] of 1.82.
+
 ### Added
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "parley"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "accesskit",
  "core_maths",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ repository = "https://github.com/linebender/parley"
 [workspace.dependencies]
 accesskit = "0.19.0"
 bytemuck = { version = "1.23.0", default-features = false }
-fontique = { version = "0.3.0", default-features = false, path = "fontique" }
+fontique = { version = "0.4.0", default-features = false, path = "fontique" }
 hashbrown = "0.15.3"
-parley = { version = "0.3.0", default-features = false, path = "parley" }
+parley = { version = "0.4.0", default-features = false, path = "parley" }
 peniko = { version = "0.4.0", default-features = false }
 skrifa = { version = "0.31.0", default-features = false }
 read-fonts = { version = "0.29.0", default-features = false }

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontique"
-version = "0.3.0" # Keep in sync with workspace dependency specification
+version = "0.4.0" # Keep in sync with workspace dependency specification
 description = "Font enumeration and fallback."
 keywords = ["font", "text"]
 categories = ["gui", "os"]

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parley"
-version = "0.3.0"
+version = "0.4.0"
 description = "Parley provides an API for implementing rich text layout."
 keywords = ["text", "layout"]
 categories = ["gui", "graphics"]


### PR DESCRIPTION
This will be merged once the [0.4.0 milestone](https://github.com/linebender/parley/milestone/8) has no other open issues left.