### PR TITLE
Implement shift-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This release has an [MSRV] of 1.82.
 
 ### Added
 
+#### Parley
+
+- Shift-click support through `Selection::shift_click_extension` and `PlainEditorDriver::shift_click_extension`. ([#385][] by [@kekelp][])
+
 ### Changed
 
 ### Fixed
@@ -24,6 +28,10 @@ This release has an [MSRV] of 1.82.
 #### Fontique
 
 - Font family name aliases (secondary names for font families, often in another language) not being registered. ([#380][] by [@valadaptive][])
+
+#### Parley
+
+- Selection extension moves the focus to the side being extended. ([#385][] by [@kekelp][])
 
 ## [0.5.0] - 2025-06-01
 
@@ -225,6 +233,7 @@ This release has an [MSRV][] of 1.70.
 [@xorgy]: https://github.com/xorgy
 [@xStrom]: https://github.com/xStrom
 [@dhardy]: https://github.com/dhardy
+[@kekelp]: https://github.com/kekelp
 
 [#54]: https://github.com/linebender/parley/pull/54
 [#55]: https://github.com/linebender/parley/pull/55
@@ -297,6 +306,7 @@ This release has an [MSRV][] of 1.70.
 [#362]: https://github.com/linebender/parley/pull/362
 [#369]: https://github.com/linebender/parley/pull/369
 [#380]: https://github.com/linebender/parley/pull/380
+[#385]: https://github.com/linebender/parley/pull/385
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.5.0...HEAD
 [0.5.0]: https://github.com/linebender/parley/compare/v0.4.0...v0.5.0

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -268,7 +268,7 @@ impl Editor {
                     3 => drv.select_hard_line_at_point(cursor_pos.0, cursor_pos.1),
                     _ => {
                         if state.modifiers.shift() {
-                            drv.extend_selection_to_precise_point(cursor_pos.0, cursor_pos.1);
+                            drv.shift_click_extension(cursor_pos.0, cursor_pos.1);
                         } else {
                             drv.move_to_point(cursor_pos.0, cursor_pos.1);
                         }

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -266,7 +266,13 @@ impl Editor {
                 match state.count {
                     2 => drv.select_word_at_point(cursor_pos.0, cursor_pos.1),
                     3 => drv.select_hard_line_at_point(cursor_pos.0, cursor_pos.1),
-                    _ => drv.move_to_point(cursor_pos.0, cursor_pos.1),
+                    _ => {
+                        if state.modifiers.shift() {
+                            drv.extend_selection_to_precise_point(cursor_pos.0, cursor_pos.1);
+                        } else {
+                            drv.move_to_point(cursor_pos.0, cursor_pos.1);
+                        }
+                    }
                 }
             }
             PointerEvent::Move(u)

--- a/parley/src/layout/cursor.rs
+++ b/parley/src/layout/cursor.rs
@@ -864,6 +864,33 @@ impl Selection {
         }
     }
 
+    /// Returns a new selection with the focus extended to the given point.
+    #[must_use]
+    pub fn extend_to_precise_point<B: Brush>(&self, layout: &Layout<B>, x: f32, y: f32) -> Self {
+        let cluster = Cursor::from_point(layout, x, y);
+        match self.anchor_base {
+            AnchorBase::Cluster => Self::new(self.anchor, cluster),
+            AnchorBase::Word(start, end) => {
+                let [anchor, focus] = cursor_min_max(layout, [cluster, cluster, start, end]);
+                Self {
+                    anchor,
+                    focus,
+                    anchor_base: self.anchor_base,
+                    h_pos: None,
+                }
+            }
+            AnchorBase::Line(start, end) => {
+                let [anchor, focus] = cursor_min_max(layout, [cluster, cluster, start, end]);
+                Self {
+                    anchor,
+                    focus,
+                    anchor_base: self.anchor_base,
+                    h_pos: None,
+                }
+            }
+        }
+    }
+
     /// Returns a new selection with the current anchor and the focus set to
     /// the given value.
     #[must_use]

--- a/parley/src/layout/cursor.rs
+++ b/parley/src/layout/cursor.rs
@@ -864,21 +864,16 @@ impl Selection {
 
     /// Returns a new selection with the focus extended to the given point.
     #[must_use]
-    pub fn extend_to_precise_point<B: Brush>(&self, layout: &Layout<B>, x: f32, y: f32) -> Self {
-        let cluster = Cursor::from_point(layout, x, y);
+    pub fn shift_click_extension<B: Brush>(&self, layout: &Layout<B>, x: f32, y: f32) -> Self {
+        let target = Cursor::from_point(layout, x, y);
         match self.anchor_base {
-            AnchorBase::Cluster => Self::new(self.anchor, cluster),
-            AnchorBase::Word(start, end) => {
-                let [anchor, focus] = cursor_min_max(layout, [cluster, cluster, start, end]);
-                Self {
-                    anchor,
-                    focus,
-                    anchor_base: self.anchor_base,
-                    h_pos: None,
-                }
-            }
-            AnchorBase::Line(start, end) => {
-                let [anchor, focus] = cursor_min_max(layout, [cluster, cluster, start, end]);
+            AnchorBase::Cluster => Self::new(self.anchor, target),
+            AnchorBase::Word(start, end) | AnchorBase::Line(start, end) => {
+                let [anchor, focus] = if target.index < start.index {
+                    [end, target]
+                } else {
+                    [start, target]
+                };
                 Self {
                     anchor,
                     focus,

--- a/parley/src/layout/cursor.rs
+++ b/parley/src/layout/cursor.rs
@@ -869,14 +869,15 @@ impl Selection {
         match self.anchor_base {
             AnchorBase::Cluster => Self::new(self.anchor, target),
             AnchorBase::Word(start, end) | AnchorBase::Line(start, end) => {
-                let [anchor, focus] = if target.index < start.index {
-                    [end, target]
+                // Place the focus where the user just clicked, and the anchor on the "far" side of the anchorbase.
+                let anchor = if target.index < start.index {
+                    end
                 } else {
-                    [start, target]
+                    start
                 };
                 Self {
                     anchor,
-                    focus,
+                    focus: target,
                     anchor_base: self.anchor_base,
                     h_pos: None,
                 }

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -715,6 +715,9 @@ where
     }
 
     /// Move the selection focus point to the cluster boundary closest to point.
+    ///
+    /// If the initial selection was created from a word or line, then the new
+    /// selection will be extended at the same granularity.
     pub fn extend_selection_to_point(&mut self, x: f32, y: f32) {
         self.refresh_layout();
         // FIXME: This is usually the wrong way to handle selection extension for mouse moves, but not a regression.
@@ -723,6 +726,17 @@ where
                 .selection
                 .extend_to_point(&self.editor.layout, x, y),
         );
+    }
+
+    /// Move the selection focus point to the cluster boundary closest to point.
+    pub fn extend_selection_to_precise_point(&mut self, x: f32, y: f32) {
+        self.refresh_layout();
+        self.editor
+            .set_selection(self.editor.selection.extend_to_precise_point(
+                &self.editor.layout,
+                x,
+                y,
+            ));
     }
 
     /// Move the selection focus point to a byte index.

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -729,14 +729,14 @@ where
     }
 
     /// Move the selection focus point to the cluster boundary closest to point.
-    pub fn extend_selection_to_precise_point(&mut self, x: f32, y: f32) {
+    pub fn shift_click_extension(&mut self, x: f32, y: f32) {
         self.refresh_layout();
         self.editor
-            .set_selection(self.editor.selection.extend_to_precise_point(
-                &self.editor.layout,
-                x,
-                y,
-            ));
+            .set_selection(
+                self.editor
+                    .selection
+                    .shift_click_extension(&self.editor.layout, x, y),
+            );
     }
 
     /// Move the selection focus point to a byte index.


### PR DESCRIPTION
This is a pull request to implement shift-click selection extension.

Shift-click extends the selection starting from the anchor base, but always using cluster granularity. As far as I could tell, there's no way to do this with `Selection`'s current public API. The new function `Selection::extend_to_precise_point` allows doing this.

The function is very similar to the existing `Selection::extend_to_point`, but I created a new one instead of modifying it, since I'm not familiar with the backwards compatibility requirements.