### PR TITLE
Upgrade windows crate to 0.62

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,8 +1305,8 @@ dependencies = [
  "roxmltree",
  "smallvec",
  "text_primitives",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
  "yeslogic-fontconfig-sys",
 ]
 
@@ -5417,11 +5417,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -5431,6 +5443,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5493,7 +5514,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5571,6 +5603,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5737,6 +5779,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -47,11 +47,8 @@ hashbrown = { workspace = true }
 text_primitives = { path = "../text_primitives", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.58.0", features = [
-    "implement",
-    "Win32_Graphics_DirectWrite",
-], optional = true }
-windows-core = { version = "0.58.0", optional = true }
+windows = { version = "0.62.2", features = ["Win32_Graphics_DirectWrite"], optional = true }
+windows-core = { version = "0.62.2", optional = true }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 # FIX: Enable relax-sign-encoding to prevent the bug described in this issue: https://github.com/madsmtm/objc2/issues/566

--- a/fontique/src/backend/dwrite.rs
+++ b/fontique/src/backend/dwrite.rs
@@ -19,7 +19,7 @@ use windows::{
         IDWriteFontFamily, IDWriteFontFile, IDWriteLocalFontFileLoader, IDWriteNumberSubstitution,
         IDWriteTextAnalysisSource, IDWriteTextAnalysisSource_Impl,
     },
-    core::{Interface, PCWSTR, implement},
+    core::{Interface, OutRef, PCWSTR, implement},
 };
 
 use super::{
@@ -350,10 +350,10 @@ impl IDWriteTextAnalysisSource_Impl for TextSource_Impl<'_> {
         &self,
         textposition: u32,
         textlength: *mut u32,
-        numbersubstitution: *mut Option<IDWriteNumberSubstitution>,
+        numbersubstitution: OutRef<'_, IDWriteNumberSubstitution>,
     ) -> windows::core::Result<()> {
+        numbersubstitution.write(None)?;
         unsafe {
-            *numbersubstitution = None;
             *textlength = (self.text.len() as u32).saturating_sub(textposition);
         }
         Ok(())


### PR DESCRIPTION
Upgrades the `windows` and `windows-core` crates to the latest 0.62 versions