### PR TITLE
Test that all the builders produce the same results.

### DIFF
--- a/parley/src/inline_box.rs
+++ b/parley/src/inline_box.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /// A box to be laid out inline with text
-#[derive(Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct InlineBox {
     /// User-specified identifier for the box, which can be used by the user to determine which box in
     /// parley's output corresponds to which box in its input.

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -17,7 +17,7 @@ use alloc::vec::Vec;
 #[allow(unused_imports)]
 use core_maths::CoreFloat;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) struct ClusterData {
     pub(crate) info: ClusterInfo,
     pub(crate) flags: u16,
@@ -55,7 +55,7 @@ impl ClusterData {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct RunData {
     /// Index of the font for the run.
     pub(crate) font_index: usize,
@@ -94,7 +94,7 @@ pub enum BreakReason {
     Emergency,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, PartialEq)]
 pub(crate) struct LineData {
     /// Range of the source text.
     pub(crate) text_range: Range<usize>,
@@ -104,10 +104,6 @@ pub(crate) struct LineData {
     pub(crate) metrics: LineMetrics,
     /// The cause of the line break.
     pub(crate) break_reason: BreakReason,
-    #[expect(
-        dead_code,
-        reason = "needed in the future for aligning around floated boxes"
-    )]
     /// Maximum advance for the line.
     pub(crate) max_advance: f32,
     /// Number of justified clusters on the line.
@@ -120,7 +116,7 @@ impl LineData {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct LineItemData {
     /// Whether the item is a run or an inline box
     pub(crate) kind: LayoutItemKind,
@@ -186,7 +182,7 @@ pub(crate) enum LayoutItemKind {
     InlineBox,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct LayoutItem {
     /// Whether the item is a run or an inline box
     pub(crate) kind: LayoutItemKind,
@@ -196,7 +192,7 @@ pub(crate) struct LayoutItem {
     pub(crate) bidi_level: u8,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct LayoutData<B: Brush> {
     pub(crate) scale: f32,
     pub(crate) quantize: bool,

--- a/parley/src/layout/line/mod.rs
+++ b/parley/src/layout/line/mod.rs
@@ -93,7 +93,7 @@ impl<'a, B: Brush> Line<'a, B> {
 }
 
 /// Metrics information for a line.
-#[derive(Copy, Clone, Default, Debug)]
+#[derive(Copy, Clone, Default, Debug, PartialEq)]
 pub struct LineMetrics {
     /// Typographic ascent.
     pub ascent: f32,

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -256,7 +256,7 @@ pub struct Cluster<'a, B: Brush> {
 }
 
 /// Glyph with an offset and advance.
-#[derive(Copy, Clone, Default, Debug)]
+#[derive(Copy, Clone, Default, Debug, PartialEq)]
 pub struct Glyph {
     pub id: GlyphId,
     pub style_index: u16,
@@ -280,7 +280,7 @@ pub struct Line<'a, B: Brush> {
     data: &'a LineData,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum LayoutLineHeight {
     MetricsRelative(f32),
     Absolute(f32),
@@ -299,7 +299,7 @@ impl LayoutLineHeight {
 
 #[allow(clippy::partial_pub_fields)]
 /// Style properties.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Style<B: Brush> {
     /// Brush for drawing glyphs.
     pub brush: B,
@@ -314,7 +314,7 @@ pub struct Style<B: Brush> {
 }
 
 /// Underline or strikethrough decoration.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Decoration<B: Brush> {
     /// Brush used to draw the decoration.
     pub brush: B,

--- a/parley/src/layout/run.rs
+++ b/parley/src/layout/run.rs
@@ -202,7 +202,7 @@ impl<'a, B: Brush> Iterator for Clusters<'a, B> {
 }
 
 /// Metrics information for a run.
-#[derive(Copy, Clone, Default, Debug)]
+#[derive(Copy, Clone, Default, Debug, PartialEq)]
 pub struct RunMetrics {
     /// Typographic ascent.
     pub ascent: f32,

--- a/parley/src/tests/mod.rs
+++ b/parley/src/tests/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 mod test_basic;
+mod test_builders;
 mod test_cursor;
 mod test_editor;
 mod test_lines;

--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -7,11 +7,11 @@ use peniko::{
 };
 
 use crate::{
-    Alignment, AlignmentOptions, Brush, ContentWidths, FontStack, InlineBox, Layout, LineHeight,
-    StyleProperty, TextStyle, WhiteSpaceCollapse, data::LayoutData, test_name,
+    Alignment, AlignmentOptions, ContentWidths, FontStack, InlineBox, Layout, LineHeight,
+    StyleProperty, TextStyle, WhiteSpaceCollapse, test_name,
 };
 
-use super::utils::{ColorBrush, FONT_STACK, TestEnv};
+use super::utils::{ColorBrush, FONT_STACK, TestEnv, asserts::assert_eq_layout_data_alignments};
 
 #[test]
 fn plain_multiline_text() {
@@ -497,7 +497,7 @@ fn realign_all() {
                         let top_layout_truth = &layouts[jdx];
                         jdx += 1;
 
-                        assert_eq_layout_alignments(
+                        assert_eq_layout_data_alignments(
                             &top_layout_truth.data,
                             &top_layout.data,
                             &format!("{base_name} -> {top_name}"),
@@ -513,33 +513,4 @@ fn realign_all() {
 fn layout_impl_send_sync() {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<Layout<()>>();
-}
-
-/// Assert that the two provided layouts are equal in terms of alignment metrics.
-fn assert_eq_layout_alignments<B: Brush>(a: &LayoutData<B>, b: &LayoutData<B>, case: &str) {
-    assert_eq!(
-        a.lines.len(),
-        b.lines.len(),
-        "line count mismatch with {case}"
-    );
-
-    for (line_a, line_b) in a.lines.iter().zip(b.lines.iter()) {
-        assert_eq!(
-            line_a.metrics.offset, line_b.metrics.offset,
-            "line offset mismatch with {case}"
-        );
-    }
-
-    assert_eq!(
-        a.clusters.len(),
-        b.clusters.len(),
-        "cluster count mismatch with {case}"
-    );
-
-    for (cluster_a, cluster_b) in a.clusters.iter().zip(b.clusters.iter()) {
-        assert_eq!(
-            cluster_a.advance, cluster_b.advance,
-            "cluster advance mismatch with {case}"
-        );
-    }
 }

--- a/parley/src/tests/test_builders.rs
+++ b/parley/src/tests/test_builders.rs
@@ -30,7 +30,7 @@ use crate::{
 /// LayoutContext D - Tree for dirt
 /// LayoutContext D - Ranged from dirty
 /// ```
-fn compute(
+fn assert_builders_produce_same_result(
     text: &str,
     scale: f32,
     quantize: bool,
@@ -229,7 +229,7 @@ fn builders_root_only() {
         tb.push_text(text);
     };
 
-    compute(
+    assert_builders_produce_same_result(
         text,
         scale,
         quantize,
@@ -283,7 +283,7 @@ fn builders_mixed_styles() {
         tb.push_text(&text[17..]);
     };
 
-    compute(
+    assert_builders_produce_same_result(
         text,
         scale,
         quantize,

--- a/parley/src/tests/test_builders.rs
+++ b/parley/src/tests/test_builders.rs
@@ -1,0 +1,295 @@
+// Copyright 2025 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Test that the various builders produce the same results.
+
+use std::borrow::Cow;
+
+use fontique::{FontStyle, FontWeight, FontWidth};
+use peniko::color::palette;
+use swash::text::WordBreakStrength;
+
+use super::utils::{ColorBrush, FONT_STACK, asserts::assert_eq_layout_data, create_font_context};
+use crate::{
+    FontSettings, FontStack, LayoutContext, LineHeight, OverflowWrap, RangedBuilder, StyleProperty,
+    TextStyle, TreeBuilder,
+};
+
+/// Computes layout in various ways to ensure they all produce the same result.
+///
+/// ```text
+/// LayoutContext A - Ranged
+/// LayoutContext A - Ranged for idempotency
+///
+/// LayoutContext B - Tree
+/// LayoutContext B - Tree for idempotency
+///
+/// LayoutContext C - Ranged for dirt
+/// LayoutContext C - Tree from dirty
+///
+/// LayoutContext D - Tree for dirt
+/// LayoutContext D - Ranged from dirty
+/// ```
+fn compute(
+    text: &str,
+    scale: f32,
+    quantize: bool,
+    max_advance: Option<f32>,
+    root_style: &TextStyle<'_, ColorBrush>,
+    with_ranged_builder: impl Fn(&mut RangedBuilder<'_, ColorBrush>),
+    with_tree_builder: impl Fn(&mut TreeBuilder<'_, ColorBrush>),
+) {
+    let mut fcx = create_font_context();
+
+    let mut lcx_a: LayoutContext<ColorBrush> = LayoutContext::new();
+    let mut lcx_b: LayoutContext<ColorBrush> = LayoutContext::new();
+    let mut lcx_c: LayoutContext<ColorBrush> = LayoutContext::new();
+    let mut lcx_d: LayoutContext<ColorBrush> = LayoutContext::new();
+
+    // Source of truth - ranged builder from a clean layout context
+    let mut lcx_a_rb_one = lcx_a.ranged_builder(&mut fcx, text, scale, quantize);
+    with_ranged_builder(&mut lcx_a_rb_one);
+    let mut lcx_a_rb_one_layout = lcx_a_rb_one.build(text);
+    lcx_a_rb_one_layout.break_all_lines(max_advance);
+    assert!(
+        !lcx_a_rb_one_layout.data.runs.is_empty(),
+        "expected runs to exist for lcx_a_rb_one_layout"
+    );
+
+    // Testing idempotence of ranged builder creation
+    let mut lcx_a_rb_two = lcx_a.ranged_builder(&mut fcx, text, scale, quantize);
+    with_ranged_builder(&mut lcx_a_rb_two);
+    let mut lcx_a_rb_two_layout = lcx_a_rb_two.build(text);
+    lcx_a_rb_two_layout.break_all_lines(max_advance);
+    assert!(
+        !lcx_a_rb_two_layout.data.runs.is_empty(),
+        "expected runs to exist for lcx_a_rb_two_layout"
+    );
+
+    assert_eq_layout_data(
+        &lcx_a_rb_one_layout.data,
+        &lcx_a_rb_two_layout.data,
+        "lcx_a_rb_two",
+    );
+
+    // Basic builder compatibility - tree builder from a clean layout context
+    let mut lcx_b_tb_one = lcx_b.tree_builder(&mut fcx, scale, quantize, root_style);
+    with_tree_builder(&mut lcx_b_tb_one);
+    let (mut lcx_b_tb_one_layout, _) = lcx_b_tb_one.build();
+    lcx_b_tb_one_layout.break_all_lines(max_advance);
+    assert!(
+        !lcx_b_tb_one_layout.data.runs.is_empty(),
+        "expected runs to exist for lcx_b_tb_one_layout"
+    );
+
+    assert_eq_layout_data(
+        &lcx_a_rb_one_layout.data,
+        &lcx_b_tb_one_layout.data,
+        "lcx_b_tb_one",
+    );
+
+    // Testing idempotence of tree builder creation
+    let mut lcx_b_tb_two = lcx_b.tree_builder(&mut fcx, scale, quantize, root_style);
+    with_tree_builder(&mut lcx_b_tb_two);
+    let (mut lcx_b_tb_two_layout, _) = lcx_b_tb_two.build();
+    lcx_b_tb_two_layout.break_all_lines(max_advance);
+    assert!(
+        !lcx_b_tb_two_layout.data.runs.is_empty(),
+        "expected runs to exist for lcx_b_tb_two_layout"
+    );
+
+    assert_eq_layout_data(
+        &lcx_a_rb_one_layout.data,
+        &lcx_b_tb_two_layout.data,
+        "lcx_b_tb_two",
+    );
+
+    // Priming a fresh layout context with ranged builder creation
+    let mut lcx_c_rb_one = lcx_c.ranged_builder(&mut fcx, text, scale, quantize);
+    with_ranged_builder(&mut lcx_c_rb_one);
+    let _ = lcx_c_rb_one.build(text);
+
+    // Testing tree builder creation with a dirty layout context
+    let mut lcx_c_tb_one = lcx_c.tree_builder(&mut fcx, scale, quantize, root_style);
+    with_tree_builder(&mut lcx_c_tb_one);
+    let (mut lcx_c_tb_one_layout, _) = lcx_c_tb_one.build();
+    lcx_c_tb_one_layout.break_all_lines(max_advance);
+    assert!(
+        !lcx_c_tb_one_layout.data.runs.is_empty(),
+        "expected runs to exist for lcx_c_tb_one_layout"
+    );
+
+    assert_eq_layout_data(
+        &lcx_a_rb_one_layout.data,
+        &lcx_c_tb_one_layout.data,
+        "lcx_c_tb_one",
+    );
+
+    // Priming a fresh layout context with tree builder creation
+    let mut lcx_d_tb_one = lcx_d.tree_builder(&mut fcx, scale, quantize, root_style);
+    with_tree_builder(&mut lcx_d_tb_one);
+    let _ = lcx_d_tb_one.build();
+
+    // Testing ranged builder creation with a dirty layout context
+    let mut lcx_d_rb_one = lcx_d.ranged_builder(&mut fcx, text, scale, quantize);
+    with_ranged_builder(&mut lcx_d_rb_one);
+    let mut lcx_d_rb_one_layout = lcx_d_rb_one.build(text);
+    lcx_d_rb_one_layout.break_all_lines(max_advance);
+    assert!(
+        !lcx_d_rb_one_layout.data.runs.is_empty(),
+        "expected runs to exist for lcx_d_rb_one_layout"
+    );
+
+    assert_eq_layout_data(
+        &lcx_a_rb_one_layout.data,
+        &lcx_d_rb_one_layout.data,
+        "lcx_d_rb_one",
+    );
+}
+
+/// Returns a root style that uses non-default values.
+///
+/// The [`TreeBuilder`] version of [`set_root_style`].
+fn create_root_style() -> TextStyle<'static, ColorBrush> {
+    TextStyle {
+        font_stack: FontStack::from(FONT_STACK),
+        font_size: 20.,
+        font_width: FontWidth::CONDENSED,
+        font_style: FontStyle::Italic,
+        font_weight: FontWeight::BOLD,
+        font_variations: FontSettings::List(Cow::Borrowed(&[])), // TODO: Set a non-default value
+        font_features: FontSettings::List(Cow::Borrowed(&[])),   // TODO: Set a non-default value
+        locale: Some("en-US"),
+        brush: ColorBrush::new(palette::css::GREEN),
+        has_underline: true,
+        underline_offset: Some(2.),
+        underline_size: Some(3.5),
+        underline_brush: Some(ColorBrush::new(palette::css::CYAN)),
+        has_strikethrough: true,
+        strikethrough_offset: Some(1.3),
+        strikethrough_size: Some(1.7),
+        strikethrough_brush: Some(ColorBrush::new(palette::css::BEIGE)),
+        line_height: LineHeight::Absolute(30.),
+        word_spacing: 2.,
+        letter_spacing: 1.5,
+        word_break: WordBreakStrength::BreakAll,
+        overflow_wrap: OverflowWrap::Anywhere,
+    }
+}
+
+/// Sets a root style with non-default values.
+///
+/// The [`RangedBuilder`] version of [`create_root_style`].
+fn set_root_style(rb: &mut RangedBuilder<'_, ColorBrush>) {
+    rb.push_default(FontStack::from(FONT_STACK));
+    rb.push_default(StyleProperty::FontSize(20.));
+    rb.push_default(StyleProperty::FontWidth(FontWidth::CONDENSED));
+    rb.push_default(StyleProperty::FontStyle(FontStyle::Italic));
+    rb.push_default(StyleProperty::FontWeight(FontWeight::BOLD));
+    rb.push_default(StyleProperty::FontVariations(FontSettings::List(
+        Cow::Borrowed(&[]),
+    )));
+    rb.push_default(StyleProperty::FontFeatures(FontSettings::List(
+        Cow::Borrowed(&[]),
+    )));
+    rb.push_default(StyleProperty::Locale(Some("en-US")));
+    rb.push_default(StyleProperty::Brush(ColorBrush::new(palette::css::GREEN)));
+    rb.push_default(StyleProperty::Underline(true));
+    rb.push_default(StyleProperty::UnderlineOffset(Some(2.)));
+    rb.push_default(StyleProperty::UnderlineSize(Some(3.5)));
+    rb.push_default(StyleProperty::UnderlineBrush(Some(ColorBrush::new(
+        palette::css::CYAN,
+    ))));
+    rb.push_default(StyleProperty::Strikethrough(true));
+    rb.push_default(StyleProperty::StrikethroughOffset(Some(1.3)));
+    rb.push_default(StyleProperty::StrikethroughSize(Some(1.7)));
+    rb.push_default(StyleProperty::StrikethroughBrush(Some(ColorBrush::new(
+        palette::css::BEIGE,
+    ))));
+    rb.push_default(LineHeight::Absolute(30.));
+    rb.push_default(StyleProperty::WordSpacing(2.));
+    rb.push_default(StyleProperty::LetterSpacing(1.5));
+    rb.push_default(StyleProperty::WordBreak(WordBreakStrength::BreakAll));
+    rb.push_default(StyleProperty::OverflowWrap(OverflowWrap::Anywhere));
+}
+
+/// Test that all the builders behave the same when given the same root style.
+#[test]
+fn builders_root_only() {
+    let text = "Builders often wear hard hats for safety while working on construction sites.";
+    let scale = 2.;
+    let quantize = false;
+    let max_advance = Some(50.);
+    let root_style = create_root_style();
+
+    let with_ranged_builder = |rb: &mut RangedBuilder<'_, ColorBrush>| {
+        set_root_style(rb);
+    };
+    let with_tree_builder = |tb: &mut TreeBuilder<'_, ColorBrush>| {
+        tb.push_text(text);
+    };
+
+    compute(
+        text,
+        scale,
+        quantize,
+        max_advance,
+        &root_style,
+        with_ranged_builder,
+        with_tree_builder,
+    );
+}
+
+/// Test that all the builders behave the same with mixed styles.
+#[test]
+fn builders_mixed_styles() {
+    let text = "Builders often wear hard hats for safety while working on construction sites.";
+    let scale = 2.;
+    let quantize = false;
+    let max_advance = Some(50.);
+    let root_style = create_root_style();
+
+    let with_ranged_builder = |rb: &mut RangedBuilder<'_, ColorBrush>| {
+        set_root_style(rb);
+
+        // Make the first word bigger
+        rb.push(StyleProperty::FontSize(68.), 0..8);
+        // Push two modified styles for the same range
+        rb.push(StyleProperty::LetterSpacing(4.), 12..17);
+        rb.push(StyleProperty::WordSpacing(3.), 12..17);
+        // Plus, change the line height for the last letter
+        rb.push(StyleProperty::LineHeight(LineHeight::Absolute(40.)), 16..17);
+    };
+    let with_tree_builder = |tb: &mut TreeBuilder<'_, ColorBrush>| {
+        // Make the first word bigger
+        tb.push_style_modification_span(&[StyleProperty::FontSize(68.)]);
+        tb.push_text(&text[..8]);
+        tb.pop_style_span();
+
+        tb.push_text(&text[8..12]);
+
+        // Push two modified styles in batch
+        tb.push_style_modification_span(&[
+            StyleProperty::LetterSpacing(4.),
+            StyleProperty::WordSpacing(3.),
+        ]);
+        tb.push_text(&text[12..16]);
+        // Plus, change the line height for the last letter
+        tb.push_style_modification_span(&[StyleProperty::LineHeight(LineHeight::Absolute(40.))]);
+        tb.push_text(&text[16..17]);
+        tb.pop_style_span();
+        tb.pop_style_span();
+
+        tb.push_text(&text[17..]);
+    };
+
+    compute(
+        text,
+        scale,
+        quantize,
+        max_advance,
+        &root_style,
+        with_ranged_builder,
+        with_tree_builder,
+    );
+}

--- a/parley/src/tests/utils/asserts.rs
+++ b/parley/src/tests/utils/asserts.rs
@@ -1,0 +1,84 @@
+// Copyright 2025 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Various helper functions to assert truths during testing.
+
+use crate::{Brush, data::LayoutData};
+
+/// Assert that the two provided `LayoutData` are equal.
+pub(crate) fn assert_eq_layout_data<B: Brush>(a: &LayoutData<B>, b: &LayoutData<B>, case: &str) {
+    assert_eq!(a.scale, b.scale, "{case} scale mismatch");
+    assert_eq!(a.quantize, b.quantize, "{case} quantize mismatch");
+    assert_eq!(a.has_bidi, b.has_bidi, "{case} has_bidi mismatch");
+    assert_eq!(a.base_level, b.base_level, "{case} base_level mismatch");
+    assert_eq!(a.text_len, b.text_len, "{case} text_len mismatch");
+    assert_eq!(a.width, b.width, "{case} width mismatch");
+    assert_eq!(a.full_width, b.full_width, "{case} full_width mismatch");
+    assert_eq!(a.height, b.height, "{case} height mismatch");
+    assert_eq!(a.fonts, b.fonts, "{case} fonts mismatch");
+    assert_eq!(a.coords, b.coords, "{case} coords mismatch");
+
+    // Input (/ output of style resolution)
+    assert_eq!(a.styles, b.styles, "{case} styles mismatch");
+    assert_eq!(
+        a.inline_boxes, b.inline_boxes,
+        "{case} inline_boxes mismatch"
+    );
+
+    // Output of shaping
+    assert_eq!(a.runs, b.runs, "{case} runs mismatch");
+    assert_eq!(a.items, b.items, "{case} items mismatch");
+    assert_eq!(a.clusters, b.clusters, "{case} clusters mismatch");
+    assert_eq!(a.glyphs, b.glyphs, "{case} glyphs mismatch");
+
+    // Output of line breaking
+    assert_eq!(a.lines, b.lines, "{case} lines mismatch");
+    assert_eq!(a.line_items, b.line_items, "{case} line_items mismatch");
+
+    // Output of alignment
+    assert_eq!(
+        a.is_aligned_justified, b.is_aligned_justified,
+        "{case} is_aligned_justified mismatch"
+    );
+    assert_eq!(
+        a.alignment_width, b.alignment_width,
+        "{case} alignment_width mismatch"
+    );
+
+    // Also compare the whole struct in case any fields have been added that aren't
+    // part of this test yet. If this triggers, add the missing assert to the above set.
+    assert_eq!(a, b, "{case} LayoutData mismatch");
+}
+
+/// Assert that the two provided `LayoutData` are equal in terms of alignment metrics.
+pub(crate) fn assert_eq_layout_data_alignments<B: Brush>(
+    a: &LayoutData<B>,
+    b: &LayoutData<B>,
+    case: &str,
+) {
+    assert_eq!(
+        a.lines.len(),
+        b.lines.len(),
+        "line count mismatch with {case}"
+    );
+
+    for (line_a, line_b) in a.lines.iter().zip(b.lines.iter()) {
+        assert_eq!(
+            line_a.metrics.offset, line_b.metrics.offset,
+            "line offset mismatch with {case}"
+        );
+    }
+
+    assert_eq!(
+        a.clusters.len(),
+        b.clusters.len(),
+        "cluster count mismatch with {case}"
+    );
+
+    for (cluster_a, cluster_b) in a.clusters.iter().zip(b.clusters.iter()) {
+        assert_eq!(
+            cluster_a.advance, cluster_b.advance,
+            "cluster advance mismatch with {case}"
+        );
+    }
+}

--- a/parley/src/tests/utils/mod.rs
+++ b/parley/src/tests/utils/mod.rs
@@ -1,10 +1,11 @@
 // Copyright 2024 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+pub(crate) mod asserts;
 mod cursor_test;
 mod env;
 mod renderer;
 
 pub(crate) use cursor_test::CursorTest;
-pub(crate) use env::{FONT_STACK, TestEnv};
+pub(crate) use env::{FONT_STACK, TestEnv, create_font_context};
 pub(crate) use renderer::ColorBrush;


### PR DESCRIPTION
This will help ensure that the builders won't diverge in behavior as we continue modifying them. It also tests the reusability of `LayoutContext`.

There are known cases where the builders do currently diverge. For example:
* Using only default styles.
  Would be good to have it catch the builders disagreeing on default font size or missing scale multipliers. While adding this test is trivial within the framework of this PR, unfortunately the solution isn't super trivial. So I will add the default style test along with the code fix in a separate PR.
* When adding a span with the same style as the currently active span.
  For example see #365.
  However, this gets into questions about supporting things like margin/padding on spans and how exactly the common core span API should look like.

I wanted to keep this PR here limited to the cases that don't require any builder modification. So that we can at least start protecting the partial commonality that the builders have. This will also mean that the follow-up PRs that do change builder code won't be burdened by the noise of adding a bunch of this testing framework code.
