### PR TITLE
Fix `clippy::obfuscated_if_else` lints

### DIFF
--- a/fontique/src/font.rs
+++ b/fontique/src/font.rs
@@ -430,14 +430,16 @@ fn read_attributes(font: &FontRef<'_>) -> (FontWidth, FontStyle, FontWeight) {
 
     fn from_head(head: Head<'_>) -> (FontWidth, FontStyle, FontWeight) {
         let mac_style = head.mac_style();
-        let style = mac_style
-            .contains(MacStyle::ITALIC)
-            .then_some(FontStyle::Italic)
-            .unwrap_or_default();
-        let weight = mac_style
-            .contains(MacStyle::BOLD)
-            .then_some(700.0)
-            .unwrap_or_default();
+        let style = if mac_style.contains(MacStyle::ITALIC) {
+            FontStyle::Italic
+        } else {
+            FontStyle::default()
+        };
+        let weight = if mac_style.contains(MacStyle::BOLD) {
+            700.0
+        } else {
+            0.0
+        };
         (FontWidth::default(), style, FontWeight::new(weight))
     }
 

--- a/parley/src/layout/cursor.rs
+++ b/parley/src/layout/cursor.rs
@@ -1050,14 +1050,16 @@ enum AnchorBase {
 }
 
 fn cursor_rect<B: Brush>(cluster: &Cluster<'_, B>, at_end: bool, size: f32) -> Rect {
-    let line_x = (cluster.visual_offset().unwrap_or_default()
-        + at_end.then(|| cluster.advance()).unwrap_or_default()) as f64;
+    let mut line_x = cluster.visual_offset().unwrap_or_default();
+    if at_end {
+        line_x += cluster.advance();
+    }
     let line = cluster.line();
     let metrics = line.metrics();
     Rect::new(
-        line_x,
+        line_x as f64,
         metrics.min_coord as f64,
-        line_x + size as f64,
+        (line_x + size) as f64,
         metrics.max_coord as f64,
     )
 }


### PR DESCRIPTION
Another round of clippy lint fixes for new rustc. Not sure that I love these changes (/this lint), but they're not egregious enough for me to want to fight against them.