### PR TITLE
Cache charmap metadata in fontique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This release has an [MSRV] of 1.82.
 - Shift-click support through `Selection::shift_click_extension` and `PlainEditorDriver::shift_click_extension`. ([#385][] by [@kekelp][])
 - Benchmarks. ([#405]() by [@taj-p][])
 
+#### Fontique
+
+- Cache character mapping metadata for each font to improve performance of font selection. ([#413][] by [@dfrg][])
+
 ### Changed
 
 #### Parley
@@ -328,6 +332,7 @@ This release has an [MSRV][] of 1.70.
 [#400]: https://github.com/linebender/parley/pull/400
 [#402]: https://github.com/linebender/parley/pull/402
 [#405]: https://github.com/linebender/parley/pull/405
+[#413]: https://github.com/linebender/parley/pull/413
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.5.0...HEAD
 [0.5.0]: https://github.com/linebender/parley/compare/v0.4.0...v0.5.0

--- a/fontique/src/charmap.rs
+++ b/fontique/src/charmap.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use read_fonts::{
     FontData, FontRead, FontRef, TableProvider, TopLevelTable,
     tables::cmap::{Cmap, CmapSubtable},

--- a/fontique/src/charmap.rs
+++ b/fontique/src/charmap.rs
@@ -1,0 +1,120 @@
+use read_fonts::{
+    FontData, FontRead, FontRef, TableProvider, TopLevelTable,
+    tables::cmap::{Cmap, CmapSubtable},
+    types::GlyphId,
+};
+
+/// Metadata for constructing a character map from font data.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct CharmapIndex {
+    subtable_offset: u32,
+    is_symbol: bool,
+    is_mac_roman: bool,
+}
+
+impl CharmapIndex {
+    pub(crate) fn new(font: &FontRef<'_>) -> Option<Self> {
+        let cmap = font.cmap().ok()?;
+        let cmap_offset = font
+            .table_directory()
+            .table_records()
+            .iter()
+            .find(|rec| rec.tag() == Cmap::TAG)
+            .map(|rec| rec.offset())?;
+        let (_, rec, _) = cmap.best_subtable()?;
+        let subtable_offset = cmap_offset.checked_add(rec.subtable_offset().to_u32())?;
+        Some(Self {
+            subtable_offset,
+            is_symbol: rec.is_symbol(),
+            is_mac_roman: rec.is_mac_roman(),
+        })
+    }
+
+    /// Creates a character map from the given font data.
+    pub fn charmap<'a>(&self, font_data: &'a [u8]) -> Option<Charmap<'a>> {
+        let subtable_data = font_data.get(self.subtable_offset as usize..)?;
+        let subtable = CmapSubtable::read(FontData::new(subtable_data)).ok()?;
+        Some(Charmap {
+            subtable,
+            is_symbol: self.is_symbol,
+            is_mac_roman: self.is_mac_roman,
+        })
+    }
+}
+
+/// Mapping from Unicode codepoints to nominal glyph identifiers.
+#[derive(Clone)]
+pub struct Charmap<'a> {
+    subtable: CmapSubtable<'a>,
+    is_symbol: bool,
+    is_mac_roman: bool,
+}
+
+impl Charmap<'_> {
+    /// Returns the glyph identifier for the given codepoint.
+    pub fn map(&self, codepoint: impl Into<u32>) -> Option<u32> {
+        let mut c = codepoint.into();
+        if self.is_mac_roman && c > 0x7F {
+            c = unicode_to_mac_roman(c);
+        }
+        let result = match &self.subtable {
+            CmapSubtable::Format0(table) => table.map_codepoint(c),
+            CmapSubtable::Format6(table) => table.map_codepoint(c),
+            CmapSubtable::Format10(table) => {
+                if let Some(index) = c.checked_sub(table.start_char_code()) {
+                    if index < table.num_chars() {
+                        table
+                            .glyph_id_array()
+                            .get(index as usize)
+                            .map(|gid| GlyphId::from(gid.get()))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+            CmapSubtable::Format4(table) => table.map_codepoint(c),
+            CmapSubtable::Format12(table) => table.map_codepoint(c),
+            CmapSubtable::Format13(table) => table.map_codepoint(c),
+            _ => None,
+        };
+        if result.is_none() && self.is_symbol && c <= 0x00FF {
+            // For symbol-encoded OpenType fonts, we duplicate the
+            // U+F000..F0FF range at U+0000..U+00FF.  That's what
+            // Windows seems to do, and that's hinted about at:
+            // https://docs.microsoft.com/en-us/typography/opentype/spec/recom
+            // under "Non-Standard (Symbol) Fonts".
+            return self.map(0xF000 + c);
+        }
+        result.map(|gid| gid.to_u32())
+    }
+}
+
+#[rustfmt::skip]
+static UNICODE_TO_MAC_ROMAN: &[u16] = &[
+    0x00C4, 0x00C5, 0x00C7, 0x00C9, 0x00D1, 0x00D6, 0x00DC, 0x00E1,
+    0x00E0, 0x00E2, 0x00E4, 0x00E3, 0x00E5, 0x00E7, 0x00E9, 0x00E8,
+    0x00EA, 0x00EB, 0x00ED, 0x00EC, 0x00EE, 0x00EF, 0x00F1, 0x00F3,
+    0x00F2, 0x00F4, 0x00F6, 0x00F5, 0x00FA, 0x00F9, 0x00FB, 0x00FC,
+    0x2020, 0x00B0, 0x00A2, 0x00A3, 0x00A7, 0x2022, 0x00B6, 0x00DF,
+    0x00AE, 0x00A9, 0x2122, 0x00B4, 0x00A8, 0x2260, 0x00C6, 0x00D8,
+    0x221E, 0x00B1, 0x2264, 0x2265, 0x00A5, 0x00B5, 0x2202, 0x2211,
+    0x220F, 0x03C0, 0x222B, 0x00AA, 0x00BA, 0x03A9, 0x00E6, 0x00F8,
+    0x00BF, 0x00A1, 0x00AC, 0x221A, 0x0192, 0x2248, 0x2206, 0x00AB,
+    0x00BB, 0x2026, 0x00A0, 0x00C0, 0x00C3, 0x00D5, 0x0152, 0x0153,
+    0x2013, 0x2014, 0x201C, 0x201D, 0x2018, 0x2019, 0x00F7, 0x25CA,
+    0x00FF, 0x0178, 0x2044, 0x20AC, 0x2039, 0x203A, 0xFB01, 0xFB02,
+    0x2021, 0x00B7, 0x201A, 0x201E, 0x2030, 0x00C2, 0x00CA, 0x00C1,
+    0x00CB, 0x00C8, 0x00CD, 0x00CE, 0x00CF, 0x00CC, 0x00D3, 0x00D4,
+    0xF8FF, 0x00D2, 0x00DA, 0x00DB, 0x00D9, 0x0131, 0x02C6, 0x02DC,
+    0x00AF, 0x02D8, 0x02D9, 0x02DA, 0x00B8, 0x02DD, 0x02DB, 0x02C7,
+];
+
+fn unicode_to_mac_roman(c: u32) -> u32 {
+    let u = c as u16;
+    let Some(index) = UNICODE_TO_MAC_ROMAN.iter().position(|m| *m == u) else {
+        return 0;
+    };
+    (0x80 + index) as u32
+}

--- a/fontique/src/collection/query.rs
+++ b/fontique/src/collection/query.rs
@@ -3,6 +3,8 @@
 
 //! Query support.
 
+use crate::{Charmap, CharmapIndex};
+
 use super::super::{Collection, SourceCache};
 
 use alloc::vec::Vec;
@@ -219,6 +221,15 @@ pub struct QueryFont {
     pub index: u32,
     /// Synthesis suggestions for this font based on the requested attributes.
     pub synthesis: Synthesis,
+    /// Data used for constructing a character map for this font.
+    pub charmap_index: CharmapIndex,
+}
+
+impl QueryFont {
+    /// Attempts to construct a [Charmap] for this font.
+    pub fn charmap(&self) -> Option<Charmap<'_>> {
+        self.charmap_index.charmap(self.blob.as_ref())
+    }
 }
 
 fn load_font<'a>(
@@ -250,6 +261,7 @@ fn load_font<'a>(
                 blob: blob.clone(),
                 index: blob_index,
                 synthesis,
+                charmap_index: font_info.charmap_index(),
             });
             if let Entry::Ok(font) = status {
                 Some(font)

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -35,6 +35,7 @@ extern crate alloc;
 
 mod attributes;
 mod backend;
+mod charmap;
 mod collection;
 mod fallback;
 mod family;
@@ -52,6 +53,7 @@ pub use icu_locid::LanguageIdentifier as Language;
 pub use peniko::Blob;
 
 pub use attributes::{Attributes, FontStyle, FontWeight, FontWidth};
+pub use charmap::{Charmap, CharmapIndex};
 pub use collection::{Collection, CollectionOptions, Query, QueryFamily, QueryFont, QueryStatus};
 pub use fallback::FallbackKey;
 pub use family::{FamilyId, FamilyInfo};

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -527,7 +527,11 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
                     .map(ch)
                     .map(|g| {
                         // HACK: in reality, we're only using swash to compute
-                        // coverage so the actual gid doesn't matter
+                        // coverage so we only care about whether the font
+                        // has a mapping for a particular glyph. Any non-zero
+                        // value indicates the existence of a glyph so we can
+                        // simplify this without a fallible conversion from u32
+                        // to u16.
                         (g != 0) as u16
                     })
                     .unwrap_or_default()

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -516,21 +516,19 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
         }
         let mut selected_font = None;
         self.query.matches_with(|font| {
-            use skrifa::MetadataProvider;
             use swash::text::cluster::Status as MapStatus;
 
-            let Ok(font_ref) = skrifa::FontRef::from_index(font.blob.as_ref(), font.index) else {
+            let Some(charmap) = font.charmap() else {
                 return fontique::QueryStatus::Continue;
             };
 
-            let charmap = font_ref.charmap();
             let map_status = cluster.map(|ch| {
                 charmap
                     .map(ch)
                     .map(|g| {
-                        g.to_u32()
-                            .try_into()
-                            .expect("Swash requires u16 glyph, so we hope that the glyph fits")
+                        // HACK: in reality, we're only using swash to compute
+                        // coverage so the actual gid doesn't matter
+                        (g != 0) as u16
                     })
                     .unwrap_or_default()
             });


### PR DESCRIPTION
And use this in parley for font selection. This is an alternative to #412.

@nicoburns care to check the performance of this one?