### PR TITLE
parley: split TextStyle lifetimes for family vs settings

### DIFF
--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -81,7 +81,7 @@ pub struct TreeBuilder<'a, B: Brush> {
 }
 
 impl<B: Brush> TreeBuilder<'_, B> {
-    pub fn push_style_span(&mut self, style: TextStyle<'_, B>) {
+    pub fn push_style_span(&mut self, style: TextStyle<'_, '_, B>) {
         let resolved = self
             .lcx
             .rcx

--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -57,7 +57,7 @@ impl<B: Brush> LayoutContext<B> {
         &mut self,
         font_ctx: &mut FontContext,
         scale: f32,
-        raw_style: &TextStyle<'_, B>,
+        raw_style: &TextStyle<'_, '_, B>,
     ) -> ResolvedStyle<B> {
         self.rcx
             .resolve_entire_style_set(font_ctx, raw_style, scale)
@@ -129,7 +129,7 @@ impl<B: Brush> LayoutContext<B> {
         fcx: &'a mut FontContext,
         scale: f32,
         quantize: bool,
-        root_style: &TextStyle<'_, B>,
+        root_style: &TextStyle<'_, '_, B>,
     ) -> TreeBuilder<'a, B> {
         self.begin();
 

--- a/parley/src/resolve/mod.rs
+++ b/parley/src/resolve/mod.rs
@@ -165,7 +165,7 @@ impl ResolveContext {
     pub(crate) fn resolve_entire_style_set<B: Brush>(
         &mut self,
         fcx: &mut FontContext,
-        raw_style: &TextStyle<'_, B>,
+        raw_style: &TextStyle<'_, '_, B>,
         scale: f32,
     ) -> ResolvedStyle<B> {
         ResolvedStyle {

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -121,9 +121,9 @@ pub enum StyleProperty<'a, B: Brush> {
 
 /// Unresolved styles.
 #[derive(Clone, PartialEq, Debug)]
-pub struct TextStyle<'a, B: Brush> {
+pub struct TextStyle<'family, 'settings, B: Brush> {
     /// CSS `font-family` property value.
-    pub font_family: FontFamily<'a>,
+    pub font_family: FontFamily<'family>,
     /// Font size.
     pub font_size: f32,
     /// Font width.
@@ -133,9 +133,9 @@ pub struct TextStyle<'a, B: Brush> {
     /// Font weight.
     pub font_weight: FontWeight,
     /// Font variation settings.
-    pub font_variations: FontVariations<'a>,
+    pub font_variations: FontVariations<'settings>,
     /// Font feature settings.
-    pub font_features: FontFeatures<'a>,
+    pub font_features: FontFeatures<'settings>,
     /// Locale.
     pub locale: Option<Language>,
     /// Brush for rendering text.
@@ -170,7 +170,7 @@ pub struct TextStyle<'a, B: Brush> {
     pub text_wrap_mode: TextWrapMode,
 }
 
-impl<B: Brush> Default for TextStyle<'_, B> {
+impl<B: Brush> Default for TextStyle<'static, 'static, B> {
     fn default() -> Self {
         TextStyle {
             font_family: FontFamily::Source(Cow::Borrowed("sans-serif")),

--- a/parley/src/tests/test_builders.rs
+++ b/parley/src/tests/test_builders.rs
@@ -27,7 +27,7 @@ struct TreeOptions<'a, 'b> {
     scale: f32,
     quantize: bool,
     max_advance: Option<f32>,
-    root_style: &'a TextStyle<'b, ColorBrush>,
+    root_style: &'a TextStyle<'b, 'b, ColorBrush>,
 }
 
 /// Generates a `Layout` with a ranged builder.
@@ -73,12 +73,12 @@ fn build_layout_with_tree(
 /// LayoutContext D - Tree for dirt
 /// LayoutContext D - Ranged from dirty
 /// ```
-fn assert_builders_produce_same_result<'a, 'b>(
+fn assert_builders_produce_same_result<'b>(
     text: &str,
     scale: f32,
     quantize: bool,
     max_advance: Option<f32>,
-    root_style: &'a TextStyle<'b, ColorBrush>,
+    root_style: &TextStyle<'b, 'b, ColorBrush>,
     with_ranged_builder: impl Fn(&mut RangedBuilder<'_, ColorBrush>),
     with_tree_builder: impl Fn(&mut TreeBuilder<'_, ColorBrush>),
     expect_empty: bool,
@@ -160,7 +160,7 @@ fn assert_builders_produce_same_result<'a, 'b>(
 /// Returns a root style that uses non-default values.
 ///
 /// The [`TreeBuilder`] version of [`set_root_style`].
-fn create_root_style() -> TextStyle<'static, ColorBrush> {
+fn create_root_style() -> TextStyle<'static, 'static, ColorBrush> {
     TextStyle {
         font_family: FontFamily::from(FONT_FAMILY_LIST),
         font_size: 20.,


### PR DESCRIPTION
Change `TextStyle` to take two lifetimes: one for `FontFamily` and one for OpenType settings (`FontVariations` / `FontFeatures`). This lets callers keep a long-lived font-family value while borrowing per-run settings without forcing both to share a single lifetime.

Update internal APIs and tests to use `TextStyle<'_, '_, B>`.