### PR TITLE
Add `Cluster::from_point_exact` method for hit-testing spans

### DIFF
--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -53,8 +53,29 @@ impl<'a, B: Brush> Cluster<'a, B> {
         None
     }
 
-    /// Returns the cluster and side for the given layout and point.
+    /// Returns the cluster and side which is at the specified position in the given layout. If no cluster is
+    /// under the specified point then None will be returned.
+    ///
+    /// This is usually the expected behaviour when hit-testing clusters for "hover" or "click" functionality.
+    pub fn from_point_exact(layout: &'a Layout<B>, x: f32, y: f32) -> Option<(Self, ClusterSide)> {
+        Cluster::from_point_impl(layout, x, y, true)
+    }
+
+    /// Returns the cluster and side which is at the specified position in the given layout. If no cluster is
+    /// under the specified point but the point is within the overall layout area then it will return the nearest.
+    ///
+    /// This is usually the expected behaviour when hit-testing clusers for text selection or caret positioning.
     pub fn from_point(layout: &'a Layout<B>, x: f32, y: f32) -> Option<(Self, ClusterSide)> {
+        Cluster::from_point_impl(layout, x, y, false)
+    }
+
+    /// Returns the cluster and side for the given layout and point.
+    fn from_point_impl(
+        layout: &'a Layout<B>,
+        x: f32,
+        y: f32,
+        exact: bool,
+    ) -> Option<(Self, ClusterSide)> {
         let mut path = ClusterPath::default();
         if let Some((line_index, line)) = layout.line_for_offset(y) {
             path.line_index = line_index as u32;
@@ -67,7 +88,7 @@ impl<'a, B: Brush> Cluster<'a, B> {
                         let run_advance = run.advance();
                         path.run_index = run.index;
                         path.logical_index = 0;
-                        if x > offset + run_advance && !is_last_run {
+                        if x > offset + run_advance && (exact || !is_last_run) {
                             offset += run_advance;
                             continue;
                         }
@@ -79,7 +100,10 @@ impl<'a, B: Brush> Cluster<'a, B> {
                             let cluster_advance = cluster.advance();
                             let edge = offset;
                             offset += cluster_advance;
-                            if x > offset && !is_last_cluster {
+                            if x > offset && (exact || !is_last_cluster) {
+                                continue;
+                            }
+                            if x < edge && exact {
                                 continue;
                             }
                             let side = if x <= edge + cluster_advance * 0.5 {
@@ -96,7 +120,7 @@ impl<'a, B: Brush> Cluster<'a, B> {
                 }
             }
         }
-        if y <= 0.0 {
+        if y <= 0.0 && !exact {
             Some((path.cluster(layout)?, ClusterSide::Left))
         } else {
             None


### PR DESCRIPTION
## Motivation

The existing `Cluster::from_point` method is tuned for text-selection / caret positioning where in the case that the cursor is not positioned exactly above a cluster, you usually want to position the caret (or selection anchor/focus) relative to the *nearest* cluster.

For example if you click the empty space at the end of a left-aligned line of text in an editable textbox, then you would expect the caret to be positioned at the end of the line of text.

However, this logic doesn't work very well when hit-testing clusters for "hover" or "click" functionality (e.g. click a link within a paragraph of text). In that case you usually simply want to return `None` in the case that the cursor is not directly over a cluster.

## Changes made

- Move the implementation of `Cluster::from_point` into a new private function `Cluster::from_point_impl` that takes a boolean parameter which  determines whether or not the match should be exact (good for hit-testing click/hover) or not (the existing functionality - good for text selection).
- Make `Cluster::from_point` simply call into `Cluster::from_point_impl` with `exact: false`
- Add a new public function  `Cluster::from_point_exact` that calls into `Cluster::from_point_impl` with `exact: true`

This PR is non-breaking

## Videos

Before:


https://github.com/user-attachments/assets/5dc1ec51-4762-4f77-b9a0-3857ac938024

After:


https://github.com/user-attachments/assets/6d9c759b-3b0c-42ff-b5a6-9c6ffbaa0284


