### PR TITLE
Implement the ability to hide the editor text with a given repeated character

### DIFF
--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -22,6 +22,7 @@ use accesskit::{Node, NodeId, Role, TextDirection, TreeUpdate};
 use alignment::unjustify;
 #[cfg(feature = "accesskit")]
 use alloc::vec::Vec;
+use alloc::{string::String, sync::Arc};
 use core::{cmp::Ordering, ops::Range};
 use data::{ClusterData, LayoutData, LayoutItem, LayoutItemKind, LineData, LineItemData, RunData};
 #[cfg(feature = "accesskit")]
@@ -314,6 +315,8 @@ pub struct Style<B: Brush> {
     pub(crate) line_height: LayoutLineHeight,
     /// Per-cluster overflow-wrap setting
     pub(crate) overflow_wrap: OverflowWrap,
+    /// Replace graphemes with another grapheme.
+    pub(crate) grapheme_replacement: Option<Arc<String>>,
 }
 
 /// Underline or strikethrough decoration.

--- a/parley/src/resolve/mod.rs
+++ b/parley/src/resolve/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod tree;
 
 pub(crate) use range::RangedStyleBuilder;
 
-use alloc::{vec, vec::Vec};
+use alloc::{string::String, sync::Arc, vec, vec::Vec};
 
 use super::style::{
     Brush, FontFamily, FontFeature, FontSettings, FontStack, FontStyle, FontVariation, FontWeight,
@@ -157,6 +157,7 @@ impl ResolveContext {
             StyleProperty::LetterSpacing(value) => LetterSpacing(*value * scale),
             StyleProperty::WordBreak(value) => WordBreak(*value),
             StyleProperty::OverflowWrap(value) => OverflowWrap(*value),
+            StyleProperty::GraphemeReplacement(value) => GraphemeReplacement(value.clone()),
         }
     }
 
@@ -193,6 +194,7 @@ impl ResolveContext {
             letter_spacing: raw_style.letter_spacing * scale,
             word_break: raw_style.word_break,
             overflow_wrap: raw_style.overflow_wrap,
+            grapheme_replacement: raw_style.grapheme_replacement.clone(),
         }
     }
 
@@ -374,6 +376,8 @@ pub(crate) enum ResolvedProperty<B: Brush> {
     WordBreak(WordBreakStrength),
     /// Control over "emergency" line-breaking.
     OverflowWrap(OverflowWrap),
+    /// Replace graphemes with another grapheme.
+    GraphemeReplacement(Option<Arc<String>>),
 }
 
 /// Flattened group of style properties.
@@ -411,6 +415,8 @@ pub(crate) struct ResolvedStyle<B: Brush> {
     pub(crate) word_break: WordBreakStrength,
     /// Control over "emergency" line-breaking.
     pub(crate) overflow_wrap: OverflowWrap,
+    /// Replace graphemes with another grapheme.
+    pub(crate) grapheme_replacement: Option<Arc<String>>,
 }
 
 impl<B: Brush> ResolvedStyle<B> {
@@ -440,6 +446,7 @@ impl<B: Brush> ResolvedStyle<B> {
             LetterSpacing(value) => self.letter_spacing = value,
             WordBreak(value) => self.word_break = value,
             OverflowWrap(value) => self.overflow_wrap = value,
+            GraphemeReplacement(value) => self.grapheme_replacement = value,
         }
     }
 
@@ -468,6 +475,7 @@ impl<B: Brush> ResolvedStyle<B> {
             LetterSpacing(value) => nearly_eq(self.letter_spacing, *value),
             WordBreak(value) => self.word_break == *value,
             OverflowWrap(value) => self.overflow_wrap == *value,
+            GraphemeReplacement(value) => self.grapheme_replacement == *value,
         }
     }
 
@@ -478,6 +486,7 @@ impl<B: Brush> ResolvedStyle<B> {
             strikethrough: self.strikethrough.as_layout_decoration(&self.brush),
             line_height: self.line_height.resolve(self.font_size),
             overflow_wrap: self.overflow_wrap,
+            grapheme_replacement: self.grapheme_replacement.clone(),
         }
     }
 }

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -7,7 +7,7 @@ mod brush;
 mod font;
 mod styleset;
 
-use alloc::borrow::Cow;
+use alloc::{borrow::Cow, string::String, sync::Arc};
 
 pub use brush::*;
 pub use font::{
@@ -140,6 +140,8 @@ pub enum StyleProperty<'a, B: Brush> {
     WordBreak(WordBreakStrength),
     /// Control over "emergency" line-breaking.
     OverflowWrap(OverflowWrap),
+    /// Replace graphemes with another grapheme.
+    GraphemeReplacement(Option<Arc<String>>),
 }
 
 /// Unresolved styles.
@@ -189,6 +191,8 @@ pub struct TextStyle<'a, B: Brush> {
     pub word_break: WordBreakStrength,
     /// Control over "emergency" line-breaking.
     pub overflow_wrap: OverflowWrap,
+    /// Replace graphemes with another grapheme.
+    pub grapheme_replacement: Option<Arc<String>>,
 }
 
 impl<B: Brush> Default for TextStyle<'_, B> {
@@ -216,6 +220,7 @@ impl<B: Brush> Default for TextStyle<'_, B> {
             letter_spacing: Default::default(),
             word_break: Default::default(),
             overflow_wrap: Default::default(),
+            grapheme_replacement: Default::default(),
         }
     }
 }

--- a/parley/src/tests/test_builders.rs
+++ b/parley/src/tests/test_builders.rs
@@ -184,6 +184,7 @@ fn create_root_style() -> TextStyle<'static, ColorBrush> {
         letter_spacing: 1.5,
         word_break: WordBreakStrength::BreakAll,
         overflow_wrap: OverflowWrap::Anywhere,
+        grapheme_replacement: None, // TODO: Set a non-default value
     }
 }
 


### PR DESCRIPTION
I am currently using a text input field in xilem as a password field, but there is currently no way to hide the text by replacing the actual buffer of characters with a repeated character such as an asterisk (i.e., `'*'`). Further looking into xilem and masonry, I found that the text input field leverages `PlainEditor` in parley, so I am trying to extend that first.

More specifically, this commit adds a `visible_buffer` field to hold the character buffer with the replaced characters and a `hide_symbol` field to hold the character that needs to be shown (if any is set). This is to ensure that the original `buffer` field stays intact everywhere else (together with the corresponding logic), and this seems to be the least intrusive way to achieve this. Further, I have extended `update_layout` to update the `visible_buffer` field if the symbol or the length of the original buffer changed and to decide which buffer needs to be shown based on whether the symbol is set or not. Finally, this adds two methods to set and clear the symbol used for hiding the text.

Extending this functionality to masonry/xilem should be as simple as calling those two methods once this lands. I think this is also neat because this makes it simple to add a show/hide password checkbox if desired.

Issue #327 is related, but we should keep that open even if this lands, because there are probably a bunch of corner cases or additional desired features, I am just trying to get the most awkward part out of the way which is that the password shouldn't be visible on the screen.