### PR TITLE
parley: add style-run builder; accept precomputed runs from `styled_text`

### DIFF
--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -10,7 +10,7 @@ use super::style::{Brush, StyleProperty, TextStyle, WhiteSpaceCollapse};
 use super::layout::Layout;
 
 use alloc::string::String;
-use core::ops::RangeBounds;
+use core::ops::{Bound, Range, RangeBounds};
 
 use crate::inline_box::InlineBox;
 use crate::resolve::{ResolvedStyle, StyleRun, tree::ItemKind};
@@ -56,6 +56,96 @@ impl<B: Brush> RangedBuilder<'_, B> {
             .finish(&mut self.lcx.style_table, &mut self.lcx.style_runs);
 
         // Call generic layout builder method
+        build_into_layout(
+            layout,
+            self.scale,
+            self.quantize,
+            text.as_ref(),
+            self.lcx,
+            self.fcx,
+        );
+    }
+
+    pub fn build(self, text: impl AsRef<str>) -> Layout<B> {
+        let mut layout = Layout::default();
+        self.build_into(&mut layout, text);
+        layout
+    }
+}
+
+/// Builder for constructing a text layout from a style table and
+/// indexed style runs.
+#[must_use]
+pub struct StyleRunBuilder<'a, B: Brush> {
+    pub(crate) scale: f32,
+    pub(crate) quantize: bool,
+    pub(crate) len: usize,
+    pub(crate) lcx: &'a mut LayoutContext<B>,
+    pub(crate) fcx: &'a mut FontContext,
+    pub(crate) cursor: usize,
+}
+
+impl<B: Brush> StyleRunBuilder<'_, B> {
+    /// Reserves additional capacity for styles and runs.
+    ///
+    /// This is an optional optimization for callers that know counts
+    /// up front; call it before pushing styles and runs to reduce
+    /// reallocations.
+    pub fn reserve(&mut self, additional_styles: usize, additional_runs: usize) {
+        self.lcx.style_table.reserve(additional_styles);
+        self.lcx.style_runs.reserve(additional_runs);
+    }
+
+    /// Adds a fully-specified style to the shared style table and
+    /// returns its index.
+    pub fn push_style<'family, 'settings>(
+        &mut self,
+        style: TextStyle<'family, 'settings, B>,
+    ) -> u16 {
+        let resolved = self
+            .lcx
+            .rcx
+            .resolve_entire_style_set(self.fcx, &style, self.scale);
+        let style_index = self.lcx.style_table.len();
+        assert!(style_index <= u16::MAX as usize, "too many styles");
+        self.lcx.style_table.push(resolved);
+        style_index as u16
+    }
+
+    /// Adds a style run referencing an entry from the style table.
+    ///
+    /// Runs must be contiguous and non-overlapping, and must cover
+    /// `0..text.len()` once all runs have been added.
+    pub fn push_style_run(&mut self, style_index: u16, range: impl RangeBounds<usize>) {
+        let range = resolve_range(range, self.len);
+        assert!(
+            range.start == self.cursor,
+            "StyleRunBuilder expects contiguous non-overlapping runs"
+        );
+        assert!(
+            range.start <= range.end,
+            "StyleRunBuilder expects ordered ranges"
+        );
+        assert!(
+            (style_index as usize) < self.lcx.style_table.len(),
+            "StyleRunBuilder expects style indices that were previously added via push_style"
+        );
+        self.lcx.style_runs.push(StyleRun {
+            style_index,
+            range: range.clone(),
+        });
+        self.cursor = range.end;
+    }
+
+    pub fn push_inline_box(&mut self, inline_box: InlineBox) {
+        self.lcx.inline_boxes.push(inline_box);
+    }
+
+    pub fn build_into(self, layout: &mut Layout<B>, text: impl AsRef<str>) {
+        assert!(
+            self.cursor == self.len,
+            "StyleRunBuilder requires runs that cover the full text"
+        );
         build_into_layout(
             layout,
             self.scale,
@@ -219,4 +309,18 @@ fn build_into_layout<B: Brush>(
     core::mem::swap(&mut layout.data.inline_boxes, &mut lcx.inline_boxes);
 
     layout.data.finish();
+}
+
+fn resolve_range(range: impl RangeBounds<usize>, len: usize) -> Range<usize> {
+    let start = match range.start_bound() {
+        Bound::Unbounded => 0,
+        Bound::Included(n) => *n,
+        Bound::Excluded(n) => *n + 1,
+    };
+    let end = match range.end_bound() {
+        Bound::Unbounded => len,
+        Bound::Included(n) => *n + 1,
+        Bound::Excluded(n) => *n,
+    };
+    start.min(len)..end.min(len)
 }

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -7,15 +7,18 @@
 //! - [`FontContext`] and [`LayoutContext`] are resources which should be shared globally (or at coarse-grained boundaries).
 //!   - [`FontContext`] is database of fonts.
 //!   - [`LayoutContext`] is scratch space that allows for reuse of allocations between layouts.
-//! - [`RangedBuilder`] and [`TreeBuilder`] which are builders for creating a [`Layout`].
-//!     - [`RangedBuilder`] allows styles to be specified as a flat `Vec` of spans
-//!     - [`TreeBuilder`] allows styles to be specified as a tree of spans
+//! - Builders for creating a [`Layout`]:
+//!   - [`RangedBuilder`]: styles specified as a flat `Vec` of property spans
+//!   - [`TreeBuilder`]: styles specified as a tree of spans
+//!   - [`StyleRunBuilder`]: styles specified as a shared style table plus non-overlapping indexed runs
 //!
-//!   They are constructed using the [`ranged_builder`](LayoutContext::ranged_builder) and [`tree_builder`](LayoutContext::ranged_builder) methods on [`LayoutContext`].
+//!   They are constructed using [`LayoutContext::ranged_builder`], [`LayoutContext::tree_builder`],
+//!   and [`LayoutContext::style_run_builder`].
 //! - [`Layout`] which represents styled paragraph(s) of text and can perform shaping, line-breaking, bidi-reordering, and alignment of that text.
 //!
 //!   `Layout` supports re-linebreaking and re-aligning many times (in case the width at which wrapping should occur changes). But if the text content or
-//!   the styles applied to that content change then a new `Layout` must be created using a new `RangedBuilder` or `TreeBuilder`.
+//!   the styles applied to that content change then a new `Layout` must be created using a new
+//!   `RangedBuilder`, `TreeBuilder`, or `StyleRunBuilder`.
 //!
 //! ## Usage Example
 //!
@@ -128,7 +131,7 @@ mod tests;
 pub use linebender_resource_handle::FontData;
 pub use util::BoundingBox;
 
-pub use builder::{RangedBuilder, TreeBuilder};
+pub use builder::{RangedBuilder, StyleRunBuilder, TreeBuilder};
 pub use context::LayoutContext;
 pub use font::FontContext;
 pub use inline_box::InlineBox;


### PR DESCRIPTION
- Add `LayoutContext::style_run_builder` and a `StyleRunBuilder` API for constructing a Layout from contiguous, non-overlapping style runs, skipping Parley’s internal range-splitting step.
- Update `styled_text_parley` to lower StyledText’s computed runs directly into `StyleRunBuilder` using `TextStyle<'static, '_, B>`.
- Add a parity test ensuring `StyleRunBuilder` output matches `RangedBuilder` for equivalent styles.