### PR TITLE
CI: use taiki-e/install-action to install ripgrep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,18 +89,13 @@ jobs:
       - name: Run taplo fmt
         run: taplo fmt --check --diff
 
-      - name: install ripgrep
-        run: |
-          sudo apt update
-          sudo apt install ripgrep
+      - name: Install ripgrep+cargo-rdme
+        uses: taiki-e/install-action@v2
+        with:
+          tool: ripgrep@15.1.0,cargo-rdme@1.4.8
 
       - name: check copyright headers
         run: bash .github/copyright.sh
-
-      - name: Install cargo-rdme
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-rdme@1.4.8
 
       - name: Run cargo rdme (attributed_text)
         run: cargo rdme --check --heading-base-level=0 --workspace-project=attributed_text


### PR DESCRIPTION
Installing packages using `apt` can be very slow on GitHub actions runners (see this run https://github.com/linebender/parley/actions/runs/18908491217/job/53972578290 where it takes 6 minutes to install ripgrep - all other CI jobs finish in 1-2mins).

We are already using `taiki-e/install-action` for `cargo-rdme`. This PR also uses it to install ripgrep.
UPDATE: for comparison `taiki-e/install-action` installs ripgrep and cargo-rdme in a total of 2 seconds