### PR TITLE
Make Layout builders #[must_use]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This release has an [MSRV] of 1.82.
   - The default line height was previously `LineHeight::FontSizeRelative(1.0)` if you used `RangedStyleBuilder`, or `LineHeight::FontSizeRelative(1.2)` if you used `TreeStyleBuilder`.
     It is now `LineHeight::MetricsRelative(1.0)` in both cases.
     This will affect layout if you don't specify your own line height.
+- Breaking change: `{RangedBuilder, TreeBuilder}::{build_into, build}` methods now consume `self`. ([#369][] by [@dhardy][])
 
 ### Fixed
 
@@ -211,6 +212,7 @@ This release has an [MSRV][] of 1.70.
 [@wfdewith]: https://github.com/wfdewith
 [@xorgy]: https://github.com/xorgy
 [@xStrom]: https://github.com/xStrom
+[@dhardy]: https://github.com/dhardy
 
 [#54]: https://github.com/linebender/parley/pull/54
 [#55]: https://github.com/linebender/parley/pull/55
@@ -281,6 +283,7 @@ This release has an [MSRV][] of 1.70.
 [#348]: https://github.com/linebender/parley/pull/348
 [#353]: https://github.com/linebender/parley/pull/353
 [#362]: https://github.com/linebender/parley/pull/362
+[#369]: https://github.com/linebender/parley/pull/369
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/linebender/parley/releases/tag/v0.4.0

--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -16,6 +16,7 @@ use crate::inline_box::InlineBox;
 use crate::resolve::tree::ItemKind;
 
 /// Builder for constructing a text layout with ranged attributes.
+#[must_use]
 pub struct RangedBuilder<'a, B: Brush> {
     pub(crate) scale: f32,
     pub(crate) quantize: bool,
@@ -48,7 +49,7 @@ impl<B: Brush> RangedBuilder<'_, B> {
         self.lcx.inline_boxes.push(inline_box);
     }
 
-    pub fn build_into(&mut self, layout: &mut Layout<B>, text: impl AsRef<str>) {
+    pub fn build_into(self, layout: &mut Layout<B>, text: impl AsRef<str>) {
         // Apply RangedStyleBuilder styles to LayoutContext
         self.lcx.ranged_style_builder.finish(&mut self.lcx.styles);
 
@@ -63,7 +64,7 @@ impl<B: Brush> RangedBuilder<'_, B> {
         );
     }
 
-    pub fn build(&mut self, text: impl AsRef<str>) -> Layout<B> {
+    pub fn build(self, text: impl AsRef<str>) -> Layout<B> {
         let mut layout = Layout::default();
         self.build_into(&mut layout, text);
         layout
@@ -71,6 +72,7 @@ impl<B: Brush> RangedBuilder<'_, B> {
 }
 
 /// Builder for constructing a text layout with a tree of attributes.
+#[must_use]
 pub struct TreeBuilder<'a, B: Brush> {
     pub(crate) scale: f32,
     pub(crate) quantize: bool,
@@ -126,7 +128,8 @@ impl<B: Brush> TreeBuilder<'_, B> {
             .set_white_space_mode(white_space_collapse);
     }
 
-    pub fn build_into(&mut self, layout: &mut Layout<B>) -> String {
+    #[inline]
+    pub fn build_into(self, layout: &mut Layout<B>) -> String {
         // Apply TreeStyleBuilder styles to LayoutContext
         let text = self.lcx.tree_style_builder.finish(&mut self.lcx.styles);
 
@@ -136,7 +139,8 @@ impl<B: Brush> TreeBuilder<'_, B> {
         text
     }
 
-    pub fn build(&mut self) -> (Layout<B>, String) {
+    #[inline]
+    pub fn build(self) -> (Layout<B>, String) {
         let mut layout = Layout::default();
         let text = self.build_into(&mut layout);
         (layout, text)

--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -18,7 +18,7 @@ fn plain_multiline_text() {
     let mut env = TestEnv::new(test_name!(), None);
 
     let text = "Hello world!\nLine 2\nLine 4";
-    let mut builder = env.ranged_builder(text);
+    let builder = env.ranged_builder(text);
     let mut layout = builder.build(text);
     layout.break_all_lines(None);
     layout.align(None, Alignment::Start, AlignmentOptions::default());
@@ -147,7 +147,7 @@ fn trailing_whitespace() {
     let mut env = TestEnv::new(test_name!(), None);
 
     let text = "AAA BBB";
-    let mut builder = env.ranged_builder(text);
+    let builder = env.ranged_builder(text);
     let mut layout = builder.build(text);
     layout.break_all_lines(Some(45.));
     layout.align(None, Alignment::Start, AlignmentOptions::default());
@@ -247,7 +247,7 @@ fn base_level_alignment_ltr() {
         (Alignment::Justified, "justified"),
     ] {
         let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
-        let mut builder = env.ranged_builder(text);
+        let builder = env.ranged_builder(text);
         let mut layout = builder.build(text);
         layout.break_all_lines(Some(150.0));
         layout.align(Some(150.0), alignment, AlignmentOptions::default());
@@ -266,7 +266,7 @@ fn base_level_alignment_rtl() {
         (Alignment::Justified, "justified"),
     ] {
         let text = "عند برمجة أجهزة الكمبيوتر، قد تجد نفسك فجأة في مواقف غريبة، مثل الكتابة بلغة لا تتحدثها فعليًا.";
-        let mut builder = env.ranged_builder(text);
+        let builder = env.ranged_builder(text);
         let mut layout = builder.build(text);
         layout.break_all_lines(Some(150.0));
         layout.align(None, alignment, AlignmentOptions::default());
@@ -281,7 +281,7 @@ fn overflow_alignment_rtl() {
     let mut env = TestEnv::new(test_name!(), None);
 
     let text = "عند برمجة أجهزة الكمبيوتر، قد تجد نفسك فجأة في مواقف غريبة، مثل الكتابة بلغة لا تتحدثها فعليًا.";
-    let mut builder = env.ranged_builder(text);
+    let builder = env.ranged_builder(text);
     let mut layout = builder.build(text);
     layout.break_all_lines(Some(1000.0));
     layout.align(Some(10.), Alignment::Middle, AlignmentOptions::default());
@@ -294,7 +294,7 @@ fn content_widths() {
     let mut env = TestEnv::new(test_name!(), None);
 
     let text = "Hello world!\nLonger line with a looooooooong word.";
-    let mut builder = env.ranged_builder(text);
+    let builder = env.ranged_builder(text);
 
     let mut layout = builder.build(text);
 
@@ -317,7 +317,7 @@ fn content_widths_rtl() {
     let mut env = TestEnv::new(test_name!(), None);
 
     let text = "بببب ااااا";
-    let mut builder = env.ranged_builder(text);
+    let builder = env.ranged_builder(text);
 
     let mut layout = builder.build(text);
 
@@ -396,7 +396,7 @@ fn realign() {
     let mut env = TestEnv::new(test_name!(), None);
 
     let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
-    let mut builder = env.ranged_builder(text);
+    let builder = env.ranged_builder(text);
     let mut layout = builder.build(text);
     layout.break_all_lines(Some(150.0));
     for idx in 0..8 {
@@ -458,7 +458,7 @@ fn realign_all() {
     for (text, _) in texts {
         for (alignment, _) in alignments {
             for (max_advance, opts, _, _) in all_opts {
-                let mut builder = env.ranged_builder(text);
+                let builder = env.ranged_builder(text);
                 let mut layout = builder.build(text);
                 layout.break_all_lines(max_advance);
                 layout.align(Some(150.), alignment, opts);

--- a/parley/src/tests/utils/cursor_test.rs
+++ b/parley/src/tests/utils/cursor_test.rs
@@ -49,7 +49,7 @@ impl CursorTest {
         lcx: &mut LayoutContext<ColorBrush>,
         fcx: &mut FontContext,
     ) -> Self {
-        let mut builder = lcx.ranged_builder(fcx, text, 1.0, true);
+        let builder = lcx.ranged_builder(fcx, text, 1.0, true);
         let mut layout = builder.build(text);
         layout.break_all_lines(None);
 


### PR DESCRIPTION
This avoids a potential foot-gun where `Layout` is default-constructed.