### PR TITLE
Fix cursor rectangle calculation for last line

### DIFF
--- a/parley/src/editing/cursor.rs
+++ b/parley/src/editing/cursor.rs
@@ -453,9 +453,9 @@ fn last_line_cursor_rect<B: Brush>(layout: &Layout<B>, size: f32) -> BoundingBox
     if let Some(line) = layout.get(layout.len().saturating_sub(1)) {
         let metrics = line.metrics();
         BoundingBox::new(
-            0.0,
+            metrics.offset as f64,
             metrics.min_coord as f64,
-            size as f64,
+            (metrics.offset + size) as f64,
             metrics.max_coord as f64,
         )
     } else {


### PR DESCRIPTION
this fixes https://github.com/linebender/parley/issues/534 so that the cursor goes to the right position or an empty line when alignment is center or right