### PR TITLE
Fix applying a skew on hinted, scaled text

### DIFF
--- a/parley_draw/src/glyph.rs
+++ b/parley_draw/src/glyph.rs
@@ -582,7 +582,10 @@ fn prepare_glyph_run<'a>(
         });
 
         PreparedGlyphRun {
-            transform: Affine::new([1., 0., t_c, 1., t_e, t_f]),
+            // The scale has been absorbed into the font size, so we need to remove it from the skew coefficient (t_c)
+            // as well. Otherwise the skew would be applied twice: once via the larger outline, once via the transform.
+            // The translation (t_e, t_f) stays as-is since it positions the run in scene coordinates.
+            transform: Affine::new([1., 0., t_c / t_d, 1., t_e, t_f]),
             size,
             normalized_coords: run.normalized_coords,
             hinting_instance,


### PR DESCRIPTION
Fixes [an issue I ran into](https://github.com/linebender/parley/pull/509#discussion_r2699975720) when fixing *another* issue in the underline implementation.

Before:

<img width="432" height="390" alt="image" src="https://github.com/user-attachments/assets/e2fd55a6-8ff4-484b-8742-75c882a8b475" />

After:

<img width="432" height="390" alt="image" src="https://github.com/user-attachments/assets/60d72bae-01f7-4a7b-bafe-819773722e0f" />

And unhinted, for comparison:

<img width="432" height="390" alt="image" src="https://github.com/user-attachments/assets/cf27ff9a-ebc6-4bc3-8b0d-6521adc89f43" />
