### PR TITLE
Remove hashbrown default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,12 +137,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,8 +1602,6 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ bytemuck = { version = "1.24.0", default-features = false }
 databake = { version = "0.2", default-features = false }
 fontique = { version = "0.7.0", default-features = false, path = "fontique" }
 harfrust = { version = "0.3.2", default-features = false }
-hashbrown = "0.16.1"
+hashbrown = { version = "0.16.1", default-features = false, features = ["default-hasher"] }
 icu_codepointtrie_builder = { version = "0.5.1", default-features = false, features = ["wasm"] }
 icu_collections = { version = "2.1.1", default-features = false }
 icu_locale = { version = "2.1.1", default-features = false }


### PR DESCRIPTION
This drops the dependency count of the "parley" crate from 51 to 49.
