### PR TITLE
Change to commit compare links in the changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,8 +293,9 @@ This release has an [MSRV][] of 1.70.
 [#362]: https://github.com/linebender/parley/pull/362
 [#369]: https://github.com/linebender/parley/pull/369
 
-[Unreleased]: https://github.com/linebender/parley/compare/v0.4.0...HEAD
-[0.4.0]: https://github.com/linebender/parley/releases/tag/v0.4.0
-[0.3.0]: https://github.com/linebender/parley/releases/tag/v0.3.0
-[0.2.0]: https://github.com/linebender/parley/releases/tag/v0.2.0
-[0.1.0]: https://github.com/linebender/parley/releases/tag/v0.1.0
+[Unreleased]: https://github.com/linebender/parley/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/linebender/parley/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/linebender/parley/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/linebender/parley/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/linebender/parley/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/linebender/parley/compare/v0.0.0...v0.1.0


### PR DESCRIPTION
Here in the Parley repo we've used the tag links, but those now just get you the same changelog entry. Instead, [we want to link to the git compare page](https://github.com/linebender/linebender.github.io/pull/109#discussion_r2096170653) to see all the commits for the release.

Also adds the missing link definition for v0.5.0.