### PR TITLE
Don't have `std` imported by default

### DIFF
--- a/fontique/src/backend/android.rs
+++ b/fontique/src/backend/android.rs
@@ -1,7 +1,15 @@
 // Copyright 2024 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::{path::Path, str::FromStr, sync::Arc};
+use alloc::{
+    boxed::Box,
+    str::FromStr,
+    string::{String, ToString},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
+use std::path::Path;
 
 use hashbrown::HashMap;
 use icu_locale_core::subtags::script;

--- a/fontique/src/backend/coretext.rs
+++ b/fontique/src/backend/coretext.rs
@@ -5,6 +5,8 @@ use super::{
     FallbackKey, FamilyId, FamilyInfo, FamilyNameMap, GenericFamily, GenericFamilyMap, ScriptExt,
     scan,
 };
+use alloc::format;
+use alloc::string::ToString;
 use alloc::sync::Arc;
 use core::ptr::{null, null_mut};
 use hashbrown::HashMap;

--- a/fontique/src/backend/dwrite.rs
+++ b/fontique/src/backend/dwrite.rs
@@ -1,12 +1,14 @@
 // Copyright 2024 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::{vec, vec::Vec};
 use hashbrown::HashMap;
 use std::{
     ffi::{OsString, c_void},
     os::windows::ffi::OsStringExt,
     path::PathBuf,
-    sync::Arc,
 };
 use windows::{
     Win32::Graphics::DirectWrite::{

--- a/fontique/src/impl_fontconfig.rs
+++ b/fontique/src/impl_fontconfig.rs
@@ -111,6 +111,7 @@ impl FromFontconfig for FontStyle {
 mod tests {
     use super::FromFontconfig;
     use crate::{FontStyle, FontWeight, FontWidth};
+    use alloc::string::ToString;
 
     #[test]
     fn fontwidth_from_fontconfig() {

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -13,7 +13,7 @@
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![allow(unsafe_code, reason = "We access platform libraries using ffi.")]
 #![allow(missing_docs, reason = "We have many as-yet undocumented items.")]
 #![expect(
@@ -33,6 +33,9 @@
 compile_error!("fontique requires either the `std` or `libm` feature to be enabled");
 
 extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 mod attributes;
 mod backend;

--- a/fontique/src/scan.rs
+++ b/fontique/src/scan.rs
@@ -11,6 +11,7 @@ use super::{
     font::FontInfo,
 };
 use alloc::string::String;
+use alloc::vec;
 use hashbrown::HashMap;
 use read_fonts::{FileRef, FontRef, TableProvider as _, tables::name, types::NameId};
 use smallvec::SmallVec;

--- a/parley/src/editing/editor.rs
+++ b/parley/src/editing/editor.rs
@@ -1166,6 +1166,8 @@ where
         #[cfg(feature = "std")]
         #[allow(clippy::print_stderr)] // reason = "unreachable debug code"
         if false {
+            use std::{eprint, eprintln};
+
             let focus = new_sel.focus();
             let cluster = focus.logical_clusters(&self.layout);
             let dbg = (

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -81,7 +81,7 @@
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![allow(missing_docs, reason = "We have many as-yet undocumented items.")]
 #![expect(
     missing_debug_implementations,
@@ -99,6 +99,9 @@
 compile_error!("parley requires either the `std` or `libm` feature to be enabled");
 
 extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 pub use fontique;
 

--- a/parley/src/lru_cache.rs
+++ b/parley/src/lru_cache.rs
@@ -89,6 +89,7 @@ impl<ID, T> LruCache<ID, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::{String, ToString};
 
     #[derive(Debug, Clone, PartialEq)]
     struct TestId(String);

--- a/parley/src/style/styleset.rs
+++ b/parley/src/style/styleset.rs
@@ -39,7 +39,7 @@ impl<Brush: crate::Brush> StyleSet<Brush> {
         self.0.insert(discriminant, style)
     }
 
-    /// [Retain](std::vec::Vec::retain) only the styles for which `f` returns true.
+    /// [Retain](alloc::vec::Vec::retain) only the styles for which `f` returns true.
     ///
     /// Styles which are removed return to their default values.
     ///

--- a/parley/src/tests/test_analysis.rs
+++ b/parley/src/tests/test_analysis.rs
@@ -3,6 +3,7 @@
 
 use crate::analysis::Boundary;
 use crate::{FontContext, LayoutContext, RangedBuilder, StyleProperty, WordBreak};
+use alloc::{vec, vec::Vec};
 use fontique::FontWeight;
 use icu_properties::props::{GraphemeClusterBreak, Script};
 

--- a/parley/src/tests/test_basic.rs
+++ b/parley/src/tests/test_basic.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use alloc::{format, vec::Vec};
 use peniko::{
     color::{AlphaColor, Srgb, palette},
     kurbo::Size,

--- a/parley/src/tests/test_issues.rs
+++ b/parley/src/tests/test_issues.rs
@@ -3,6 +3,7 @@
 
 use super::utils::TestEnv;
 use crate::{Alignment, AlignmentOptions, test_name};
+use alloc::vec::Vec;
 
 /// Test that rendering RTL text doesn't affect subsequent LTR layouts.
 /// See <https://github.com/linebender/parley/issues/489>.

--- a/parley/src/tests/test_lines.rs
+++ b/parley/src/tests/test_lines.rs
@@ -3,6 +3,7 @@
 
 //! Test line layouts, including the vertical size and positioning of the line box.
 
+use alloc::vec::Vec;
 use peniko::kurbo::Size;
 
 use super::utils::{ColorBrush, TestEnv};

--- a/parley/src/tests/utils/cursor_test.rs
+++ b/parley/src/tests/utils/cursor_test.rs
@@ -1,6 +1,11 @@
 // Copyright 2024 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use alloc::{
+    format,
+    string::{String, ToString},
+};
+use std::eprintln;
 use tiny_skia::{Color, Pixmap, PixmapPaint, Transform};
 
 use crate::tests::utils::renderer::{ColorBrush, RenderingConfig, render_layout};

--- a/parley/src/tests/utils/env.rs
+++ b/parley/src/tests/utils/env.rs
@@ -8,14 +8,17 @@ use crate::{
     BoundingBox, FontContext, FontFamily, FontFamilyName, Layout, LayoutContext, LineHeight,
     PlainEditor, PlainEditorDriver, RangedBuilder, StyleProperty, TextStyle, TreeBuilder,
 };
+use alloc::{
+    borrow::Cow,
+    format,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
 use fontique::{Blob, Collection, CollectionOptions, SourceCache};
 use peniko::kurbo::Size;
 use std::collections::HashMap;
-use std::{
-    borrow::Cow,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::path::{Path, PathBuf};
 use tiny_skia::{Color, Pixmap};
 
 // Returns the current function name
@@ -24,7 +27,7 @@ macro_rules! test_name {
     () => {{
         fn f() {}
         fn type_name_of<T>(_: T) -> &'static str {
-            std::any::type_name::<T>()
+            core::any::type_name::<T>()
         }
         let name = type_name_of(f);
         let name = &name[..name.len() - 3];

--- a/parley/src/tests/utils/renderer.rs
+++ b/parley/src/tests/utils/renderer.rs
@@ -10,6 +10,7 @@
 use std::collections::HashMap;
 
 use crate::{GlyphRun, Layout, PositionedLayoutItem};
+use alloc::vec::Vec;
 use peniko::kurbo;
 use skrifa::{
     GlyphId, MetadataProvider, OutlineGlyph,


### PR DESCRIPTION
In other Linebender crates (and in other parts of the Rust ecosystem), it is common to be unconditiaonally `no_std` and then conditionally `extern crate std`. This makes it easier to keep things working on `no_std` configurations as the `std` is no longer imported by default.