### PR TITLE
Remove kurbo and peniko dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,14 @@ This release has an [MSRV] of 1.82.
 - `Alignment`` variants have been renamed to better match CSS. `Alignment::Justified` is now `Alignment::Justify` and `Alignment::Middle` is now `Alignment::Center`. ([#389][] by [@waywardmonkeys][])
 - Updated to `accesskit` 0.21. ([#390][] by [@mwcampbell][])
 - Uses `HarfRust` for text shaping ([[#400][] by [@taj-p][]).
+- Fontique no longer depends on `peniko` or `kurbo`:
+   - The use of `peniko::Font` has been replaced with `linebender_resource_handle::Font`. This is unlikely to affect users of the crate.
+   - The use of `kurbo::Rect` has been replaced with a new `parley::BoundingBox` type.
 
 #### Fontique
 
 - The fontconfig backend, used to enumerate system fonts on Linux, has been rewritten to call into the system's fontconfig library instead of parsing fontconfig's configuration files itself. This should significantly improve the behavior of system fonts and generic families on Linux. ([#378][] by [@valadaptive][])
+- Fontique no longer depends on `peniko`. The use of `peniko::Blob` has been replaced with `linebender_resource_handle::Blob`. This is unlikely to affect users of the crate.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,12 +1181,12 @@ dependencies = [
  "hashbrown",
  "icu_locale_core",
  "icu_properties",
+ "linebender_resource_handle",
  "memmap2",
  "objc2 0.6.1",
  "objc2-core-foundation",
  "objc2-core-text",
  "objc2-foundation 0.3.1",
- "peniko",
  "read-fonts 0.34.0",
  "roxmltree",
  "smallvec",
@@ -1932,6 +1932,12 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.12",
 ]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b443df28f3fa8b5bc32ada6daca59994b34ef37e061b4232f367db69408d83b6"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2682,6 +2688,7 @@ dependencies = [
  "fontique",
  "harfrust",
  "hashbrown",
+ "linebender_resource_handle",
  "parley_dev",
  "peniko",
  "skrifa 0.36.0",
@@ -2715,12 +2722,13 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peniko"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f9529efd019889b2a205193c14ffb6e2839b54ed9d2720674f10f4b04d87ac9"
+checksum = "9b44f9ddd2f480176b34278eb653ec1c8062f3b143a4e16eeff5ffac3334e288"
 dependencies = [
  "color",
  "kurbo",
+ "linebender_resource_handle",
  "smallvec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ bytemuck = { version = "1.23.0", default-features = false }
 fontique = { version = "0.5.0", default-features = false, path = "fontique" }
 harfrust = { version = "0.2.0", default-features = false }
 hashbrown = "0.15.3"
+linebender_resource_handle = { version = "0.1.0", default-features = false }
 parley = { version = "0.5.0", default-features = false, path = "parley" }
 parley_dev = { version = "0.0.0", default-features = false, path = "parley_dev" }
 peniko = { version = "0.4.0", default-features = false }

--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -16,7 +16,6 @@ use anyhow::Result;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use ui_events_winit::{WindowEventReducer, WindowEventTranslation};
-use vello::kurbo;
 use vello::peniko::Color;
 use vello::util::{RenderContext, RenderSurface};
 use vello::wgpu;
@@ -100,7 +99,7 @@ struct SimpleVelloApp<'s> {
     last_drawn_generation: text::Generation,
 
     /// The IME cursor area we last sent to the platform.
-    last_sent_ime_cursor_area: kurbo::Rect,
+    last_sent_ime_cursor_area: parley::BoundingBox,
 
     /// The event loop proxy required by the AccessKit winit adapter.
     event_loop_proxy: EventLoopProxy<accesskit_winit::Event>,
@@ -405,7 +404,7 @@ fn main() -> Result<()> {
         scene: Scene::new(),
         editor: text::Editor::new(text::LOREM),
         last_drawn_generation: Default::default(),
-        last_sent_ime_cursor_area: kurbo::Rect::new(f64::NAN, f64::NAN, f64::NAN, f64::NAN),
+        last_sent_ime_cursor_area: parley::BoundingBox::new(f64::NAN, f64::NAN, f64::NAN, f64::NAN),
         event_loop_proxy: event_loop.create_proxy(),
         event_reducer: Default::default(),
     };

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -39,6 +39,10 @@ pub struct Editor {
     blink_period: Duration,
 }
 
+fn convert_rect(rect: &parley::BoundingBox) -> peniko::kurbo::Rect {
+    peniko::kurbo::Rect::new(rect.x0, rect.y0, rect.x1, rect.y1)
+}
+
 impl Editor {
     pub fn new(text: &str) -> Self {
         let mut editor = PlainEditor::new(32.0);
@@ -337,12 +341,18 @@ impl Editor {
                 transform,
                 palette::css::STEEL_BLUE,
                 None,
-                &rect,
+                &convert_rect(&rect),
             );
         });
         if self.cursor_visible {
             if let Some(cursor) = self.editor.cursor_geometry(1.5) {
-                scene.fill(Fill::NonZero, transform, palette::css::WHITE, None, &cursor);
+                scene.fill(
+                    Fill::NonZero,
+                    transform,
+                    palette::css::WHITE,
+                    None,
+                    &convert_rect(&cursor),
+                );
             }
         }
         let layout = self.editor.layout(&mut self.font_cx, &mut self.layout_cx);

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [features]
 default = ["system"]
-std = ["read-fonts/std", "linebender_resource_handle/std", "dep:memmap2"]
+std = ["read-fonts/std", "dep:memmap2"]
 libm = ["read-fonts/libm", "dep:core_maths"]
 icu_properties = ["dep:icu_properties"]
 unicode_script = ["dep:unicode-script"]

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -17,8 +17,8 @@ workspace = true
 
 [features]
 default = ["system"]
-std = ["read-fonts/std", "peniko/std", "dep:memmap2"]
-libm = ["read-fonts/libm", "peniko/libm", "dep:core_maths"]
+std = ["read-fonts/std", "linebender_resource_handle/std", "dep:memmap2"]
+libm = ["read-fonts/libm", "dep:core_maths"]
 icu_properties = ["dep:icu_properties"]
 unicode_script = ["dep:unicode-script"]
 # Enables support for system font backends
@@ -37,7 +37,7 @@ system = [
 [dependencies]
 bytemuck = { workspace = true }
 read-fonts = { workspace = true }
-peniko = { workspace = true }
+linebender_resource_handle = { workspace = true }
 smallvec = "1.15.0"
 memmap2 = { version = "0.9.5", optional = true }
 unicode-script = { version = "0.5.7", optional = true }

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -50,7 +50,7 @@ mod source;
 mod source_cache;
 
 pub use icu_locale_core::LanguageIdentifier as Language;
-pub use peniko::Blob;
+pub use linebender_resource_handle::Blob;
 
 pub use attributes::{Attributes, FontStyle, FontWeight, FontWidth};
 pub use charmap::{Charmap, CharmapIndex};

--- a/fontique/src/source.rs
+++ b/fontique/src/source.rs
@@ -4,7 +4,7 @@
 //! Model for font data.
 
 use core::sync::atomic::{AtomicU64, Ordering};
-use peniko::Blob;
+use linebender_resource_handle::Blob;
 #[cfg(feature = "std")]
 use {
     hashbrown::HashMap,

--- a/fontique/src/source_cache.rs
+++ b/fontique/src/source_cache.rs
@@ -8,9 +8,9 @@ use super::source::SourceId;
 use super::source::{SourceInfo, SourceKind};
 #[cfg(feature = "std")]
 use hashbrown::HashMap;
-use peniko::Blob;
+use linebender_resource_handle::Blob;
 #[cfg(feature = "std")]
-use peniko::WeakBlob;
+use linebender_resource_handle::WeakBlob;
 #[cfg(feature = "std")]
 use std::{
     path::Path,

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -18,13 +18,7 @@ workspace = true
 
 [features]
 default = ["system"]
-std = [
-    "fontique/std",
-    "harfrust/std",
-    "peniko/std",
-    "skrifa/std",
-    "swash/std",
-]
+std = ["fontique/std", "harfrust/std", "peniko/std", "skrifa/std", "swash/std"]
 libm = ["fontique/libm", "peniko/libm", "skrifa/libm", "swash/libm", "dep:core_maths"]
 # Enables support for system font backends
 system = ["std", "fontique/system"]

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -21,7 +21,6 @@ default = ["system"]
 std = [
     "fontique/std",
     "harfrust/std",
-    "linebender_resource_handle/std",
     "peniko/std",
     "skrifa/std",
     "swash/std",

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -18,7 +18,14 @@ workspace = true
 
 [features]
 default = ["system"]
-std = ["fontique/std", "harfrust/std", "peniko/std", "skrifa/std", "swash/std"]
+std = [
+    "fontique/std",
+    "harfrust/std",
+    "linebender_resource_handle/std",
+    "peniko/std",
+    "skrifa/std",
+    "swash/std",
+]
 libm = ["fontique/libm", "peniko/libm", "skrifa/libm", "swash/libm", "dep:core_maths"]
 # Enables support for system font backends
 system = ["std", "fontique/system"]
@@ -27,7 +34,7 @@ accesskit = ["dep:accesskit"]
 [dependencies]
 swash = { workspace = true }
 skrifa = { workspace = true }
-peniko = { workspace = true }
+linebender_resource_handle = { workspace = true }
 fontique = { workspace = true }
 core_maths = { version = "0.1.1", optional = true }
 accesskit = { workspace = true, optional = true }
@@ -36,4 +43,5 @@ harfrust = { workspace = true }
 
 [dev-dependencies]
 parley_dev = { workspace = true }
+peniko = { workspace = true }
 tiny-skia = "0.11.4"

--- a/parley/src/layout/editor.rs
+++ b/parley/src/layout/editor.rs
@@ -4,7 +4,7 @@
 //! A simple plain text editor and related types.
 
 use crate::{
-    FontContext, LayoutContext, Rect, StyleProperty, StyleSet,
+    BoundingBox, FontContext, LayoutContext, StyleProperty, StyleSet,
     layout::{
         Affinity, Alignment, AlignmentOptions, Layout,
         cursor::{Cursor, Selection},
@@ -860,7 +860,7 @@ where
 
     /// Get rectangles, and their corresponding line indices, representing the selected portions of
     /// text.
-    pub fn selection_geometry(&self) -> Vec<(Rect, usize)> {
+    pub fn selection_geometry(&self) -> Vec<(BoundingBox, usize)> {
         // We do not check `self.show_cursor` here, as the IME handling code collapses the
         // selection to a caret in that case.
         self.selection.geometry(&self.layout)
@@ -868,7 +868,7 @@ where
 
     /// Invoke a callback with each rectangle representing the selected portions of text, and the
     /// indices of the lines to which they belong.
-    pub fn selection_geometry_with(&self, f: impl FnMut(Rect, usize)) {
+    pub fn selection_geometry_with(&self, f: impl FnMut(BoundingBox, usize)) {
         // We do not check `self.show_cursor` here, as the IME handling code collapses the
         // selection to a caret in that case.
         self.selection.geometry_with(&self.layout, f);
@@ -878,7 +878,7 @@ where
     ///
     /// There is not always a caret. For example, the IME may have indicated the caret should be
     /// hidden.
-    pub fn cursor_geometry(&self, size: f32) -> Option<Rect> {
+    pub fn cursor_geometry(&self, size: f32) -> Option<BoundingBox> {
         self.show_cursor
             .then(|| self.selection.focus().geometry(&self.layout, size))
     }
@@ -888,7 +888,7 @@ where
     /// This is useful for suggesting an exclusion area to the platform for, e.g., IME candidate
     /// box placement. This bounds the area of the preedit text if present, otherwise it bounds the
     /// selection on the focused line.
-    pub fn ime_cursor_area(&self) -> Rect {
+    pub fn ime_cursor_area(&self) -> BoundingBox {
         let (area, focus) = if let Some(preedit_range) = &self.compose {
             let selection = Selection::new(
                 self.cursor_at(preedit_range.start),
@@ -930,7 +930,7 @@ where
         // Using 0.6 as an estimate of the average advance
         let inflate = 3. * 0.6 * font_size as f64;
         let editor_width = self.width.map(f64::from).unwrap_or(f64::INFINITY);
-        Rect {
+        BoundingBox {
             x0: (area.x0 - inflate).max(0.),
             x1: (area.x1 + inflate).min(editor_width),
             y0: area.y0,

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -119,8 +119,8 @@ pub mod style;
 #[cfg(test)]
 mod tests;
 
-pub use peniko::Font;
-pub use peniko::kurbo::Rect;
+pub use linebender_resource_handle::FontData as Font;
+pub use util::BoundingBox;
 
 pub use builder::{RangedBuilder, TreeBuilder};
 pub use context::LayoutContext;

--- a/parley/src/tests/test_lines.rs
+++ b/parley/src/tests/test_lines.rs
@@ -3,11 +3,12 @@
 
 //! Test line layouts, including the vertical size and positioning of the line box.
 
-use peniko::kurbo::{Rect, Size};
+use peniko::kurbo::Size;
 
 use super::utils::{ColorBrush, TestEnv};
 use crate::{
-    Affinity, Brush, Cursor, InlineBox, Layout, LineHeight, Selection, StyleProperty, test_name,
+    Affinity, BoundingBox, Brush, Cursor, InlineBox, Layout, LineHeight, Selection, StyleProperty,
+    test_name,
 };
 
 const TEXT: &str = "Some text here. Let's make\n\
@@ -49,7 +50,7 @@ fn ascent_descent_box_height(font_size: f32, line_height_px: f32) -> (f32, f32, 
 }
 
 /// Returns selection geometry such that every line is covered.
-fn get_selections<B: Brush>(layout: &Layout<B>) -> Vec<(Rect, usize)> {
+fn get_selections<B: Brush>(layout: &Layout<B>) -> Vec<(BoundingBox, usize)> {
     let selection_parts = [
         ("Some text here.", 4),
         ("a bit longer", 8),
@@ -125,7 +126,7 @@ fn compute(
     test_name: &str,
     font_size: f32,
     line_height_px: f32,
-) -> (TestEnv, Layout<ColorBrush>, Vec<(Rect, usize)>) {
+) -> (TestEnv, Layout<ColorBrush>, Vec<(BoundingBox, usize)>) {
     // Use max advance as the target width to ensure consistency in case of early line breaks
     let width = max_advance(font_size);
     // Calculate precise total height based on requested line height,

--- a/parley/src/tests/utils/env.rs
+++ b/parley/src/tests/utils/env.rs
@@ -5,8 +5,8 @@ use crate::tests::utils::renderer::{
     ColorBrush, RenderingConfig, render_layout, render_layout_with_clusters,
 };
 use crate::{
-    FontContext, FontFamily, FontStack, Layout, LayoutContext, LineHeight, PlainEditor,
-    PlainEditorDriver, RangedBuilder, Rect, StyleProperty, TextStyle, TreeBuilder,
+    BoundingBox, FontContext, FontFamily, FontStack, Layout, LayoutContext, LineHeight,
+    PlainEditor, PlainEditorDriver, RangedBuilder, StyleProperty, TextStyle, TreeBuilder,
 };
 use fontique::{Blob, Collection, CollectionOptions};
 use peniko::kurbo::Size;
@@ -298,8 +298,8 @@ impl TestEnv {
     pub(crate) fn render_and_check_snapshot(
         &mut self,
         layout: &Layout<ColorBrush>,
-        cursor_rect: Option<Rect>,
-        selection_rects: &[(Rect, usize)],
+        cursor_rect: Option<BoundingBox>,
+        selection_rects: &[(BoundingBox, usize)],
     ) {
         let current_img =
             render_layout(&self.rendering_config, layout, cursor_rect, selection_rects);

--- a/parley/src/tests/utils/renderer.rs
+++ b/parley/src/tests/utils/renderer.rs
@@ -66,8 +66,8 @@ fn draw_rect(pen: &mut TinySkiaPen<'_>, x: f32, y: f32, width: f32, height: f32,
 pub(crate) fn render_layout(
     config: &RenderingConfig,
     layout: &Layout<ColorBrush>,
-    cursor_rect: Option<crate::Rect>,
-    selection_rects: &[(crate::Rect, usize)],
+    cursor_rect: Option<crate::BoundingBox>,
+    selection_rects: &[(crate::BoundingBox, usize)],
 ) -> Pixmap {
     let padding = 20;
     let width = config

--- a/parley/src/util.rs
+++ b/parley/src/util.rs
@@ -14,3 +14,53 @@ pub(crate) fn nearly_eq(x: f32, y: f32) -> bool {
 pub(crate) fn nearly_zero(x: f32) -> bool {
     nearly_eq(x, 0.)
 }
+
+/// A bounding box.
+#[derive(Clone, Copy, Default, PartialEq)]
+pub struct BoundingBox {
+    /// The left edge
+    pub x0: f64,
+    /// The top edge
+    pub y0: f64,
+    /// The right edge
+    pub x1: f64,
+    /// The bottom edge
+    pub y1: f64,
+}
+
+impl BoundingBox {
+    /// A new bounding box from minimum and maximum coordinates.
+    #[inline(always)]
+    pub const fn new(x0: f64, y0: f64, x1: f64, y1: f64) -> Self {
+        Self { x0, y0, x1, y1 }
+    }
+
+    /// The width of the bounding box.
+    ///
+    /// Note: nothing forbids negative width.
+    #[inline]
+    pub fn width(&self) -> f64 {
+        self.x1 - self.x0
+    }
+
+    /// The height of the bounding box.
+    ///
+    /// Note: nothing forbids negative height.
+    #[inline]
+    pub fn height(&self) -> f64 {
+        self.y1 - self.y0
+    }
+
+    /// The smallest bounding box enclosing two bounding boxes.
+    ///
+    /// Results are valid only if width and height are non-negative.
+    #[inline]
+    pub fn union(&self, other: Self) -> Self {
+        Self::new(
+            self.x0.min(other.x0),
+            self.y0.min(other.y0),
+            self.x1.max(other.x1),
+            self.y1.max(other.y1),
+        )
+    }
+}

--- a/parley/src/util.rs
+++ b/parley/src/util.rs
@@ -18,13 +18,13 @@ pub(crate) fn nearly_zero(x: f32) -> bool {
 /// A bounding box.
 #[derive(Clone, Copy, Default, PartialEq)]
 pub struct BoundingBox {
-    /// The left edge
+    /// The left edge.
     pub x0: f64,
-    /// The top edge
+    /// The top edge.
     pub y0: f64,
-    /// The right edge
+    /// The right edge.
     pub x1: f64,
-    /// The bottom edge
+    /// The bottom edge.
     pub y1: f64,
 }
 


### PR DESCRIPTION
We should probably wait until we've backported `linebender_resource_handle` to `peniko` 0.4 to land this. Then the font/blob conversion code can disappear.

We may want to name `parley::Rect` something more specific like `parley::SelectionArea`

Depends on:
- https://github.com/linebender/parley/pull/415