### PR TITLE
Add missing text in tree mode to `swash_render` example.

### DIFF
--- a/examples/swash_render/src/main.rs
+++ b/examples/swash_render/src/main.rs
@@ -125,6 +125,9 @@ fn main() {
         builder.push_style_modification_span(&[strikethrough_style]);
         builder.push_text(&text[155..168]);
 
+        builder.pop_style_span();
+        builder.push_text(&text[168..]);
+
         // Build the builder into a Layout
         // let mut layout: Layout<ColorBrush> = builder.build(&text);
         let (layout, _text): (Layout<ColorBrush>, String) = builder.build();


### PR DESCRIPTION
Compare the outputs of:

```sh
cargo run -p swash_render
cargo run -p swash_render -- --tree
```

This PR makes them equal.