### PR TITLE
fontique: drop optional script conversion deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,8 +1295,6 @@ name = "fontique"
 version = "0.7.0"
 dependencies = [
  "hashbrown 0.16.1",
- "icu_locale_core",
- "icu_properties",
  "linebender_resource_handle",
  "memmap2",
  "objc2 0.6.3",
@@ -1307,7 +1305,6 @@ dependencies = [
  "roxmltree",
  "smallvec",
  "text_primitives",
- "unicode-script",
  "windows 0.58.0",
  "windows-core 0.58.0",
  "yeslogic-fontconfig-sys",
@@ -4731,12 +4728,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unicode-script"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -20,8 +20,6 @@ default = ["system"]
 std = ["read-fonts/std", "dep:memmap2", "text_primitives/std"]
 libm = ["read-fonts/libm"]
 bytemuck = ["text_primitives/bytemuck"]
-icu_properties = ["dep:icu_locale_core", "dep:icu_properties"]
-unicode_script = ["dep:unicode-script"]
 # Enables support for system font backends
 system = [
     "std",
@@ -45,9 +43,6 @@ read-fonts = { workspace = true }
 linebender_resource_handle = { workspace = true }
 smallvec = "1.15.1"
 memmap2 = { version = "0.9.9", optional = true }
-unicode-script = { version = "0.5.7", optional = true }
-icu_properties = { workspace = true, features = ["compiled_data"], optional = true }
-icu_locale_core = { workspace = true, features = ["alloc"], optional = true }
 hashbrown = { workspace = true }
 text_primitives = { path = "../text_primitives", default-features = false }
 

--- a/fontique/src/script.rs
+++ b/fontique/src/script.rs
@@ -3,8 +3,6 @@
 
 //! Support for working with Unicode scripts.
 
-#[cfg(feature = "icu_properties")]
-use icu_locale_core::subtags::Script as IcuScript;
 use text_primitives::Script;
 
 pub trait ScriptExt {
@@ -13,20 +11,6 @@ pub trait ScriptExt {
 
     /// Returns a string containing sample characters for this script.
     fn sample(&self) -> Option<&'static str>;
-
-    /// Returns the associated [`icu_properties::props::Script`] value.
-    #[cfg(feature = "icu_properties")]
-    fn properties_script(self) -> icu_properties::props::Script;
-
-    /// Returns the associated [`unicode_script::Script`] value.
-    #[cfg(feature = "unicode_script")]
-    fn unicode_script(self) -> unicode_script::Script;
-
-    #[cfg(feature = "icu_properties")]
-    fn from_properties_script(value: icu_properties::props::Script) -> Script;
-
-    #[cfg(feature = "unicode_script")]
-    fn from_unicode_script(value: unicode_script::Script) -> Script;
 }
 
 impl ScriptExt for Script {
@@ -39,32 +23,6 @@ impl ScriptExt for Script {
             .binary_search_by(|entry| entry.0.cmp(self))
             .ok()?;
         SCRIPT_SAMPLES.get(ix).map(|entry| entry.1)
-    }
-
-    /// Returns the associated [`icu_properties::props::Script`] value.
-    #[cfg(feature = "icu_properties")]
-    fn properties_script(self) -> icu_properties::props::Script {
-        IcuScript::try_from_raw(self.to_bytes())
-            .unwrap_or_else(|_| IcuScript::try_from_raw(*b"Zzzz").unwrap())
-            .into()
-    }
-
-    /// Returns the associated [`unicode_script::Script`] value.
-    #[cfg(feature = "unicode_script")]
-    fn unicode_script(self) -> unicode_script::Script {
-        unicode_script::Script::from_short_name(self.as_str())
-            .unwrap_or(unicode_script::Script::Unknown)
-    }
-
-    #[cfg(feature = "icu_properties")]
-    fn from_properties_script(value: icu_properties::props::Script) -> Self {
-        let icu: IcuScript = value.into();
-        Self::from_bytes(icu.into_raw())
-    }
-
-    #[cfg(feature = "unicode_script")]
-    fn from_unicode_script(value: unicode_script::Script) -> Self {
-        value.short_name().parse::<Self>().unwrap_or(Self::UNKNOWN)
     }
 }
 


### PR DESCRIPTION
* Remove `icu_properties`/`unicode_script` features and their dependencies from `fontique`.
* Simplify `fontique::ScriptExt` by removing conversion helpers to/from ICU and `unicode_script`; keep only Script utilities like `sample()`.