### PR TITLE
Use the correct family ID when adding font aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ This release has an [MSRV] of 1.82.
 
 ### Fixed
 
+#### Fontique
+
+- Font family name aliases (secondary names for font families, often in another language) not being registered. ([#380][] by [@valadaptive][])
+
 ## [0.5.0] - 2025-06-01
 
 This release has an [MSRV] of 1.82.
@@ -292,6 +296,7 @@ This release has an [MSRV][] of 1.70.
 [#353]: https://github.com/linebender/parley/pull/353
 [#362]: https://github.com/linebender/parley/pull/362
 [#369]: https://github.com/linebender/parley/pull/369
+[#380]: https://github.com/linebender/parley/pull/380
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.5.0...HEAD
 [0.5.0]: https://github.com/linebender/parley/compare/v0.4.0...v0.5.0

--- a/fontique/src/family_name.rs
+++ b/fontique/src/family_name.rs
@@ -82,7 +82,7 @@ impl FamilyNameMap {
             }
             let new_name = FamilyName {
                 name: name.into(),
-                id: FamilyId::new(),
+                id,
             };
             self.name_map.insert(key.as_bytes().into(), new_name);
         }


### PR DESCRIPTION
Discovered this as part of #378; splitting it off because it affects all the fontique backends.

When adding font aliases, the code was not actually using the family ID we passed in, but creating a fresh family ID each time. This meant that font aliases were all mapped to nonexistent family IDs, and all queries for a font by one of its aliases would fail.

I'm a bit concerned that this has the potential to cause regressions or other general weirdness, since all font aliases went unused due to this bug. Not sure how to test that other than to just give it a spin.