### PR TITLE
Remove unused imports of `core_maths::CoreFloat`

### DIFF
--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -12,9 +12,6 @@ use alloc::vec::Vec;
 
 use crate::analysis::cluster::Whitespace;
 use crate::analysis::{Boundary, CharInfo};
-#[cfg(feature = "libm")]
-#[allow(unused_imports)]
-use core_maths::CoreFloat;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) struct ClusterData {

--- a/parley/src/util.rs
+++ b/parley/src/util.rs
@@ -3,10 +3,6 @@
 
 //! Misc helpers.
 
-#[cfg(feature = "libm")]
-#[allow(unused_imports)]
-use core_maths::CoreFloat;
-
 pub(crate) fn nearly_eq(x: f32, y: f32) -> bool {
     (x - y).abs() < f32::EPSILON
 }


### PR DESCRIPTION
With the recent bump in MSRV, these should no longer be needed.

This addresses part of #446.