### PR TITLE
Cache HarfRust structs

### DIFF
--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -107,6 +107,7 @@ mod builder;
 mod context;
 mod font;
 mod inline_box;
+mod lru_cache;
 mod resolve;
 mod shape;
 mod swash_convert;

--- a/parley/src/lru_cache.rs
+++ b/parley/src/lru_cache.rs
@@ -1,0 +1,184 @@
+/// A lookup key is distinct from the ID type. This allows the lookup key
+/// to not require ownership of the underlying ID data, which could require
+/// allocations.
+pub(crate) trait LookupKey<ID> {
+    fn eq(&self, other: &ID) -> bool;
+    fn to_id(self) -> ID;
+}
+
+/// An entry in the cache.
+pub(crate) struct Entry<ID, T> {
+    pub epoch: u64,
+    pub id: ID,
+    pub data: T,
+}
+
+/// A least-recently-used cache. This cache uses a linear scan of its entries
+/// to find a given entry - it is optimised for a low number of entries. Preferably
+/// keep `max_entries` low in the order of tens.
+pub(crate) struct LruCache<ID, T> {
+    entries: Vec<Entry<ID, T>>,
+    epoch: u64,
+    max_entries: usize,
+}
+
+impl<ID, T> LruCache<ID, T> {
+    pub(crate) fn new(max_entries: usize) -> Self {
+        Self {
+            entries: Default::default(),
+            epoch: 0,
+            max_entries,
+        }
+    }
+
+    /// Returns a reference to the entry with the given ID. If the entry is not
+    /// found, it is created and returned using `make_data`.
+    pub(crate) fn entry<'a>(
+        &'a mut self,
+        id: impl LookupKey<ID>,
+        make_data: impl FnOnce() -> T,
+    ) -> &'a T {
+        match self.find_entry(id, make_data) {
+            (true, index) => {
+                let entry = &mut self.entries[index];
+                entry.epoch = self.epoch;
+                &entry.data
+            }
+            (false, index) => {
+                self.epoch += 1;
+                let entry = &mut self.entries[index];
+                entry.epoch = self.epoch;
+                &entry.data
+            }
+        }
+    }
+
+    fn find_entry(
+        &mut self,
+        id: impl LookupKey<ID>,
+        make_data: impl FnOnce() -> T,
+    ) -> (bool, usize) {
+        let epoch = self.epoch;
+        let mut lowest_serial = epoch;
+        let mut lowest_index = 0;
+        for (i, entry) in self.entries.iter().enumerate() {
+            if id.eq(&entry.id) {
+                return (true, i);
+            }
+            if entry.epoch < lowest_serial {
+                lowest_serial = entry.epoch;
+                lowest_index = i;
+            }
+        }
+        if self.entries.len() < self.max_entries {
+            lowest_index = self.entries.len();
+            self.entries.push(Entry {
+                epoch,
+                id: id.to_id(),
+                data: make_data(),
+            });
+        } else {
+            let entry = &mut self.entries[lowest_index];
+            entry.epoch = epoch;
+            entry.id = id.to_id();
+            entry.data = make_data();
+        }
+        (false, lowest_index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Simple ID type for testing
+    #[derive(Debug, Clone, PartialEq)]
+    struct TestId(String);
+
+    // LookupKey implementation that allows &str to lookup TestId
+    struct TestLookupKey<'a>(&'a str);
+
+    impl<'a> LookupKey<TestId> for TestLookupKey<'a> {
+        fn eq(&self, other: &TestId) -> bool {
+            self.0 == other.0.as_str()
+        }
+
+        fn to_id(self) -> TestId {
+            TestId(self.0.to_string())
+        }
+    }
+
+    // Alternative implementation for owned strings
+    impl LookupKey<TestId> for TestId {
+        fn eq(&self, other: &TestId) -> bool {
+            self.0 == other.0
+        }
+
+        fn to_id(self) -> TestId {
+            self
+        }
+    }
+
+    #[test]
+    fn test_retrieve_existing_entry() {
+        let mut cache = LruCache::new(3);
+
+        // Insert an entry
+        let value1 = cache.entry(TestLookupKey("key1"), || 42);
+        assert_eq!(*value1, 42);
+
+        // Retrieve the same entry - make_data should not be called
+        let value2 = cache.entry(TestLookupKey("key1"), || {
+            panic!("Should not create new data")
+        });
+        assert_eq!(*value2, 42);
+        assert_eq!(cache.entries.len(), 1);
+    }
+
+    #[test]
+    fn test_multiple_entries() {
+        let mut cache = LruCache::new(3);
+
+        let value1 = cache.entry(TestLookupKey("key1"), || 1);
+        assert_eq!(*value1, 1);
+
+        let value2 = cache.entry(TestLookupKey("key2"), || 2);
+        assert_eq!(*value2, 2);
+
+        let value3 = cache.entry(TestLookupKey("key3"), || 3);
+        assert_eq!(*value3, 3);
+
+        assert_eq!(cache.entries.len(), 3);
+        assert_eq!(cache.epoch, 3);
+    }
+
+    #[test]
+    fn test_lru_eviction() {
+        let mut cache = LruCache::new(3);
+
+        // Add three entries
+        cache.entry(TestLookupKey("key1"), || 1);
+        cache.entry(TestLookupKey("key2"), || 2);
+        cache.entry(TestLookupKey("key3"), || 3);
+
+        // Access key1 to update its epoch
+        cache.entry(TestLookupKey("key1"), || panic!("Should not create"));
+
+        // Add key4 - should evict key2 (oldest untouched)
+        cache.entry(TestLookupKey("key4"), || 4);
+
+        // Verify key1 is still present
+        let value1 = cache.entry(TestLookupKey("key1"), || {
+            panic!("key1 should still be present")
+        });
+        assert_eq!(*value1, 1);
+
+        // Verify key2 was evicted
+        let mut was_created = false;
+        cache.entry(TestLookupKey("key2"), || {
+            was_created = true;
+            20
+        });
+        assert!(was_created, "key2 should have been evicted");
+    }
+}

--- a/parley/src/shape/cache.rs
+++ b/parley/src/shape/cache.rs
@@ -1,0 +1,124 @@
+use crate::{
+    FontVariation,
+    lru_cache::{LookupKey, LruCache},
+};
+
+/// A cache of `ShaperData` instances.
+pub(crate) type ShapeDataCache = LruCache<u64, harfrust::ShaperData>;
+pub(crate) struct ShapeDataKey {
+    font_id: u64,
+}
+
+impl ShapeDataKey {
+    pub(crate) fn new(font_id: u64) -> Self {
+        Self { font_id }
+    }
+}
+
+impl LookupKey<u64> for ShapeDataKey {
+    fn eq(&self, other: &u64) -> bool {
+        self.font_id == *other
+    }
+    fn to_id(self) -> u64 {
+        self.font_id
+    }
+}
+
+/// A cache of `ShaperInstance` instances.
+pub(crate) type ShapeInstanceCache = LruCache<ShapeInstanceId, harfrust::ShaperInstance>;
+type ShapeInstanceId = (u64, fontique::Synthesis, Option<Box<[FontVariation]>>);
+
+pub(crate) struct ShapeInstanceKey<'a> {
+    font_id: u64,
+    synthesis: &'a fontique::Synthesis,
+    variations: Option<&'a [FontVariation]>,
+}
+
+impl<'a> ShapeInstanceKey<'a> {
+    pub(crate) fn new(
+        font_id: u64,
+        synthesis: &'a fontique::Synthesis,
+        variations: Option<&'a [FontVariation]>,
+    ) -> Self {
+        Self {
+            font_id,
+            synthesis,
+            variations,
+        }
+    }
+}
+
+impl<'a> LookupKey<ShapeInstanceId> for ShapeInstanceKey<'a> {
+    fn eq(&self, other: &ShapeInstanceId) -> bool {
+        self.font_id == other.0
+            && *self.synthesis == other.1
+            && self.variations == other.2.as_deref()
+    }
+    fn to_id(self) -> ShapeInstanceId {
+        (
+            self.font_id,
+            self.synthesis.clone(),
+            self.variations.map(|v| v.to_vec().into()),
+        )
+    }
+}
+
+/// A cache of `ShapePlan` instances.
+pub(crate) type ShapePlanCache = LruCache<ShapePlanId, harfrust::ShapePlan>;
+type ShapePlanId = (
+    u64,
+    harfrust::Direction,
+    harfrust::Script,
+    Option<harfrust::Language>,
+    Box<[harfrust::Feature]>,
+);
+
+pub(crate) struct ShapePlanKey<'a> {
+    font_id: u64,
+    direction: harfrust::Direction,
+    script: harfrust::Script,
+    language: Option<harfrust::Language>,
+    features: &'a [harfrust::Feature],
+}
+
+impl<'a> ShapePlanKey<'a> {
+    pub(crate) fn new(
+        font_id: u64,
+        direction: harfrust::Direction,
+        script: harfrust::Script,
+        language: Option<harfrust::Language>,
+        features: &'a [harfrust::Feature],
+    ) -> Self {
+        Self {
+            font_id,
+            direction,
+            script,
+            language,
+            features,
+        }
+    }
+}
+
+impl<'a> LookupKey<ShapePlanId> for ShapePlanKey<'a> {
+    fn eq(&self, other: &ShapePlanId) -> bool {
+        self.font_id == other.0
+            && self.direction == other.1
+            && self.script == other.2
+            && self.language == other.3
+            && self.features.len() == other.4.len()
+            && self
+                .features
+                .iter()
+                .zip(other.4.iter())
+                .all(|(a, b)| a == b)
+    }
+    fn to_id(self) -> ShapePlanId {
+        (
+            self.font_id,
+            self.direction,
+            self.script,
+            self.language,
+            self.features.to_vec().into(),
+        )
+    }
+}

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -13,6 +13,7 @@ use super::layout::Layout;
 use super::resolve::{RangedStyle, ResolveContext, Resolved};
 use super::style::{Brush, FontFeature, FontVariation};
 use crate::inline_box::InlineBox;
+use crate::lru_cache::LruCache;
 use crate::util::nearly_eq;
 use crate::{Font, swash_convert};
 
@@ -20,14 +21,23 @@ use fontique::{self, Query, QueryFamily, QueryFont};
 use swash::text::cluster::{CharCluster, CharInfo, Token};
 use swash::text::{Language, Script};
 
+mod cache;
+
 pub(crate) struct ShapeContext {
+    shape_data_cache: cache::ShapeDataCache,
+    shape_instance_cache: cache::ShapeInstanceCache,
+    shape_plan_cache: cache::ShapePlanCache,
     unicode_buffer: Option<harfrust::UnicodeBuffer>,
     features: Vec<harfrust::Feature>,
 }
 
 impl Default for ShapeContext {
     fn default() -> Self {
+        const MAX_ENTRIES: usize = 16;
         Self {
+            shape_data_cache: LruCache::new(MAX_ENTRIES),
+            shape_instance_cache: LruCache::new(MAX_ENTRIES),
+            shape_plan_cache: LruCache::new(MAX_ENTRIES),
             unicode_buffer: Some(harfrust::UnicodeBuffer::new()),
             features: Vec::new(),
         }
@@ -281,18 +291,74 @@ fn shape_item<'a, B: Brush>(
             harfrust::FontRef::from_index(font.font.blob.as_ref(), font.font.index).unwrap();
 
         // Create harfrust shaper
-        // TODO: cache this upstream?
-        let shaper_data = harfrust::ShaperData::new(&font_ref);
-        let instance = harfrust::ShaperInstance::from_variations(
-            &font_ref,
-            variations_iter(&font.font.synthesis, rcx.variations(item.variations)),
+        let shaper_data = scx
+            .shape_data_cache
+            .entry(cache::ShapeDataKey::new(font.font.blob.id()), || {
+                harfrust::ShaperData::new(&font_ref)
+            });
+        let instance = scx.shape_instance_cache.entry(
+            cache::ShapeInstanceKey::new(
+                font.font.blob.id(),
+                &font.font.synthesis,
+                rcx.variations(item.variations),
+            ),
+            || {
+                harfrust::ShaperInstance::from_variations(
+                    &font_ref,
+                    variations_iter(&font.font.synthesis, rcx.variations(item.variations)),
+                )
+            },
         );
-        // TODO: Don't create a new shaper for each segment.
+
+        // TODO: Cache `ShapePlan`
+
+        let direction = if item.level & 1 != 0 {
+            harfrust::Direction::RightToLeft
+        } else {
+            harfrust::Direction::LeftToRight
+        };
+        let script = swash_convert::script_to_harfrust(item.script);
+        let language = if let Some(lang) = item.locale {
+            let lang_tag = lang.language();
+            if let Ok(harf_lang) = lang_tag.parse::<harfrust::Language>() {
+                Some(harf_lang)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        scx.features.clear();
+        for feature in rcx.features(item.features).unwrap_or(&[]) {
+            scx.features.push(harfrust::Feature::new(
+                harfrust::Tag::from_u32(feature.tag),
+                feature.value as u32,
+                ..,
+            ));
+        }
         let harf_shaper = shaper_data
             .shaper(&font_ref)
             .instance(Some(&instance))
             .point_size(Some(item.size))
             .build();
+        let shaper_plan = scx.shape_plan_cache.entry(
+            cache::ShapePlanKey::new(
+                font.font.blob.id(),
+                direction,
+                script,
+                language.clone(),
+                &scx.features,
+            ),
+            || {
+                harfrust::ShapePlan::new(
+                    &harf_shaper,
+                    direction,
+                    Some(script),
+                    language.as_ref(),
+                    &scx.features,
+                )
+            },
+        );
 
         // Prepare harfrust buffer
         let mut buffer = mem::take(&mut scx.unicode_buffer).unwrap();
@@ -311,33 +377,15 @@ fn shape_item<'a, B: Brush>(
             buffer.add(ch, i as u32);
         }
 
-        let direction = if item.level & 1 != 0 {
-            harfrust::Direction::RightToLeft
-        } else {
-            harfrust::Direction::LeftToRight
-        };
         buffer.set_direction(direction);
 
-        let script = swash_convert::script_to_harfrust(item.script);
         buffer.set_script(script);
 
-        if let Some(lang) = item.locale {
-            let lang_tag = lang.language();
-            if let Ok(harf_lang) = lang_tag.parse::<harfrust::Language>() {
-                buffer.set_language(harf_lang);
-            }
+        if let Some(lang) = language {
+            buffer.set_language(lang);
         }
 
-        scx.features.clear();
-        for feature in rcx.features(item.features).unwrap_or(&[]) {
-            scx.features.push(harfrust::Feature::new(
-                harfrust::Tag::from_u32(feature.tag),
-                feature.value as u32,
-                0..buffer.len(),
-            ));
-        }
-
-        let glyph_buffer = harf_shaper.shape(buffer, &scx.features);
+        let glyph_buffer = harf_shaper.shape_with_plan(&shaper_plan, buffer, &scx.features);
 
         // Extract relevant CharInfo slice for this segment
         let char_start = char_range.start + item_text[..segment_start_offset].chars().count();


### PR DESCRIPTION
Caches HarfRust `ShapeData`, `ShaperInstance`, and `ShapePlan`s using an LRU inspired by Swash's implementation.