### PR TITLE
unicode_data_gen: Create `composite` dir

### DIFF
--- a/unicode_data_gen/src/lib.rs
+++ b/unicode_data_gen/src/lib.rs
@@ -103,7 +103,9 @@ pub fn generate(out: std::path::PathBuf) {
         .build();
 
         let composite_dir = out.join("composite");
-        std::fs::create_dir(&composite_dir).unwrap();
+        if !composite_dir.exists() {
+            std::fs::create_dir(&composite_dir).unwrap();
+        }
         let mut file = BufWriter::new(std::fs::File::create(composite_dir.join("mod.rs")).unwrap());
 
         writeln!(&mut file, "{COPYRIGHT_HEADER}").unwrap();


### PR DESCRIPTION
`cargo run -p unicode_data_gen <output-path>` was failing when the `composite` dir did not exist:

```
thread 'main' panicked at unicode_data_gen/src/lib.rs:106:88:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```