### PR TITLE
Fixing Cluster Info + adding cluster layout snapshots

### DIFF
--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -391,6 +391,12 @@ impl<'a, B: Brush> Cluster<'a, B> {
     pub(crate) fn info(&self) -> &data::ClusterInfo {
         &self.data.info
     }
+
+    /// Returns the text length of the cluster in bytes.
+    #[cfg(test)]
+    pub(crate) fn text_len(&self) -> u8 {
+        self.data.text_len
+    }
 }
 
 /// Determines how a cursor attaches to a cluster.

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -6,7 +6,6 @@ use crate::layout::{ContentWidths, Glyph, LineMetrics, RunMetrics, Style};
 use crate::style::Brush;
 use crate::util::nearly_zero;
 use crate::{Font, OverflowWrap};
-use core::iter;
 use core::ops::Range;
 
 use swash::text::cluster::{Boundary, Whitespace};
@@ -99,6 +98,11 @@ impl ClusterInfo {
     /// Returns if the cluster is any whitespace.
     pub(crate) fn is_whitespace(&self) -> bool {
         self.source_char.is_whitespace()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn source_char(&self) -> char {
+        self.source_char
     }
 }
 
@@ -437,6 +441,7 @@ impl<B: Brush> LayoutData<B> {
         let is_rtl = bidi_level & 1 == 1;
         if !is_rtl {
             run.advance = process_clusters(
+                Direction::Ltr,
                 &mut self.clusters,
                 &mut self.glyphs,
                 scale_factor,
@@ -447,6 +452,7 @@ impl<B: Brush> LayoutData<B> {
             );
         } else {
             run.advance = process_clusters(
+                Direction::Rtl,
                 &mut self.clusters,
                 &mut self.glyphs,
                 scale_factor,
@@ -579,6 +585,7 @@ impl<B: Brush> LayoutData<B> {
 /// * `char_indices_iter` - Iterator over (`byte_offset`, `char`) pairs from the source text.
 ///   Should be in logical order (forward for LTR, reverse for RTL).
 fn process_clusters<I: Iterator<Item = (usize, char)>>(
+    direction: Direction,
     clusters: &mut Vec<ClusterData>,
     glyphs: &mut Vec<Glyph>,
     scale_factor: f32,
@@ -600,19 +607,54 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
     // pushing the first glyph to `glyphs` because it might be inlined into `ClusterData`.
     let mut pending_inline_glyph: Option<Glyph> = None;
 
-    let text_len = |char: (usize, char), chars: &mut iter::Peekable<I>| {
-        let next = chars
-            .peek()
-            .map(|x| x.0)
-            .unwrap_or(char.0 + char.1.len_utf8());
-        char.0.abs_diff(next) as u8
+    // The mental model for understanding this function is best grasped by first reading
+    // the HarfBuzz docs on [clusters](https://harfbuzz.github.io/working-with-harfbuzz-clusters.html).
+    //
+    // `num_components` is the number of characters in the current cluster. Since source text's characters
+    // were inserted into `HarfRust`'s buffer using their indices as the cluster ID, `HarfRust` will assign
+    // the first character's cluster ID to the cluster because `HarfRust` chooses the [minimum ID for merging](https://github.com/harfbuzz/harfrust/blob/a38025fb336230b492366740c86021bb406bcd0d/src/hb/buffer.rs#L920-L924).
+    //
+    //  So, the number of components in a given cluster is dependent on `direction`. In LTR,  `num_components`
+    // is the difference between the next cluster and the current cluster. In RTL, it is the difference between
+    // the last cluster and the current cluster. This is because we must compare the current cluster its next
+    // larger ID (or last visual index, which is downstream in LTR and upstream in RTL).
+    //
+    // For example, consider the LTR text for "afi" where "fi" form a ligature.
+    //   Initial cluster values: 0, 1, 2 (logical + visual order)
+    //   `HarfRust` assignation: 0, 1, 1
+    //   Cluster count:          2
+    //   `num_components`:       (1 - 0 =) 1, (3 - 1 =) 2
+    //
+    // Now consider the RTL text for "حداً".
+    //   Initial cluster values:  0, 1, 2, 3 (visal order)
+    //   Reversed cluster values: 3, 2, 1, 0 (logical order)
+    //   `HarfRust` assignation:  3, 2, 0, 0
+    //   Cluster count:           3
+    //   `num_components`:        (4 - 3 =) 1, (3 - 2 =) 1, (2 - 0 =) 2
+    let num_components =
+        |next_cluster: u32, current_cluster: u32, last_cluster: u32| match direction {
+            Direction::Ltr => next_cluster - current_cluster,
+            Direction::Rtl => last_cluster - current_cluster,
+        };
+    let mut last_cluster_id: u32 = match direction {
+        Direction::Ltr => 0,
+        Direction::Rtl => char_infos.len() as u32,
     };
 
     for (glyph_info, glyph_pos) in glyph_infos.iter().zip(glyph_positions.iter()) {
         // Flush previous cluster if we've reached a new cluster
         if cluster_id != glyph_info.cluster {
-            let num_components = cluster_id.abs_diff(glyph_info.cluster);
             run_advance += cluster_advance;
+            // If the difference between the current and new cluster is 1,
+            // but the num_components is greater than 1, then we have a
+            // ligature where 1 byte was expanded to multiple glyphs.
+            //
+            // So, for the purposes of `ClusterData`, this will be recorded
+            // as a single cluster (and so we want all the advance assigned)
+            // to it.
+            //
+            let num_components = num_components(glyph_info.cluster, cluster_id, last_cluster_id);
+
             cluster_advance /= num_components as f32;
             let is_newline = to_whitespace(cluster_start_char.1) == Whitespace::Newline;
             let cluster_type = if num_components > 1 {
@@ -639,7 +681,6 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
             push_cluster(
                 clusters,
                 char_info,
-                text_len(cluster_start_char, &mut char_indices_iter),
                 cluster_start_char,
                 cluster_glyph_offset,
                 cluster_advance,
@@ -651,22 +692,18 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
 
             if num_components > 1 {
                 // Skip characters until we reach the current cluster
-                for i in 0..(num_components - 1) {
+                for i in 1..num_components {
                     cluster_start_char = char_indices_iter.next().unwrap();
                     if to_whitespace(cluster_start_char.1) == Whitespace::Space {
                         break;
                     }
-                    // Iterate in correct (LTR or RTL) order
-                    let char_info_ = if cluster_id < glyph_info.cluster {
-                        &char_infos[(cluster_id + i) as usize]
-                    } else {
-                        &char_infos[(cluster_id - 1) as usize]
+                    let char_info_ = match direction {
+                        Direction::Ltr => &char_infos[(cluster_id + i) as usize],
+                        Direction::Rtl => &char_infos[(cluster_id + num_components - i) as usize],
                     };
-
                     push_cluster(
                         clusters,
                         char_info_,
-                        text_len(cluster_start_char, &mut char_indices_iter),
                         cluster_start_char,
                         cluster_glyph_offset,
                         cluster_advance,
@@ -679,6 +716,7 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
             cluster_start_char = char_indices_iter.next().unwrap();
 
             cluster_advance = 0.0;
+            last_cluster_id = cluster_id;
             cluster_id = glyph_info.cluster;
             char_info = &char_infos[cluster_id as usize];
             pending_inline_glyph = None;
@@ -709,20 +747,23 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
 
     // Push the last cluster
     {
-        // Since this is the last cluster, it covers from cluster_id to the end of char_infos
-        let remaining_chars = char_infos.len() - cluster_id.abs_diff(start_cluster_id) as usize;
-        if remaining_chars > 1 {
+        // See comment above `num_components` for why we use `char_infos.len()` for LTR and 0 for RTL.
+        let next_cluster_id = match direction {
+            Direction::Ltr => char_infos.len() as u32,
+            Direction::Rtl => 0,
+        };
+        let num_components = num_components(next_cluster_id, cluster_id, last_cluster_id);
+        if num_components > 1 {
             // This is a ligature - create ligature start + ligature components
 
             if let Some(pending) = pending_inline_glyph.take() {
                 glyphs.push(pending);
                 total_glyphs += 1;
             }
-            let ligature_advance = cluster_advance / remaining_chars as f32;
+            let ligature_advance = cluster_advance / num_components as f32;
             push_cluster(
                 clusters,
                 char_info,
-                text_len(cluster_start_char, &mut char_indices_iter),
                 cluster_start_char,
                 cluster_glyph_offset,
                 ligature_advance,
@@ -735,21 +776,17 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
 
             // Create ligature component clusters for the remaining characters
             let mut i = 1;
-            while let Some(char) = char_indices_iter.next() {
+            for char in char_indices_iter {
                 if to_whitespace(char.1) == Whitespace::Space {
                     break;
                 }
-                // Iterate in correct (LTR or RTL) order
-                let component_char_info = if cluster_start_char.0 < char.0 {
-                    &char_infos[(cluster_id + i) as usize]
-                } else {
-                    &char_infos[(cluster_id - i) as usize]
+                let component_char_info = match direction {
+                    Direction::Ltr => &char_infos[(cluster_id + i) as usize],
+                    Direction::Rtl => &char_infos[(cluster_id + num_components - i) as usize],
                 };
-
                 push_cluster(
                     clusters,
                     component_char_info,
-                    text_len(char, &mut char_indices_iter),
                     char,
                     cluster_glyph_offset,
                     ligature_advance,
@@ -785,7 +822,6 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
             push_cluster(
                 clusters,
                 char_info,
-                text_len(cluster_start_char, &mut char_indices_iter),
                 cluster_start_char,
                 cluster_glyph_offset,
                 cluster_advance,
@@ -797,6 +833,12 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
     }
 
     run_advance
+}
+
+#[derive(PartialEq)]
+enum Direction {
+    Ltr,
+    Rtl,
 }
 
 enum ClusterType {
@@ -819,7 +861,6 @@ impl From<&ClusterType> for u16 {
 fn push_cluster(
     clusters: &mut Vec<ClusterData>,
     char_info: &(swash::text::cluster::CharInfo, u16),
-    text_len: u8,
     cluster_start_char: (usize, char),
     glyph_offset: u32,
     advance: f32,
@@ -857,7 +898,7 @@ fn push_cluster(
         flags: (&cluster_type).into(),
         style_index: char_info.1,
         glyph_len: final_glyph_len,
-        text_len,
+        text_len: cluster_start_char.1.len_utf8() as u8,
         glyph_offset: final_glyph_offset,
         text_offset: cluster_start_char.0 as u16,
         advance: final_advance,

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -645,16 +645,7 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
         // Flush previous cluster if we've reached a new cluster
         if cluster_id != glyph_info.cluster {
             run_advance += cluster_advance;
-            // If the difference between the current and new cluster is 1,
-            // but the num_components is greater than 1, then we have a
-            // ligature where 1 byte was expanded to multiple glyphs.
-            //
-            // So, for the purposes of `ClusterData`, this will be recorded
-            // as a single cluster (and so we want all the advance assigned)
-            // to it.
-            //
             let num_components = num_components(glyph_info.cluster, cluster_id, last_cluster_id);
-
             cluster_advance /= num_components as f32;
             let is_newline = to_whitespace(cluster_start_char.1) == Whitespace::Newline;
             let cluster_type = if num_components > 1 {

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -578,6 +578,7 @@ impl<B: Brush> LayoutData<B> {
 ///   with zero offsets may be inlined directly into `ClusterData`.
 ///
 /// ## Input Parameters:
+/// * `direction` - Direction of the text.
 /// * `scale_factor` - Scaling factor used to convert font units to the target size.
 /// * `glyph_infos` - `HarfRust` glyph information in visual order.
 /// * `glyph_positions` - `HarfRust` glyph positioning data in visual order.

--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -493,41 +493,30 @@ fn test_cluster_info() {
     let test_name = test_name!();
     let mut env = TestEnv::new(test_name, Size::new(400.0, 200.0));
 
-    let create_layout = |env: &mut TestEnv, text: &str| {
+    let test_cluster_layout = |test: &str, text: &str, env: &mut TestEnv| {
         let mut builder = env.ranged_builder(text);
         builder.push_default(StyleProperty::FontSize(24.0));
         let mut layout = builder.build(text);
         layout.break_all_lines(Some(400.0));
-        layout
+        env.with_name(test)
+            .check_cluster_snapshot(&layout, text, 12.0);
     };
 
     // Latin LTR with ligature
-    {
-        let text = "Hello Ligature: fi";
-        let layout = create_layout(&mut env, text);
-        env.with_name("latin").check_cluster_snapshot(&layout, text);
-    }
+    let text = "Hello Ligature: fi";
+    test_cluster_layout("latin", text, &mut env);
+
     // Arabic RTL with ligature
-    {
-        let text = "حداً ";
-        let layout = create_layout(&mut env, text);
-        env.with_name("arabic")
-            .check_cluster_snapshot(&layout, text);
-    }
+    let text = "حداً ";
+    test_cluster_layout("arabic", text, &mut env);
+
     // Mixed content with ligature
-    {
-        let text = "Hello Ligature: fi, Arabic: حداً";
-        let layout = create_layout(&mut env, text);
-        env.with_name("ltr_rtl_mixed")
-            .check_cluster_snapshot(&layout, text);
-    }
+    let text = "Hello Ligature: fi, Arabic: حداً";
+    test_cluster_layout("ltr_rtl_mixed", text, &mut env);
+
     // Newlines
-    {
-        let text = "Hello\nLigature:\nfi";
-        let layout = create_layout(&mut env, text);
-        env.with_name("newlines")
-            .check_cluster_snapshot(&layout, text);
-    }
+    let text = "Hello\nLigature:\nfi";
+    test_cluster_layout("newlines", text, &mut env);
 }
 
 #[test]

--- a/parley/src/tests/utils/env.rs
+++ b/parley/src/tests/utils/env.rs
@@ -325,7 +325,12 @@ impl TestEnv {
         self.check_image(&current_img);
     }
 
-    pub(crate) fn check_cluster_snapshot(&mut self, layout: &Layout<ColorBrush>, text: &str) {
+    pub(crate) fn check_cluster_snapshot(
+        &mut self,
+        layout: &Layout<ColorBrush>,
+        text: &str,
+        char_info_font_size: f32,
+    ) {
         let mut char_layouts = HashMap::new();
         for char in text.chars() {
             let char_text = char.to_string();
@@ -334,8 +339,12 @@ impl TestEnv {
             char_layouts.insert(char, layout);
         }
 
-        let current_img =
-            render_layout_with_clusters(&self.rendering_config, layout, &char_layouts);
+        let current_img = render_layout_with_clusters(
+            &self.rendering_config,
+            layout,
+            &char_layouts,
+            char_info_font_size,
+        );
         self.check_image(&current_img);
     }
 
@@ -346,12 +355,12 @@ impl TestEnv {
         let snapshot_path = snapshot_dir().join(&image_name);
         let comparison_path = current_imgs_dir().join(&image_name);
 
-        if let Err(err) = self.check_images(img, &snapshot_path) {
+        if let Err(e) = self.check_images(img, &snapshot_path) {
             if is_accept_mode() {
                 img.save_png(&snapshot_path).unwrap();
             } else {
                 img.save_png(&comparison_path).unwrap();
-                self.errors.push((comparison_path, err));
+                self.errors.push((comparison_path, e));
             }
         } else if is_generate_all_mode() {
             img.save_png(&comparison_path).unwrap();

--- a/parley/src/tests/utils/renderer.rs
+++ b/parley/src/tests/utils/renderer.rs
@@ -149,6 +149,7 @@ pub(crate) fn render_layout_with_clusters(
     config: &RenderingConfig,
     layout: &Layout<ColorBrush>,
     char_layouts: &HashMap<char, Layout<ColorBrush>>,
+    char_info_font_size: f32,
 ) -> Pixmap {
     let padding = 20;
     let line_extra_spacing = 60.0; // Extra space between lines for cluster info
@@ -281,7 +282,7 @@ pub(crate) fn render_layout_with_clusters(
                                 let glyph_id = GlyphId::from(glyph.id as u16);
                                 if let Some(glyph_outline) = outlines.get(glyph_id) {
                                     pen.set_origin(glyph_x, glyph_y);
-                                    pen.draw_glyph(&glyph_outline, 12.0, &[]);
+                                    pen.draw_glyph(&glyph_outline, char_info_font_size, &[]);
                                 }
                             }
                         }

--- a/parley/src/tests/utils/renderer.rs
+++ b/parley/src/tests/utils/renderer.rs
@@ -7,6 +7,8 @@
 //! Note: Emoji rendering is not currently implemented in this example. See the swash example
 //! if you need emoji rendering.
 
+use std::collections::HashMap;
+
 use crate::{GlyphRun, Layout, PositionedLayoutItem};
 use peniko::kurbo;
 use skrifa::{
@@ -142,7 +144,169 @@ pub(crate) fn render_layout(
     img
 }
 
+/// Render the layout with cluster information including measurement lines and source characters.
+pub(crate) fn render_layout_with_clusters(
+    config: &RenderingConfig,
+    layout: &Layout<ColorBrush>,
+    char_layouts: &HashMap<char, Layout<ColorBrush>>,
+) -> Pixmap {
+    let padding = 20;
+    let line_extra_spacing = 60.0; // Extra space between lines for cluster info
+    let measurement_line_height = 5.0; // Height below baseline for measurement line
+    let char_display_offset = 18.0; // Offset below measurement line for character display
+
+    // Calculate dimensions with extra spacing
+    let width = config
+        .size
+        .map(|size| size.width as f32)
+        .unwrap_or(layout.width())
+        .ceil() as u32;
+    let base_height = layout.height();
+    let num_lines = layout.len();
+    let height = (base_height + (line_extra_spacing * num_lines as f32)).ceil() as u32;
+    let padded_width = width + padding * 2;
+    let padded_height = height + padding * 2;
+    let fpadding = padding as f32;
+
+    let mut img = Pixmap::new(padded_width, padded_height).unwrap();
+    img.fill(config.padding_color);
+
+    let mut pen = TinySkiaPen::new(img.as_mut());
+
+    draw_rect(
+        &mut pen,
+        fpadding,
+        fpadding,
+        width as f32,
+        height as f32,
+        config.background_color,
+    );
+
+    // Render each line with clusters
+    let mut y_offset = 0.0;
+    for line in layout.lines() {
+        let line_y = line.metrics().baseline + y_offset;
+
+        // Render the normal text first
+        for item in line.items() {
+            match item {
+                PositionedLayoutItem::GlyphRun(glyph_run) => {
+                    render_glyph_run_with_offset(&glyph_run, &mut pen, padding, y_offset);
+                }
+                PositionedLayoutItem::InlineBox(_) => {
+                    panic!("Inline boxes are not supported in cluster rendering");
+                }
+            }
+        }
+
+        // Now render cluster information
+        for item in line.items() {
+            if let PositionedLayoutItem::GlyphRun(glyph_run) = item {
+                let run = glyph_run.run();
+                let mut x_offset = glyph_run.offset();
+
+                for cluster in run.visual_clusters() {
+                    let cluster_width = cluster.advance();
+
+                    // Use the test-specific methods we added to Cluster
+                    let source_char = cluster.info().source_char();
+                    let expected_len = source_char.len_utf8() as u8;
+                    let actual_len = cluster.text_len();
+
+                    assert_eq!(
+                        expected_len, actual_len,
+                        "Cluster text_len mismatch for '{}': expected {}, got {}",
+                        source_char, expected_len, actual_len
+                    );
+
+                    // Draw measurement line
+                    let measure_y = line_y + measurement_line_height + fpadding;
+                    let measure_x_start = x_offset + fpadding;
+                    let measure_x_end = x_offset + cluster_width + fpadding;
+
+                    // Draw horizontal measurement line
+                    pen.set_color(Color::from_rgba8(100, 100, 100, 255));
+                    pen.draw_line(measure_x_start, measure_y, measure_x_end, measure_y);
+
+                    // Draw small vertical ticks at start and end
+                    const TICK_HEIGHT: f32 = 3.0;
+                    pen.draw_line(
+                        measure_x_start,
+                        measure_y - TICK_HEIGHT,
+                        measure_x_start,
+                        measure_y + TICK_HEIGHT,
+                    );
+                    pen.draw_line(
+                        measure_x_end,
+                        measure_y - TICK_HEIGHT,
+                        measure_x_end,
+                        measure_y + TICK_HEIGHT,
+                    );
+
+                    // Render the character (skip whitespace and control characters)
+                    match source_char {
+                        ' ' | '\n' | '\t' => {
+                            // Skip rendering whitespace
+                        }
+                        _ => {
+                            // Draw the character glyphs under the measurement line (these should appear
+                            // to be the same as the character in the source text).
+                            let char_layout = char_layouts.get(&source_char).unwrap();
+                            let line = char_layout.lines().next().unwrap();
+                            let item = line.items().next().unwrap();
+                            let glyph_run = match item {
+                                PositionedLayoutItem::GlyphRun(glyph_run) => glyph_run,
+                                PositionedLayoutItem::InlineBox(_) => {
+                                    panic!("Inline boxes are not supported in cluster rendering");
+                                }
+                            };
+                            let font = glyph_run.run().font();
+                            let font_collection_ref = font.data.as_ref();
+                            let font_ref =
+                                ReadFontsRef::from_index(font_collection_ref, font.index).unwrap();
+                            let outlines = font_ref.outline_glyphs();
+
+                            // Calculate total width of the character's glyphs to center them
+                            let char_total_width: f32 = glyph_run.glyphs().map(|g| g.advance).sum();
+                            let char_x_offset = (cluster_width - char_total_width) / 2.0;
+
+                            let mut glyph_x_offset = 0.0;
+                            // Iterates over the glyphs in the GlyphRun
+                            for glyph in glyph_run.glyphs() {
+                                let glyph_x =
+                                    measure_x_start + char_x_offset + glyph.x + glyph_x_offset;
+                                let glyph_y = measure_y + char_display_offset - glyph.y;
+                                glyph_x_offset += glyph.advance;
+
+                                let glyph_id = GlyphId::from(glyph.id as u16);
+                                if let Some(glyph_outline) = outlines.get(glyph_id) {
+                                    pen.set_origin(glyph_x, glyph_y);
+                                    pen.draw_glyph(&glyph_outline, 12.0, &[]);
+                                }
+                            }
+                        }
+                    };
+                    x_offset += cluster_width;
+                }
+            }
+        }
+
+        y_offset += line_extra_spacing;
+    }
+
+    img
+}
+
 fn render_glyph_run(glyph_run: &GlyphRun<'_, ColorBrush>, pen: &mut TinySkiaPen<'_>, padding: u32) {
+    render_glyph_run_with_offset(glyph_run, pen, padding, 0.0);
+}
+
+fn render_glyph_run_with_offset(
+    glyph_run: &GlyphRun<'_, ColorBrush>,
+    pen: &mut TinySkiaPen<'_>,
+    padding: u32,
+    y_offset: f32,
+) {
     // Resolve properties of the GlyphRun
     let mut run_x = glyph_run.offset();
     let run_y = glyph_run.baseline();
@@ -170,7 +334,7 @@ fn render_glyph_run(glyph_run: &GlyphRun<'_, ColorBrush>, pen: &mut TinySkiaPen<
     // Iterates over the glyphs in the GlyphRun
     for glyph in glyph_run.glyphs() {
         let glyph_x = run_x + glyph.x + padding as f32;
-        let glyph_y = run_y - glyph.y + padding as f32;
+        let glyph_y = run_y - glyph.y + padding as f32 + y_offset;
         run_x += glyph.advance;
 
         let glyph_id = GlyphId::from(glyph.id as u16);
@@ -187,17 +351,34 @@ fn render_glyph_run(glyph_run: &GlyphRun<'_, ColorBrush>, pen: &mut TinySkiaPen<
     if let Some(decoration) = &style.underline {
         let offset = decoration.offset.unwrap_or(run_metrics.underline_offset);
         let size = decoration.size.unwrap_or(run_metrics.underline_size);
-        render_decoration(pen, glyph_run, decoration.brush, offset, size, padding);
+        render_decoration_with_offset(
+            pen,
+            glyph_run,
+            decoration.brush,
+            offset,
+            size,
+            padding,
+            y_offset,
+        );
     }
     if let Some(decoration) = &style.strikethrough {
         let offset = decoration
             .offset
             .unwrap_or(run_metrics.strikethrough_offset);
         let size = decoration.size.unwrap_or(run_metrics.strikethrough_size);
-        render_decoration(pen, glyph_run, decoration.brush, offset, size, padding);
+        render_decoration_with_offset(
+            pen,
+            glyph_run,
+            decoration.brush,
+            offset,
+            size,
+            padding,
+            y_offset,
+        );
     }
 }
 
+#[allow(dead_code)]
 fn render_decoration(
     pen: &mut TinySkiaPen<'_>,
     glyph_run: &GlyphRun<'_, ColorBrush>,
@@ -206,7 +387,19 @@ fn render_decoration(
     width: f32,
     padding: u32,
 ) {
-    let y = glyph_run.baseline() - offset + padding as f32;
+    render_decoration_with_offset(pen, glyph_run, brush, offset, width, padding, 0.0);
+}
+
+fn render_decoration_with_offset(
+    pen: &mut TinySkiaPen<'_>,
+    glyph_run: &GlyphRun<'_, ColorBrush>,
+    brush: ColorBrush,
+    offset: f32,
+    width: f32,
+    padding: u32,
+    y_offset: f32,
+) {
+    let y = glyph_run.baseline() - offset + padding as f32 + y_offset;
     let x = glyph_run.offset() + padding as f32;
     pen.set_color(brush.color);
     pen.set_origin(x, y);
@@ -245,6 +438,18 @@ impl TinySkiaPen<'_> {
         let rect = Rect::from_xywh(self.x, self.y, width, height).expect("Invalid rect");
         self.pixmap
             .fill_rect(rect, &self.paint, Transform::identity(), None);
+    }
+
+    fn draw_line(&mut self, x1: f32, y1: f32, x2: f32, y2: f32) {
+        let mut pb = PathBuilder::new();
+        pb.move_to(x1, y1);
+        pb.line_to(x2, y2);
+        if let Some(path) = pb.finish() {
+            let mut stroke = tiny_skia::Stroke::default();
+            stroke.width = 1.0;
+            self.pixmap
+                .stroke_path(&path, &self.paint, &stroke, Transform::identity(), None);
+        }
     }
 
     fn draw_glyph(

--- a/parley/src/tests/utils/renderer.rs
+++ b/parley/src/tests/utils/renderer.rs
@@ -200,7 +200,7 @@ pub(crate) fn render_layout_with_clusters(
             }
         }
 
-        // Now render cluster information
+        // Now render cluster information below each line.
         for item in line.items() {
             if let PositionedLayoutItem::GlyphRun(glyph_run) = item {
                 let run = glyph_run.run();
@@ -250,8 +250,8 @@ pub(crate) fn render_layout_with_clusters(
                             // Skip rendering whitespace
                         }
                         _ => {
-                            // Draw the character glyphs under the measurement line (these should appear
-                            // to be the same as the character in the source text).
+                            // Draw the cluster's character glyphs under the measurement line (these
+                            // should appear to be the same as the character in the source text).
                             let char_layout = char_layouts.get(&source_char).unwrap();
                             let line = char_layout.lines().next().unwrap();
                             let item = line.items().next().unwrap();

--- a/parley/tests/snapshots/test_cluster_info-arabic.png
+++ b/parley/tests/snapshots/test_cluster_info-arabic.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89d2036b4bc18de7c4c21812bf162cc0478f165e443dd455790bdb0750425ee1
+size 939

--- a/parley/tests/snapshots/test_cluster_info-latin.png
+++ b/parley/tests/snapshots/test_cluster_info-latin.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b490ca22a2eb87eeaeb7d947bb1143c1808e2b7887e1e028e8883438985b3483
+size 1970

--- a/parley/tests/snapshots/test_cluster_info-ltr_rtl_mixed.png
+++ b/parley/tests/snapshots/test_cluster_info-ltr_rtl_mixed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b78a29d1f5a421afeb15369cfc1ea523c6c627f312d27b15249bd67c1deafd7
+size 3078

--- a/parley/tests/snapshots/test_cluster_info-newlines.png
+++ b/parley/tests/snapshots/test_cluster_info-newlines.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b61687b6a0d013254ce9b8757bdbec6487e030489e70a2f82042bc633b5e34a2
+size 2410


### PR DESCRIPTION
I noticed that, although my manual tests were passing, the `source_char` used for a given cluster wasn't always correct. I think we were lucky (if that's the right word) that characters that contribute to a ligature typically mimic the properties of other characters in that ligature.

I think it's pretty tricky to ensure that returned clusters are correct so I've added a new snapshot type enabled via `check_cluster_snapshot` which tries to visualise cluster information (and ensure correct `text_len`). This should make `push_run` more resilient to regressions and maintenance easier.

<img width="1872" height="550" alt="image" src="https://github.com/user-attachments/assets/c9c67bf1-90af-4f50-8fb8-677a9dbfa00d" />


