### PR TITLE
Fontique: add `load_system_fonts` and `load_fonts_from_paths` methods

### DIFF
--- a/fontique/src/collection/mod.rs
+++ b/fontique/src/collection/mod.rs
@@ -86,7 +86,6 @@ impl Collection {
     }
 
     /// Load system fonts. If system fonts are already loaded then this does nothing.
-    /// See [`Self::reload_system_fonts`] to reload already-loaded system fonts.
     pub fn load_system_fonts(&mut self) {
         if self.inner.system.is_none() {
             self.inner.load_system_fonts();


### PR DESCRIPTION
Adds additional methods with the aim of making `fontique` a suitable replacement for `fontdb` in resvg:

- `load_system_fonts` loads system fonts into a `Collection` that did not specify loading them at creation time
- `load_fonts_from_paths` loads all fonts from the specified directory(s)