### PR TITLE
Add word and letter spacing to text layout based on style properties

### DIFF
--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -174,6 +174,8 @@ pub(crate) fn shape_text<'a, B: Brush>(
             item.locale = style.locale;
             item.variations = style.font_variations;
             item.features = style.font_features;
+            item.word_spacing = style.word_spacing;
+            item.letter_spacing = style.letter_spacing;
             text_range.start = text_range.end;
             char_range.start = char_range.end;
         }

--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -735,6 +735,34 @@ fn realign_all() {
 }
 
 #[test]
+fn spacing_changes_per_style_run() {
+    let mut env = TestEnv::new(test_name!(), None);
+
+    let text = "foo bar";
+    let mut builder = env.ranged_builder(text);
+    builder.push(StyleProperty::WordSpacing(2.0), 3..text.len());
+    builder.push(StyleProperty::LetterSpacing(1.5), 3..text.len());
+
+    let layout = builder.build(text);
+    assert_eq!(
+        layout.data.runs.len(),
+        2,
+        "expected two runs after style break"
+    );
+
+    let first_run = &layout.data.runs[0];
+    let second_run = &layout.data.runs[1];
+
+    assert_eq!(&text[first_run.text_range.clone()], "foo");
+    assert_eq!(first_run.word_spacing, 0.0);
+    assert_eq!(first_run.letter_spacing, 0.0);
+
+    assert_eq!(&text[second_run.text_range.clone()], " bar");
+    assert_eq!(second_run.word_spacing, 2.0);
+    assert_eq!(second_run.letter_spacing, 1.5);
+}
+
+#[test]
 fn layout_impl_send_sync() {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<Layout<()>>();


### PR DESCRIPTION
- Updated `shape_text` function to include `word_spacing` and `letter_spacing` from the style.
- Added a new test to verify that spacing changes are correctly applied per style run in the text layout.

It closes #290