### PR TITLE
`attributed_text`: add `as_str()` accessor to borrow underlying `&str`

### DIFF
--- a/attributed_text/src/attributed_text.rs
+++ b/attributed_text/src/attributed_text.rs
@@ -36,6 +36,14 @@ impl<T: Debug + TextStorage, Attr: Debug> AttributedText<T, Attr> {
         }
     }
 
+    /// Borrow the underlying text as `&str` when the storage is contiguous.
+    pub fn as_str(&self) -> &str
+    where
+        T: AsRef<str>,
+    {
+        self.text.as_ref()
+    }
+
     /// Apply an `attribute` to a `range` within the text.
     pub fn apply_attribute(
         &mut self,


### PR DESCRIPTION
Expose a borrow of the underlying UTF‑8 text as `&str` only when `T: AsRef<str>` (e.g., `String`, `&str`, `Arc<str>`).

This provides a convenient path for contiguous storages without constraining `TextStorage`, keeping room for a future rope-backed implementation.