### PR TITLE
Don't cache min/max content widths in `Layout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ This release has an [MSRV] of 1.82.
 
 ### Changed
 
+#### Parley
+
+- Breaking change: `Layout::min_content_width`, `Layout::max_content_width`, and `Layout::content_widths` have been replaced with `Layout::calculate_content_widths`, which does not internally cache the widths. This means that `Layout` is now `Sync` again, but callers will have to cache the min and max content widths themselves. ([#353][] by [@valadaptive][])
+
 ### Fixed
 
 ## [0.4.0] - 2025-05-08
@@ -270,6 +274,7 @@ This release has an [MSRV][] of 1.70.
 [#342]: https://github.com/linebender/parley/pull/342
 [#344]: https://github.com/linebender/parley/pull/344
 [#348]: https://github.com/linebender/parley/pull/348
+[#353]: https://github.com/linebender/parley/pull/353
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/linebender/parley/releases/tag/v0.4.0

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -98,6 +98,9 @@ impl<B: Brush> Layout<B> {
 
     /// Calculates the lower and upper bounds on the width of the layout. These
     /// are recalculated every time this method is called.
+    ///
+    /// This method currently may not return the correct results for
+    /// mixed-direction text.
     pub fn calculate_content_widths(&self) -> ContentWidths {
         self.data.calculate_content_widths()
     }

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -96,21 +96,10 @@ impl<B: Brush> Layout<B> {
         self.data.full_width
     }
 
-    /// Returns the lower and upper bounds on the width of the layout.
-    pub fn content_widths(&self) -> ContentWidths {
-        self.data.content_widths()
-    }
-
-    /// Returns the minimum content width of the layout. This is the width of the layout if _all_
-    /// soft line-breaking opportunities are taken.
-    pub fn min_content_width(&self) -> f32 {
-        self.data.content_widths().min
-    }
-
-    /// Returns the maximum content width of the layout. This is the width of the layout if _no_
-    /// soft line-breaking opportunities are taken.
-    pub fn max_content_width(&self) -> f32 {
-        self.data.content_widths().max
+    /// Calculates the lower and upper bounds on the width of the layout. These
+    /// are recalculated every time this method is called.
+    pub fn calculate_content_widths(&self) -> ContentWidths {
+        self.data.calculate_content_widths()
     }
 
     /// Returns the height of the layout.

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -37,7 +37,7 @@ pub enum OverflowWrap {
     /// them.
     Anywhere,
     /// Like [`OverflowWrap::Anywhere`], except arbitrary wrapping opportunities are not considered
-    /// when calculating the minimum content width (see [`crate::Layout::min_content_width`]).
+    /// when calculating the minimum content width (see [`crate::Layout::calculate_content_widths`]).
     BreakWord,
 }
 

--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -4,7 +4,9 @@
 use peniko::kurbo::Size;
 
 use crate::data::LayoutData;
-use crate::{Alignment, AlignmentOptions, Brush, InlineBox, WhiteSpaceCollapse, test_name};
+use crate::{
+    Alignment, AlignmentOptions, Brush, ContentWidths, InlineBox, WhiteSpaceCollapse, test_name,
+};
 
 use super::utils::TestEnv;
 
@@ -241,11 +243,16 @@ fn content_widths() {
 
     let mut layout = builder.build(text);
 
-    layout.break_all_lines(Some(layout.min_content_width()));
+    let ContentWidths {
+        min: min_content_width,
+        max: max_content_width,
+    } = layout.calculate_content_widths();
+
+    layout.break_all_lines(Some(min_content_width));
     layout.align(None, Alignment::Start, AlignmentOptions::default());
     env.with_name("min").check_layout_snapshot(&layout);
 
-    layout.break_all_lines(Some(layout.max_content_width()));
+    layout.break_all_lines(Some(max_content_width));
     layout.align(None, Alignment::Start, AlignmentOptions::default());
     env.with_name("max").check_layout_snapshot(&layout);
 }
@@ -259,14 +266,19 @@ fn content_widths_rtl() {
 
     let mut layout = builder.build(text);
 
-    layout.break_all_lines(Some(layout.min_content_width()));
+    let ContentWidths {
+        min: min_content_width,
+        max: max_content_width,
+    } = layout.calculate_content_widths();
+
+    layout.break_all_lines(Some(min_content_width));
     layout.align(None, Alignment::Start, AlignmentOptions::default());
     env.with_name("min").check_layout_snapshot(&layout);
 
-    layout.break_all_lines(Some(layout.max_content_width()));
+    layout.break_all_lines(Some(max_content_width));
     layout.align(None, Alignment::Start, AlignmentOptions::default());
     assert!(
-        layout.width() <= layout.max_content_width(),
+        layout.width() <= max_content_width,
         "Layout should never be wider than the max content width"
     );
     env.with_name("max").check_layout_snapshot(&layout);
@@ -286,7 +298,11 @@ fn inbox_content_width() {
             height: 10.0,
         });
         let mut layout = builder.build(text);
-        layout.break_all_lines(Some(layout.min_content_width()));
+        let ContentWidths {
+            min: min_content_width,
+            ..
+        } = layout.calculate_content_widths();
+        layout.break_all_lines(Some(min_content_width));
         layout.align(None, Alignment::Start, AlignmentOptions::default());
 
         env.with_name("full_width").check_layout_snapshot(&layout);
@@ -302,11 +318,15 @@ fn inbox_content_width() {
             height: 10.0,
         });
         let mut layout = builder.build(text);
-        layout.break_all_lines(Some(layout.max_content_width()));
+        let ContentWidths {
+            max: max_content_width,
+            ..
+        } = layout.calculate_content_widths();
+        layout.break_all_lines(Some(max_content_width));
         layout.align(None, Alignment::Start, AlignmentOptions::default());
 
         assert!(
-            layout.width() <= layout.max_content_width(),
+            layout.width() <= max_content_width,
             "Layout should never be wider than the max content width"
         );
 

--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -5,7 +5,8 @@ use peniko::kurbo::Size;
 
 use crate::data::LayoutData;
 use crate::{
-    Alignment, AlignmentOptions, Brush, ContentWidths, InlineBox, WhiteSpaceCollapse, test_name,
+    Alignment, AlignmentOptions, Brush, ContentWidths, InlineBox, Layout, WhiteSpaceCollapse,
+    test_name,
 };
 
 use super::utils::TestEnv;
@@ -452,6 +453,12 @@ fn realign_all() {
             }
         }
     }
+}
+
+#[test]
+fn layout_impl_send_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Layout<()>>();
 }
 
 /// Assert that the two provided layouts are equal in terms of alignment metrics.

--- a/parley/src/tests/test_wrap.rs
+++ b/parley/src/tests/test_wrap.rs
@@ -140,7 +140,7 @@ fn overflow_wrap_anywhere_min_content_width() {
 
     let mut layout = builder.build(text);
 
-    layout.break_all_lines(Some(layout.min_content_width()));
+    layout.break_all_lines(Some(layout.calculate_content_widths().min));
     layout.align(None, Alignment::Start, AlignmentOptions::default());
     env.check_layout_snapshot(&layout);
 }
@@ -155,7 +155,7 @@ fn overflow_wrap_break_word_min_content_width() {
 
     let mut layout = builder.build(text);
 
-    layout.break_all_lines(Some(layout.min_content_width()));
+    layout.break_all_lines(Some(layout.calculate_content_widths().min));
     layout.align(None, Alignment::Start, AlignmentOptions::default());
     env.check_layout_snapshot(&layout);
 }
@@ -222,7 +222,7 @@ fn word_break_break_all_min_content_width() {
 
     let mut layout = builder.build(text);
 
-    layout.break_all_lines(Some(layout.min_content_width()));
+    layout.break_all_lines(Some(layout.calculate_content_widths().min));
     layout.align(None, Alignment::Start, AlignmentOptions::default());
     // This snapshot will have slightly different line wrapping than the corresponding overflow-wrap test. This is to be
     // expected and matches browser/CSS behavior.


### PR DESCRIPTION
Caching the min/max content widths of a `Layout` was previously done using a `OnceCell`. This makes the entire `Layout` struct neither `Send` nor `Sync`, and means we have to wrap it in a `Mutex` if we want those properties.

Because of the requirement to use a `Mutex`, API consumers that never use the min/max content widths (or could easily cache them themselves) but *do* need `Layout` to be `Send` or `Sync` end up paying for a feature that they never use.

There are a few different solutions here:
- Use an `Option` instead of a `OnceCell` and have the content size methods take `&mut self`
- Cache the sizes in an `AtomicU64` or `OnceLock` instead
- Don't cache the sizes at all and leave it up to the API consumer

Based on [discussion on Zulip](https://xi.zulipchat.com/#narrow/channel/205635-parley/topic/Should.20the.20.60Layout.60.20type.20return.20to.20being.20.60Sync.60.3F/near/508638378), the last option seems to be the preferred one, so that's what I've gone with here. If the caching is going to be a leaky abstraction anyway, it's probably best not to bother.

I've also added a test to ensure that `Layout` always implements `Send + Sync` going forward.