### PR TITLE
Expose `Tag`

### DIFF
--- a/parley/src/setting.rs
+++ b/parley/src/setting.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-pub(crate) use harfrust::Tag;
+pub use harfrust::Tag;
 
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 pub struct Setting<T> {


### PR DESCRIPTION
Makes the `Tag` type publicly accessible via `parley::setting::Tag`, enabling consumers to construct `FontVariation` and `FontFeature` settings without requiring the use of the `parse*` functions..

Previously, `Tag` was only exposed as `pub(crate)`, which meant consumers could see the `Setting<T>` struct (and its aliases FontVariation/FontFeature) but couldn't construct them directly—the tag field required a Tag that wasn't publicly accessible.

Users had to rely on the CSS string parsing like FontSettings::Source("'liga' on").

Now consumers can:

```rs
use parley::setting::Tag;
use parley::style::FontVariation;

let wght = FontVariation {
    tag: Tag::new(b"wght"),
    value: 700.0,
};
```