### PR TITLE
Use the same default style for both builders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,14 @@ This release has an [MSRV] of 1.82.
 
 ### Fixed
 
-#### Fontique
-
-- Font family name aliases (secondary names for font families, often in another language) not being registered. ([#380][] by [@valadaptive][])
-
 #### Parley
 
 - Selection extension moves the focus to the side being extended. ([#385][] by [@kekelp][])
+- Ranged builder default style not respecting `scale`. ([#368][] by [@xStrom][])
+
+#### Fontique
+
+- Font family name aliases (secondary names for font families, often in another language) not being registered. ([#380][] by [@valadaptive][])
 
 ## [0.5.0] - 2025-06-01
 
@@ -308,6 +309,7 @@ This release has an [MSRV][] of 1.70.
 [#348]: https://github.com/linebender/parley/pull/348
 [#353]: https://github.com/linebender/parley/pull/353
 [#362]: https://github.com/linebender/parley/pull/362
+[#368]: https://github.com/linebender/parley/pull/368
 [#369]: https://github.com/linebender/parley/pull/369
 [#378]: https://github.com/linebender/parley/pull/378
 [#380]: https://github.com/linebender/parley/pull/380

--- a/examples/swash_render/src/main.rs
+++ b/examples/swash_render/src/main.rs
@@ -133,7 +133,7 @@ fn main() {
         let (layout, _text): (Layout<ColorBrush>, String) = builder.build();
         layout
     } else {
-        // RANGE BUILDER
+        // RANGED BUILDER
         // ============
 
         // Creates a RangedBuilder

--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -87,7 +87,10 @@ impl<B: Brush> LayoutContext<B> {
         quantize: bool,
     ) -> RangedBuilder<'a, B> {
         self.begin();
-        self.ranged_style_builder.begin(text.len());
+
+        let resolved_root_style = self.resolve_style_set(fcx, scale, &TextStyle::default());
+        self.ranged_style_builder
+            .begin(resolved_root_style, text.len());
 
         fcx.source_cache.prune(128, false);
 
@@ -123,11 +126,11 @@ impl<B: Brush> LayoutContext<B> {
         fcx: &'a mut FontContext,
         scale: f32,
         quantize: bool,
-        raw_style: &TextStyle<'_, B>,
+        root_style: &TextStyle<'_, B>,
     ) -> TreeBuilder<'a, B> {
         self.begin();
 
-        let resolved_root_style = self.resolve_style_set(fcx, scale, raw_style);
+        let resolved_root_style = self.resolve_style_set(fcx, scale, root_style);
         self.tree_style_builder.begin(resolved_root_style);
 
         fcx.source_cache.prune(128, false);

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -9,7 +9,6 @@ use crate::{
         Affinity, Alignment, AlignmentOptions, Layout,
         cursor::{Cursor, Selection},
     },
-    resolve::ResolvedStyle,
     style::Brush,
 };
 use alloc::{borrow::ToOwned, string::String, vec::Vec};
@@ -114,6 +113,7 @@ where
     /// Whether the cursor should be shown. The IME can request to hide the cursor.
     show_cursor: bool,
     width: Option<f32>,
+    font_size: f32,
     scale: f32,
     quantize: bool,
     // Simple tracking of when the layout needs to be updated
@@ -146,6 +146,7 @@ where
             compose: None,
             show_cursor: true,
             width: None,
+            font_size,
             scale: 1.0,
             quantize: true,
             layout_dirty: true,
@@ -925,7 +926,7 @@ where
         let font_size = downstream
             .or(upstream)
             .map(|cluster| cluster.run().font_size())
-            .unwrap_or(ResolvedStyle::<T>::default().font_size);
+            .unwrap_or(self.font_size * self.scale);
         // Using 0.6 as an estimate of the average advance
         let inflate = 3. * 0.6 * font_size as f64;
         let editor_width = self.width.map(f64::from).unwrap_or(f64::INFINITY);

--- a/parley/src/resolve/mod.rs
+++ b/parley/src/resolve/mod.rs
@@ -377,7 +377,7 @@ pub(crate) enum ResolvedProperty<B: Brush> {
 }
 
 /// Flattened group of style properties.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Default)]
 pub(crate) struct ResolvedStyle<B: Brush> {
     /// Font stack.
     pub(crate) font_stack: Resolved<FamilyId>,
@@ -411,29 +411,6 @@ pub(crate) struct ResolvedStyle<B: Brush> {
     pub(crate) word_break: WordBreakStrength,
     /// Control over "emergency" line-breaking.
     pub(crate) overflow_wrap: OverflowWrap,
-}
-
-impl<B: Brush> Default for ResolvedStyle<B> {
-    fn default() -> Self {
-        Self {
-            font_stack: Resolved::default(),
-            font_size: 16.,
-            font_width: Default::default(),
-            font_style: Default::default(),
-            font_weight: Default::default(),
-            font_variations: Default::default(),
-            font_features: Default::default(),
-            locale: None,
-            brush: Default::default(),
-            underline: Default::default(),
-            strikethrough: Default::default(),
-            line_height: Default::default(),
-            word_spacing: 0.,
-            letter_spacing: 0.,
-            word_break: Default::default(),
-            overflow_wrap: Default::default(),
-        }
-    }
 }
 
 impl<B: Brush> ResolvedStyle<B> {

--- a/parley/src/resolve/tree.rs
+++ b/parley/src/resolve/tree.rs
@@ -57,7 +57,9 @@ impl<B: Brush> Default for TreeStyleBuilder<B> {
 }
 
 impl<B: Brush> TreeStyleBuilder<B> {
-    /// Prepares the builder for accepting a style tree for text of the specified length.
+    /// Prepares the builder for accepting a tree of styles and text.
+    ///
+    /// The provided `root_style` is the default style applied to all text unless overridden.
     pub(crate) fn begin(&mut self, root_style: ResolvedStyle<B>) {
         self.tree.clear();
         self.flatted_styles.clear();

--- a/parley/src/tests/test_builders.rs
+++ b/parley/src/tests/test_builders.rs
@@ -223,6 +223,36 @@ fn set_root_style(rb: &mut RangedBuilder<'_, ColorBrush>) {
     rb.push_default(StyleProperty::OverflowWrap(OverflowWrap::Anywhere));
 }
 
+/// Test that all the builders have the same default behavior.
+#[test]
+fn builders_default() {
+    let text = "Builders often wear hard hats for safety while working on construction sites.";
+    let scale = 2.;
+    let quantize = false;
+    let max_advance = Some(50.);
+    let root_style = TextStyle {
+        font_stack: FontStack::from(FONT_STACK),
+        ..TextStyle::default()
+    };
+
+    let with_ranged_builder = |rb: &mut RangedBuilder<'_, ColorBrush>| {
+        rb.push_default(FontStack::from(FONT_STACK));
+    };
+    let with_tree_builder = |tb: &mut TreeBuilder<'_, ColorBrush>| {
+        tb.push_text(text);
+    };
+
+    assert_builders_produce_same_result(
+        text,
+        scale,
+        quantize,
+        max_advance,
+        &root_style,
+        with_ranged_builder,
+        with_tree_builder,
+    );
+}
+
 /// Test that all the builders behave the same when given the same root style.
 #[test]
 fn builders_root_only() {


### PR DESCRIPTION
The two builders (ranged/tree) use different sources of truth to achieve a default style. This is already a bad idea, as evidenced by them having a [different default line height](https://github.com/linebender/parley/pull/362#issuecomment-2896237745) until very recently. It gets even worse, because the ranged builder uses `ResolvedStyle::default()` which means it has a dummy font and doesn't respect scale.

This PR makes both builders use a single source of truth - a `TextStyle` which then gets resolved.

This means that we can confidently change our default style in only one place - the `TextStyle::default` method. Those default values then also get properly resolved according to available fonts, scale, etc.

Note that I didn't change the public API on purpose. I do think that being able to immediately provide a custom root style to the ranged builder, like it is possible with the tree builder, is probably worth doing. However, I want to do any potential public API changes as a focused follow-up PR.

The `PlainEditor::ime_cursor_area` method needed a slight modification as well. It was depending on `ResolvedStyle::default()` for a font size based calculation. That did not respect scale, so I fixed it by just keeping track of the font size that was provided to the `PlainEditor` constructor.

I replaced the custom `ResolvedStyle::default()` implementation with a simple derive. The only remaining non-derivable part was setting the font size to 16. Given that it doesn't respect scale, that custom implementation just provides a false sense of utility. A zero font size is perfectly fine for a state clearing default, which is how we're still using it.

I also added a test to ensure that the default styles remain in sync between the different builders.