### PR TITLE
Restore the Rust Code Of Conduct link

### DIFF
--- a/parley/README.md
+++ b/parley/README.md
@@ -51,3 +51,5 @@ Licensed under either of
 - MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
+
+[Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct


### PR DESCRIPTION
Was removed in https://github.com/linebender/parley/pull/405