### PR TITLE
Derive `Debug` for `BoundingBox`

### DIFF
--- a/parley/src/util.rs
+++ b/parley/src/util.rs
@@ -16,7 +16,7 @@ pub(crate) fn nearly_zero(x: f32) -> bool {
 }
 
 /// A bounding box.
-#[derive(Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct BoundingBox {
     /// The left edge.
     pub x0: f64,


### PR DESCRIPTION
Per title, I noticed this didn't have a `Debug` derive after trying to integrate main into internal code.