### PR TITLE
Fix cursor tests to use `create_font_context`

### DIFF
--- a/parley_tests/Cargo.toml
+++ b/parley_tests/Cargo.toml
@@ -15,8 +15,7 @@ name = "tests"
 path = "tests/mod.rs"
 
 [dependencies]
-# TODO: fix the cursor_ligature_selection test so it doesn't depend on system fonts, then remove the "system" feature
-parley = { workspace = true, features = ["std", "system"] }
+parley = { workspace = true, features = ["std"] }
 parley_dev = { workspace = true }
 peniko = { workspace = true, features = ["std"] }
 tiny-skia = "0.11.4"


### PR DESCRIPTION
This fixes the previously-flaky `cursor_ligature_selection` test, allowing the test suite to run without using Parley's `system` feature.

I also added a check in `cursor_ligature_selection` that we are, in fact, rendering a ligature.