### PR TITLE
Refer to HarfRust in Parley's crate README

### DIFF
--- a/parley/README.md
+++ b/parley/README.md
@@ -13,7 +13,7 @@
 </div>
 
 Parley provides an API for implementing rich text layout.
-It is backed by [Swash](https://github.com/dfrg/swash).
+It is backed by [HarfRust](https://github.com/harfbuzz/harfrust) for text shaping.
 
 ## Minimum supported Rust Version (MSRV)
 


### PR DESCRIPTION
The old wording is not technically incorrect, but [HarfRust](https://github.com/harfbuzz/harfrust) is the more important dependency now.