### PR TITLE
Merge SourceCache into Collection

### DIFF
--- a/fontique/src/collection/mod.rs
+++ b/fontique/src/collection/mod.rs
@@ -48,6 +48,15 @@ pub struct CollectionOptions {
     ///
     /// The default value is `true`.
     pub system_fonts: bool,
+    #[cfg(feature = "std")]
+    /// If true, the source cache will use a secondary shared cache
+    /// guaranteeing that all clones will use the same backing store.
+    ///
+    /// This is useful for ensuring that only one copy of font data is
+    /// loaded into memory in multi-threaded scenarios.
+    ///
+    /// The default value is `false`.
+    pub shared_source_cache: bool,
 }
 
 impl Default for CollectionOptions {
@@ -55,6 +64,8 @@ impl Default for CollectionOptions {
         Self {
             shared: false,
             system_fonts: true,
+            #[cfg(feature = "std")]
+            shared_source_cache: false,
         }
     }
 }
@@ -64,6 +75,7 @@ impl Default for CollectionOptions {
 pub struct Collection {
     inner: Inner,
     query_state: query::QueryState,
+    source_cache: SourceCache,
 }
 
 impl Collection {
@@ -80,6 +92,9 @@ impl Collection {
         Self {
             inner: Inner::new(options),
             query_state: Default::default(),
+            source_cache: SourceCache::new(crate::SourceCacheOptions {
+                shared: options.shared_source_cache,
+            }),
         }
     }
 
@@ -168,8 +183,8 @@ impl Collection {
     }
 
     /// Returns an object for selecting fonts from this collection.
-    pub fn query<'a>(&'a mut self, source_cache: &'a mut SourceCache) -> Query<'a> {
-        Query::new(self, source_cache)
+    pub fn query<'a>(&'a mut self) -> Query<'a> {
+        Query::new(self)
     }
 
     /// Registers all fonts that exist in the given data.

--- a/fontique/src/collection/query.rs
+++ b/fontique/src/collection/query.rs
@@ -37,12 +37,12 @@ pub struct Query<'a> {
 }
 
 impl<'a> Query<'a> {
-    pub(super) fn new(collection: &'a mut Collection, source_cache: &'a mut SourceCache) -> Self {
+    pub(super) fn new(collection: &'a mut Collection) -> Self {
         collection.query_state.clear();
         Self {
             collection: &mut collection.inner,
             state: &mut collection.query_state,
-            source_cache,
+            source_cache: &mut collection.source_cache,
             attributes: Attributes::default(),
             fallbacks: None,
         }


### PR DESCRIPTION
INCOMPLETE: `fontique` tests pass; `parley` needs fixes

`FontContext` is literally just a `Collection` and a `SourceCache`. This collection already contains a `QueryState`, while performing a query also requires a `SourceCache`, so I don't see a good reason not to do this.

Motivation: I am transitioning `kas-text` to use `fontique` and will likely keep this as the primary text library in Kas since it integrates better with the widget lifecycle model. Parley is more capable, so makes more sense where complex text layout is required. I have a local hack adding optional Parley support to Kas, but this currently requires multiple instances of the `Collection` + `SourceCache`.

Simpler solution: move `FontContext` to `fontique`.

Note also: `Collection` and `SourceCache` have some option for internal sharing of state.