### PR TITLE
[Fontique] Fix: fallback to `FontWeight::default()` rather than `FontWeight(0.0)`

### DIFF
--- a/fontique/src/font.rs
+++ b/fontique/src/font.rs
@@ -436,11 +436,11 @@ fn read_attributes(font: &FontRef<'_>) -> (FontWidth, FontStyle, FontWeight) {
             FontStyle::default()
         };
         let weight = if mac_style.contains(MacStyle::BOLD) {
-            700.0
+            FontWeight::BOLD
         } else {
-            0.0
+            FontWeight::default()
         };
-        (FontWidth::default(), style, FontWeight::new(weight))
+        (FontWidth::default(), style, weight)
     }
 
     if let Ok(os2) = font.os2() {


### PR DESCRIPTION
Noticed in https://github.com/linebender/parley/pull/415#discussion_r2349395111

Fontique currently uses `FontWeight(0.0)` (`f32::default()`) when it should probably be using `FontWeight(400.0)` (`FontWeight::default()`) as the fallback weight when the font is not bold.