### PR TITLE
Cache charmaps

### DIFF
--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -529,7 +529,6 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
             let Ok(font_ref) = skrifa::FontRef::from_index(font.blob.as_ref(), font.index) else {
                 return fontique::QueryStatus::Continue;
             };
-
             let charmap = charmap_cache.get(font.blob.id(), &font_ref);
 
             let map_status = cluster.map(|ch| {


### PR DESCRIPTION
Caches charmap construction.

We should see even greater gains when https://github.com/googlefonts/fontations/pull/1647 is pulled in. I saw this function show up unnecessarily in profiles (we recompute it in our cache currently), so I'm hopeful to see more gains with its incorporation.

## Results

<img width="739" height="350" alt="image" src="https://github.com/user-attachments/assets/ae391d7f-8dd6-4693-af4f-725cf69ed059" />

### Blitz

Before

18ms pconstruct

<img width="721" height="44" alt="image" src="https://github.com/user-attachments/assets/837607d0-288b-415c-a24c-2bb33b0ddc4c" />

After

7ms pconstruct

<img width="726" height="41" alt="image" src="https://github.com/user-attachments/assets/48503e4c-9cc1-42c9-8f34-57019b214596" />
