### PR TITLE
text_primitives: improve OpenType settings CSS parsing

### DIFF
--- a/parley/src/resolve/mod.rs
+++ b/parley/src/resolve/mod.rs
@@ -11,8 +11,8 @@ pub(crate) use range::RangedStyleBuilder;
 use alloc::{vec, vec::Vec};
 
 use super::style::{
-    Brush, FontFamily, FontFamilyName, FontFeature, FontSettings, FontStyle, FontVariation,
-    FontWeight, FontWidth, StyleProperty,
+    Brush, FontFamily, FontFamilyName, FontFeature, FontFeatures, FontStyle, FontVariation,
+    FontVariations, FontWeight, FontWidth, StyleProperty,
 };
 use crate::font::FontContext;
 use crate::style::TextStyle;
@@ -262,15 +262,15 @@ impl ResolveContext {
     /// Resolves font variation settings.
     pub(crate) fn resolve_variations(
         &mut self,
-        variations: &FontSettings<'_, FontVariation>,
+        variations: &FontVariations<'_>,
     ) -> Resolved<FontVariation> {
         match variations {
-            FontSettings::Source(source) => {
+            FontVariations::Source(source) => {
                 self.tmp_variations.clear();
                 self.tmp_variations
                     .extend(FontVariation::parse_css_list(source).map_while(Result::ok));
             }
-            FontSettings::List(settings) => {
+            FontVariations::List(settings) => {
                 self.tmp_variations.clear();
                 self.tmp_variations.extend_from_slice(settings);
             }
@@ -287,15 +287,15 @@ impl ResolveContext {
     /// Resolves font feature settings.
     pub(crate) fn resolve_features(
         &mut self,
-        features: &FontSettings<'_, FontFeature>,
+        features: &FontFeatures<'_>,
     ) -> Resolved<FontFeature> {
         match features {
-            FontSettings::Source(source) => {
+            FontFeatures::Source(source) => {
                 self.tmp_features.clear();
                 self.tmp_features
                     .extend(FontFeature::parse_css_list(source).map_while(Result::ok));
             }
-            FontSettings::List(settings) => {
+            FontFeatures::List(settings) => {
                 self.tmp_features.clear();
                 self.tmp_features.extend_from_slice(settings);
             }

--- a/parley/src/setting.rs
+++ b/parley/src/setting.rs
@@ -3,4 +3,4 @@
 
 //! OpenType settings (features and variations).
 
-pub use text_primitives::{Setting, Tag};
+pub use text_primitives::{FontFeature, FontVariation, Tag};

--- a/parley/src/style/font.rs
+++ b/parley/src/style/font.rs
@@ -2,50 +2,75 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use alloc::borrow::Cow;
-use alloc::borrow::ToOwned;
-use core::fmt;
 
-use crate::setting::Setting;
-
+pub use crate::setting::{FontFeature, FontVariation};
 pub use fontique::{FontStyle, FontWeight, FontWidth, GenericFamily};
 pub use text_primitives::{FontFamily, FontFamilyName};
 
-/// Setting for a font variation.
-pub type FontVariation = Setting<f32>;
-
-/// Setting for a font feature.
-pub type FontFeature = Setting<u16>;
-
-/// Font settings that can be supplied as a raw source string or
-/// a parsed slice.
+/// Font variation settings that can be supplied as a raw source string or a parsed slice.
 #[derive(Clone, PartialEq, Debug)]
-pub enum FontSettings<'a, T>
-where
-    [T]: ToOwned,
-    <[T] as ToOwned>::Owned: fmt::Debug + PartialEq + Clone,
-{
+pub enum FontVariations<'a> {
     /// Setting source in CSS format.
     Source(Cow<'a, str>),
     /// List of settings.
-    List(Cow<'a, [T]>),
+    List(Cow<'a, [FontVariation]>),
 }
 
-impl<'a, T> From<&'a str> for FontSettings<'a, T>
-where
-    [T]: ToOwned,
-    <[T] as ToOwned>::Owned: fmt::Debug + PartialEq + Clone,
-{
+impl<'a> FontVariations<'a> {
+    /// Creates an empty list of font variations.
+    pub const fn empty() -> Self {
+        Self::List(Cow::Borrowed(&[]))
+    }
+}
+
+impl<'a> From<&'a str> for FontVariations<'a> {
     fn from(value: &'a str) -> Self {
         Self::Source(Cow::Borrowed(value))
     }
 }
 
-impl<'a, T> From<&'a [T]> for FontSettings<'a, T>
-where
-    [T]: ToOwned,
-    <[T] as ToOwned>::Owned: fmt::Debug + PartialEq + Clone,
-{
-    fn from(value: &'a [T]) -> Self {
+impl<'a> From<&'a [FontVariation]> for FontVariations<'a> {
+    fn from(value: &'a [FontVariation]) -> Self {
         Self::List(Cow::Borrowed(value))
+    }
+}
+
+impl<'a, const N: usize> From<&'a [FontVariation; N]> for FontVariations<'a> {
+    fn from(value: &'a [FontVariation; N]) -> Self {
+        Self::List(Cow::Borrowed(&value[..]))
+    }
+}
+
+/// Font feature settings that can be supplied as a raw source string or a parsed slice.
+#[derive(Clone, PartialEq, Debug)]
+pub enum FontFeatures<'a> {
+    /// Setting source in CSS format.
+    Source(Cow<'a, str>),
+    /// List of settings.
+    List(Cow<'a, [FontFeature]>),
+}
+
+impl<'a> FontFeatures<'a> {
+    /// Creates an empty list of font features.
+    pub const fn empty() -> Self {
+        Self::List(Cow::Borrowed(&[]))
+    }
+}
+
+impl<'a> From<&'a str> for FontFeatures<'a> {
+    fn from(value: &'a str) -> Self {
+        Self::Source(Cow::Borrowed(value))
+    }
+}
+
+impl<'a> From<&'a [FontFeature]> for FontFeatures<'a> {
+    fn from(value: &'a [FontFeature]) -> Self {
+        Self::List(Cow::Borrowed(value))
+    }
+}
+
+impl<'a, const N: usize> From<&'a [FontFeature; N]> for FontFeatures<'a> {
+    fn from(value: &'a [FontFeature; N]) -> Self {
+        Self::List(Cow::Borrowed(&value[..]))
     }
 }

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -11,8 +11,8 @@ use alloc::borrow::Cow;
 
 pub use brush::*;
 pub use font::{
-    FontFamily, FontFamilyName, FontFeature, FontSettings, FontStyle, FontVariation, FontWeight,
-    FontWidth, GenericFamily,
+    FontFamily, FontFamilyName, FontFeature, FontFeatures, FontStyle, FontVariation,
+    FontVariations, FontWeight, FontWidth, GenericFamily,
 };
 pub use styleset::StyleSet;
 pub use text_primitives::{OverflowWrap, TextWrapMode, WordBreak};
@@ -81,9 +81,9 @@ pub enum StyleProperty<'a, B: Brush> {
     /// Font weight.
     FontWeight(FontWeight),
     /// Font variation settings.
-    FontVariations(FontSettings<'a, FontVariation>),
+    FontVariations(FontVariations<'a>),
     /// Font feature settings.
-    FontFeatures(FontSettings<'a, FontFeature>),
+    FontFeatures(FontFeatures<'a>),
     /// Locale.
     Locale(Option<&'a str>),
     /// Brush for rendering text.
@@ -132,9 +132,9 @@ pub struct TextStyle<'a, B: Brush> {
     /// Font weight.
     pub font_weight: FontWeight,
     /// Font variation settings.
-    pub font_variations: FontSettings<'a, FontVariation>,
+    pub font_variations: FontVariations<'a>,
     /// Font feature settings.
-    pub font_features: FontSettings<'a, FontFeature>,
+    pub font_features: FontFeatures<'a>,
     /// Locale.
     pub locale: Option<&'a str>,
     /// Brush for rendering text.
@@ -177,8 +177,8 @@ impl<B: Brush> Default for TextStyle<'_, B> {
             font_width: FontWidth::default(),
             font_style: FontStyle::default(),
             font_weight: FontWeight::default(),
-            font_variations: FontSettings::List(Cow::Borrowed(&[])),
-            font_features: FontSettings::List(Cow::Borrowed(&[])),
+            font_variations: FontVariations::empty(),
+            font_features: FontFeatures::empty(),
             locale: None,
             brush: B::default(),
             has_underline: false,
@@ -214,6 +214,18 @@ impl<'a, B: Brush> From<&'a [FontFamilyName<'a>]> for StyleProperty<'a, B> {
 impl<'a, B: Brush> From<FontFamilyName<'a>> for StyleProperty<'a, B> {
     fn from(value: FontFamilyName<'a>) -> Self {
         StyleProperty::FontFamily(value.into())
+    }
+}
+
+impl<'a, B: Brush> From<FontVariations<'a>> for StyleProperty<'a, B> {
+    fn from(value: FontVariations<'a>) -> Self {
+        StyleProperty::FontVariations(value)
+    }
+}
+
+impl<'a, B: Brush> From<FontFeatures<'a>> for StyleProperty<'a, B> {
+    fn from(value: FontFeatures<'a>) -> Self {
+        StyleProperty::FontFeatures(value)
     }
 }
 

--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -1,8 +1,6 @@
 // Copyright 2024 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::borrow::Cow;
-
 use peniko::{
     color::{AlphaColor, Srgb, palette},
     kurbo::Size,
@@ -11,10 +9,10 @@ use peniko::{
 use super::utils::{
     ColorBrush, FONT_FAMILY_LIST, TestEnv, asserts::assert_eq_layout_data_alignments,
 };
-use crate::setting::Setting;
+use crate::setting::{FontFeature, FontVariation};
 use crate::{
-    Alignment, AlignmentOptions, ContentWidths, FontFamily, FontSettings, InlineBox, Layout,
-    LineHeight, StyleProperty, TextStyle, WhiteSpaceCollapse, test_name,
+    Alignment, AlignmentOptions, ContentWidths, FontFamily, FontFeatures, FontVariations,
+    InlineBox, Layout, LineHeight, StyleProperty, TextStyle, WhiteSpaceCollapse, test_name,
 };
 
 #[test]
@@ -615,17 +613,17 @@ fn font_features() {
     let text = "fi ".repeat(4);
     let mut builder = env.ranged_builder(&text);
     builder.push(
-        StyleProperty::FontFeatures(FontSettings::List(Cow::Borrowed(&[Setting {
+        FontFeatures::from(&[FontFeature {
             tag: crate::setting::Tag::new(b"liga"),
             value: 1,
-        }]))),
+        }]),
         0..5,
     );
     builder.push(
-        StyleProperty::FontFeatures(FontSettings::List(Cow::Borrowed(&[Setting {
+        FontFeatures::from(&[FontFeature {
             tag: crate::setting::Tag::new(b"liga"),
             value: 0,
-        }]))),
+        }]),
         5..10,
     );
     let mut layout = builder.build(&text);
@@ -643,12 +641,10 @@ fn variable_fonts() {
     for wght in [100., 500., 1000.] {
         let mut builder = env.ranged_builder(text);
         builder.push_default(FontFamily::named("Arimo"));
-        builder.push_default(StyleProperty::FontVariations(FontSettings::List(
-            Cow::Borrowed(&[Setting {
-                tag: crate::setting::Tag::new(b"wght"),
-                value: wght,
-            }]),
-        )));
+        builder.push_default(FontVariations::from(&[FontVariation::new(
+            crate::setting::Tag::new(b"wght"),
+            wght,
+        )]));
         let mut layout = builder.build(text);
         layout.break_all_lines(Some(100.0));
         layout.align(None, Alignment::Start, AlignmentOptions::default());

--- a/parley/src/tests/test_builders.rs
+++ b/parley/src/tests/test_builders.rs
@@ -5,14 +5,13 @@
 
 use fontique::{FontStyle, FontWeight, FontWidth};
 use peniko::color::palette;
-use std::borrow::Cow;
 
 use super::utils::{
     ColorBrush, FONT_FAMILY_LIST, asserts::assert_eq_layout_data, create_font_context,
 };
 use crate::{
-    FontContext, FontFamily, FontSettings, Layout, LayoutContext, LineHeight, OverflowWrap,
-    RangedBuilder, StyleProperty, TextStyle, TextWrapMode, TreeBuilder, WordBreak,
+    FontContext, FontFamily, FontFeatures, FontVariations, Layout, LayoutContext, LineHeight,
+    OverflowWrap, RangedBuilder, StyleProperty, TextStyle, TextWrapMode, TreeBuilder, WordBreak,
 };
 
 /// Set of options for [`build_layout_with_ranged`].
@@ -168,8 +167,8 @@ fn create_root_style() -> TextStyle<'static, ColorBrush> {
         font_width: FontWidth::CONDENSED,
         font_style: FontStyle::Italic,
         font_weight: FontWeight::BOLD,
-        font_variations: FontSettings::List(Cow::Borrowed(&[])), // TODO: Set a non-default value
-        font_features: FontSettings::List(Cow::Borrowed(&[])),   // TODO: Set a non-default value
+        font_variations: FontVariations::empty(), // TODO: Set a non-default value
+        font_features: FontFeatures::empty(),     // TODO: Set a non-default value
         locale: Some("en-US"),
         brush: ColorBrush::new(palette::css::GREEN),
         has_underline: true,
@@ -198,12 +197,8 @@ fn set_root_style(rb: &mut RangedBuilder<'_, ColorBrush>) {
     rb.push_default(StyleProperty::FontWidth(FontWidth::CONDENSED));
     rb.push_default(StyleProperty::FontStyle(FontStyle::Italic));
     rb.push_default(StyleProperty::FontWeight(FontWeight::BOLD));
-    rb.push_default(StyleProperty::FontVariations(FontSettings::List(
-        Cow::Borrowed(&[]),
-    )));
-    rb.push_default(StyleProperty::FontFeatures(FontSettings::List(
-        Cow::Borrowed(&[]),
-    )));
+    rb.push_default(FontVariations::empty());
+    rb.push_default(FontFeatures::empty());
     rb.push_default(StyleProperty::Locale(Some("en-US")));
     rb.push_default(StyleProperty::Brush(ColorBrush::new(palette::css::GREEN)));
     rb.push_default(StyleProperty::Underline(true));

--- a/text_primitives/src/lib.rs
+++ b/text_primitives/src/lib.rs
@@ -53,5 +53,5 @@ pub use font::{FontStyle, FontWeight, FontWidth};
 pub use font_family::{FontFamily, FontFamilyName, ParseFontFamilyError, ParseFontFamilyErrorKind};
 pub use generic_family::GenericFamily;
 pub use language::{Language, ParseLanguageError};
-pub use tag::{ParseSettingsError, ParseSettingsErrorKind, Setting, Tag};
+pub use tag::{FontFeature, FontVariation, ParseSettingsError, ParseSettingsErrorKind, Tag};
 pub use text::{BaseDirection, OverflowWrap, TextWrapMode, WordBreak};


### PR DESCRIPTION
- Add structured parsing errors (kind + byte offset/span) for CSS OpenType settings strings.
- Rename list parsers to `parse_css_list`.
- Update Parley resolver to use the fallible CSS parser.
- Add unit tests covering success cases and key error offsets/spans.