### PR TITLE
`attributed_text`: switch to structured `Error` + `ErrorKind` with bo…

### DIFF
--- a/attributed_text/src/attributed_text.rs
+++ b/attributed_text/src/attributed_text.rs
@@ -5,37 +5,7 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::ops::Range;
 
-use crate::TextStorage;
-
-/// The errors that might happen as a result of [applying] an attribute.
-///
-/// [applying]: AttributedText::apply_attribute
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[non_exhaustive]
-pub enum ApplyAttributeError {
-    /// The bounds given were invalid.
-    ///
-    /// TODO: Store some data about this here.
-    InvalidBounds,
-    /// The range has `start > end`.
-    InvalidRange,
-    /// Either `start` or `end` is not on a UTF-8 character boundary.
-    NotOnCharBoundary,
-}
-
-impl core::fmt::Display for ApplyAttributeError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InvalidBounds => f.write_str("attribute range is out of bounds"),
-            Self::InvalidRange => f.write_str("attribute range start is greater than end"),
-            Self::NotOnCharBoundary => {
-                f.write_str("attribute range must align to UTF-8 char boundaries")
-            }
-        }
-    }
-}
-
-impl core::error::Error for ApplyAttributeError {}
+use crate::{Endpoint, Error, TextStorage};
 
 /// A block of text with attributes applied to ranges within the text.
 #[derive(Debug)]
@@ -62,20 +32,33 @@ impl<T: Debug + TextStorage, Attr: Debug> AttributedText<T, Attr> {
     }
 
     /// Apply an `attribute` to a `range` within the text.
-    pub fn apply_attribute(
-        &mut self,
-        range: Range<usize>,
-        attribute: Attr,
-    ) -> Result<(), ApplyAttributeError> {
+    pub fn apply_attribute(&mut self, range: Range<usize>, attribute: Attr) -> Result<(), Error> {
         let text_len = self.text.len();
         if range.start > range.end {
-            return Err(ApplyAttributeError::InvalidRange);
+            return Err(Error::invalid_range(range.start, range.end, text_len));
         }
         if range.start > text_len || range.end > text_len {
-            return Err(ApplyAttributeError::InvalidBounds);
+            return Err(Error::invalid_bounds(range.start, range.end, text_len));
         }
-        if !self.text.is_char_boundary(range.start) || !self.text.is_char_boundary(range.end) {
-            return Err(ApplyAttributeError::NotOnCharBoundary);
+        if !self.text.is_char_boundary(range.start) {
+            return Err(Error::not_on_char_boundary(
+                &self.text,
+                range.start,
+                range.end,
+                text_len,
+                Endpoint::Start,
+                range.start,
+            ));
+        }
+        if !self.text.is_char_boundary(range.end) {
+            return Err(Error::not_on_char_boundary(
+                &self.text,
+                range.start,
+                range.end,
+                text_len,
+                Endpoint::End,
+                range.end,
+            ));
         }
         self.attributes.push((range, attribute));
         Ok(())
@@ -114,7 +97,8 @@ impl<T: Debug + TextStorage, Attr: Debug> AttributedText<T, Attr> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ApplyAttributeError, AttributedText};
+    use crate::{AttributedText, Endpoint, ErrorKind};
+    use alloc::format;
     use alloc::vec::Vec;
 
     #[derive(Debug, PartialEq)]
@@ -128,8 +112,8 @@ mod tests {
         let t = "Hello!";
         let mut at = AttributedText::new(t);
 
-        assert_eq!(at.apply_attribute(1..3, TestAttribute::Keep), Ok(()));
-        assert_eq!(at.apply_attribute(2..5, TestAttribute::Remove), Ok(()));
+        assert!(at.apply_attribute(1..3, TestAttribute::Keep).is_ok());
+        assert!(at.apply_attribute(2..5, TestAttribute::Remove).is_ok());
 
         assert!(at.attributes_at(0).collect::<Vec<_>>().is_empty());
     }
@@ -143,32 +127,81 @@ mod tests {
         let t = "Hello!";
         let mut at = AttributedText::new(t);
 
-        assert_eq!(at.apply_attribute(0..3, TestAttribute::Keep), Ok(()));
-        assert_eq!(at.apply_attribute(0..6, TestAttribute::Keep), Ok(()));
-        assert_eq!(
-            at.apply_attribute(4..3, TestAttribute::Keep),
-            Err(ApplyAttributeError::InvalidRange)
-        );
-        assert_eq!(
-            at.apply_attribute(0..7, TestAttribute::Keep),
-            Err(ApplyAttributeError::InvalidBounds)
-        );
-        assert_eq!(
-            at.apply_attribute(7..8, TestAttribute::Keep),
-            Err(ApplyAttributeError::InvalidBounds)
-        );
+        assert!(at.apply_attribute(0..3, TestAttribute::Keep).is_ok());
+        assert!(at.apply_attribute(0..6, TestAttribute::Keep).is_ok());
+        match at.apply_attribute(4..3, TestAttribute::Keep) {
+            Err(e) => {
+                assert_eq!(e.kind(), ErrorKind::InvalidRange);
+                let msg = format!("{}", e);
+                assert!(msg.contains("4..3"));
+                assert!(msg.contains("invalid range"));
+                assert!(msg.contains("start > end"));
+            }
+            _ => panic!("expected InvalidRange"),
+        }
+        match at.apply_attribute(0..7, TestAttribute::Keep) {
+            Err(e) => {
+                assert_eq!(e.kind(), ErrorKind::InvalidBounds);
+                let msg = format!("{}", e);
+                assert!(msg.contains("0..7"));
+                assert!(msg.contains("len 6"));
+            }
+            _ => panic!("expected InvalidBounds"),
+        }
+        match at.apply_attribute(7..8, TestAttribute::Keep) {
+            Err(e) => {
+                assert_eq!(e.kind(), ErrorKind::InvalidBounds);
+                assert_eq!(e.start(), 7);
+                assert_eq!(e.end(), 8);
+                assert_eq!(e.len(), 6);
+                let msg = format!("{}", e);
+                assert!(msg.contains("range 7..8"));
+                assert!(msg.contains("len 6"));
+            }
+            _ => panic!("expected InvalidBounds"),
+        }
     }
 
     #[test]
     fn not_on_char_boundary() {
-        // "é" is 2 bytes in UTF-8; index 1 is not a boundary
+        // "é" is 2 bytes in UTF-8; index 1 is not a boundary.
         let t = "éclair";
         let mut at = AttributedText::new(t);
-        assert_eq!(
-            at.apply_attribute(1..2, TestAttribute::Keep),
-            Err(ApplyAttributeError::NotOnCharBoundary)
-        );
+        // Invalid start boundary at 1
+        match at.apply_attribute(1..2, TestAttribute::Keep) {
+            Err(e) => {
+                assert_eq!(e.kind(), ErrorKind::NotOnCharBoundary);
+                let b = e.boundary().expect("boundary info");
+                assert_eq!(b.which, Endpoint::Start);
+                assert_eq!(b.index, 1);
+                assert_eq!(b.char_start, 0);
+                assert_eq!(b.char_end, 2);
+                let msg = format!("{}", e);
+                assert!(msg.contains("range 1..2"));
+                assert!(msg.contains("start"));
+                assert!(msg.contains("index 1"));
+                assert!(msg.contains("char 0..2"));
+            }
+            _ => panic!("expected NotOnCharBoundary for start"),
+        }
+        // Invalid end boundary at 1
+        match at.apply_attribute(0..1, TestAttribute::Keep) {
+            Err(e) => {
+                assert_eq!(e.kind(), ErrorKind::NotOnCharBoundary);
+                let b = e.boundary().expect("boundary info");
+                assert_eq!(b.which, Endpoint::End);
+                assert_eq!(b.index, 1);
+                assert_eq!(b.char_start, 0);
+                assert_eq!(b.char_end, 2);
+                let msg = format!("{}", e);
+                assert!(msg.contains("range 0..1"));
+                assert!(msg.contains("end"));
+                assert!(msg.contains("index 1"));
+                assert!(msg.contains("char 0..2"));
+            }
+            _ => panic!("expected NotOnCharBoundary for end"),
+        }
         // Using proper boundaries is OK
-        assert_eq!(at.apply_attribute(0..2, TestAttribute::Keep), Ok(()));
+        assert!(at.apply_attribute(0..2, TestAttribute::Keep).is_ok());
     }
 }

--- a/attributed_text/src/error.rs
+++ b/attributed_text/src/error.rs
@@ -1,0 +1,222 @@
+// Copyright 2025 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::TextStorage;
+
+/// Rich error type for attributed text operations.
+///
+/// Carries a non-exhaustive [`ErrorKind`] plus contextual information about the
+/// attempted range and, when relevant, the enclosing UTF-8 character span at
+/// the offending index.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Error {
+    /// The non-exhaustive category describing this error.
+    kind: ErrorKind,
+
+    /// The start byte index of the caller-provided range.
+    start: usize,
+
+    /// The end byte index (exclusive) of the caller-provided range.
+    end: usize,
+
+    /// The length in bytes of the underlying text at the time of failure.
+    len: usize,
+
+    /// Extra detail for boundary-related errors, when available.
+    boundary: Option<BoundaryInfo>,
+}
+
+#[expect(
+    clippy::len_without_is_empty,
+    reason = "`Error::len` reports source text length context; an `is_empty` method would be misleading and unused."
+)]
+impl Error {
+    /// The machine-readable category for this error.
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    /// The start byte index of the range provided by the caller.
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// The end byte index of the range provided by the caller.
+    pub fn end(&self) -> usize {
+        self.end
+    }
+
+    /// The length in bytes of the underlying text at the time of the error.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Extra details for boundary-related errors, if available.
+    pub fn boundary(&self) -> Option<BoundaryInfo> {
+        self.boundary
+    }
+
+    pub(crate) fn invalid_bounds(start: usize, end: usize, len: usize) -> Self {
+        Self {
+            kind: ErrorKind::InvalidBounds,
+            start,
+            end,
+            len,
+            boundary: None,
+        }
+    }
+
+    pub(crate) fn invalid_range(start: usize, end: usize, len: usize) -> Self {
+        Self {
+            kind: ErrorKind::InvalidRange,
+            start,
+            end,
+            len,
+            boundary: None,
+        }
+    }
+
+    pub(crate) fn not_on_char_boundary<T: TextStorage>(
+        text: &T,
+        start: usize,
+        end: usize,
+        len: usize,
+        which: Endpoint,
+        index: usize,
+    ) -> Self {
+        let (cs, ce) = enclosing_char_span(text, index).unwrap_or((index, index));
+        Self {
+            kind: ErrorKind::NotOnCharBoundary,
+            start,
+            end,
+            len,
+            boundary: Some(BoundaryInfo {
+                which,
+                index,
+                char_start: cs,
+                char_end: ce,
+            }),
+        }
+    }
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self.kind {
+            ErrorKind::InvalidBounds => write!(
+                f,
+                "range {}..{} out of bounds for len {}",
+                self.start, self.end, self.len
+            ),
+            ErrorKind::InvalidRange => {
+                write!(f, "invalid range {}..{}: start > end", self.start, self.end)
+            }
+            ErrorKind::NotOnCharBoundary => {
+                if let Some(b) = self.boundary {
+                    let which = match b.which {
+                        Endpoint::Start => "start",
+                        Endpoint::End => "end",
+                    };
+                    write!(
+                        f,
+                        "range {}..{}: {} index {} not on UTF-8 boundary (char {}..{})",
+                        self.start, self.end, which, b.index, b.char_start, b.char_end
+                    )
+                } else {
+                    write!(
+                        f,
+                        "range {}..{} not on UTF-8 boundary",
+                        self.start, self.end
+                    )
+                }
+            }
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
+/// The non-exhaustive category of an error.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// Provided range indices were out of bounds relative to the text length.
+    InvalidBounds,
+
+    /// The provided range had `start > end`.
+    InvalidRange,
+
+    /// Either `start` or `end` was not aligned to a UTF-8 character boundary.
+    NotOnCharBoundary,
+}
+
+/// Identifies which endpoint of a range failed boundary validation.
+///
+/// This type is surfaced via [`BoundaryInfo`], which is attached to [`Error`]
+/// for boundary-related failures.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Endpoint {
+    /// The `start` endpoint of the range.
+    Start,
+
+    /// The `end` endpoint of the range.
+    End,
+}
+
+/// Details about an offending index that was not on a UTF-8 character boundary.
+///
+/// Returned by [`Error::boundary`] when the error kind is
+/// [`ErrorKind::NotOnCharBoundary`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct BoundaryInfo {
+    /// Which endpoint (`start` or `end`) was invalid.
+    pub which: Endpoint,
+
+    /// The offending byte index.
+    pub index: usize,
+
+    /// The start byte index of the enclosing UTF-8 codepoint.
+    pub char_start: usize,
+
+    /// The end byte index (exclusive) of the enclosing UTF-8 codepoint.
+    pub char_end: usize,
+}
+
+fn enclosing_char_span<T: TextStorage>(text: &T, index: usize) -> Option<(usize, usize)> {
+    let len = text.len();
+    if index > len {
+        return None;
+    }
+    if text.is_char_boundary(index) {
+        return Some((index, index));
+    }
+
+    // Previous boundary (max 3 bytes back)
+    let mut s = index;
+    for _ in 0..4 {
+        // We can never wrap around `0` here, as when `s == 0` before the decrement,
+        // the previous call to `text.is_char_boundary` (either in this loop or above)
+        // will have returned `true`.
+        if s == 0 {
+            unreachable!("`s` should never reach 0 before finding a char boundary");
+        }
+        s -= 1;
+        if text.is_char_boundary(s) {
+            break;
+        }
+    }
+
+    // Next boundary (max 3 bytes forward)
+    let mut e = index;
+    for _ in 0..4 {
+        if e >= len {
+            break;
+        }
+        e += 1;
+        if text.is_char_boundary(e) {
+            break;
+        }
+    }
+
+    if s <= e { Some((s, e)) } else { None }
+}

--- a/attributed_text/src/lib.rs
+++ b/attributed_text/src/lib.rs
@@ -21,7 +21,9 @@
 extern crate alloc;
 
 mod attributed_text;
+mod error;
 mod text_storage;
 
-pub use crate::attributed_text::{ApplyAttributeError, AttributedText};
+pub use crate::attributed_text::AttributedText;
+pub use crate::error::{BoundaryInfo, Endpoint, Error, ErrorKind};
 pub use crate::text_storage::TextStorage;


### PR DESCRIPTION
…undary details

- Replace `ApplyAttributeError` with `Error { kind: ErrorKind, start, end, len, boundary }`
- `AttributedText::apply_attribute` now returns Result<(), Error>
- Add `Endpoint` and `BoundaryInfo` (reports offending endpoint/index and enclosing codepoint span)
- Enforce UTF-8 boundaries via `TextStorage::is_char_boundary` and surface detailed context
- Enrich `Display` to include range, len, and boundary info
- Re-export `Error`, `ErrorKind`, `BoundaryInfo`, `Endpoint` at crate root
- Update tests to assert kinds and key details in messages