### PR TITLE
Treat Line Separator and Paragraph Separator as mandatory break.

### DIFF
--- a/parley/src/analysis/cluster.rs
+++ b/parley/src/analysis/cluster.rs
@@ -68,7 +68,7 @@ pub(crate) enum Whitespace {
     NoBreakSpace = 2,
     /// Horizontal tab.
     Tab = 3,
-    /// Newline (CR, LF, or CRLF).
+    /// Newline (CR, LF, CRLF, LS, or PS).
     Newline = 4,
 }
 

--- a/parley/src/analysis/mod.rs
+++ b/parley/src/analysis/mod.rs
@@ -477,7 +477,7 @@ pub(crate) fn analyze_text<B: Brush>(lcx: &mut LayoutContext<B>, mut text: &str)
                     bracket,
                     is_variation_selector,
                     is_region_indicator,
-                    is_control(general_category),
+                    general_category == GeneralCategory::Control,
                     is_emoji_or_pictograph,
                     contributes_to_shaping(general_category, script),
                     force_normalize,
@@ -505,14 +505,14 @@ pub(crate) fn analyze_text<B: Brush>(lcx: &mut LayoutContext<B>, mut text: &str)
 /// - Format characters, unless they use the "Inherited" script
 #[inline(always)]
 pub(crate) fn contributes_to_shaping(general_category: GeneralCategory, script: Script) -> bool {
-    if is_control(general_category) {
+    if matches!(
+        general_category,
+        GeneralCategory::Control
+            | GeneralCategory::LineSeparator
+            | GeneralCategory::ParagraphSeparator
+    ) {
         return false;
     }
 
     !(general_category == GeneralCategory::Format && script != Script::Inherited)
-}
-
-#[inline(always)]
-fn is_control(general_category: GeneralCategory) -> bool {
-    general_category == GeneralCategory::Control
 }

--- a/parley/src/editing/editor.rs
+++ b/parley/src/editing/editor.rs
@@ -1147,7 +1147,7 @@ where
 
         self.update_layout(font_cx, layout_cx);
         let new_index = start.saturating_add(s.len());
-        let affinity = if s.ends_with("\n") {
+        let affinity = if s.ends_with(['\n', '\r', '\u{2028}', '\u{2029}']) {
             Affinity::Downstream
         } else {
             Affinity::Upstream

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -101,12 +101,14 @@ impl ClusterInfo {
     }
 }
 
-fn to_whitespace(c: char) -> Whitespace {
+const fn to_whitespace(c: char) -> Whitespace {
+    const LINE_SEPARATOR: char = '\u{2028}';
+    const PARAGRAPH_SEPARATOR: char = '\u{2029}';
+
     match c {
         ' ' => Whitespace::Space,
         '\t' => Whitespace::Tab,
-        '\n' => Whitespace::Newline,
-        '\r' => Whitespace::Newline,
+        '\n' | '\r' | LINE_SEPARATOR | PARAGRAPH_SEPARATOR => Whitespace::Newline,
         '\u{00A0}' => Whitespace::NoBreakSpace,
         _ => Whitespace::None,
     }

--- a/parley/src/tests/test_analysis.rs
+++ b/parley/src/tests/test_analysis.rs
@@ -177,6 +177,20 @@ fn test_mandatory_break_in_text() {
 }
 
 #[test]
+fn test_line_separator_is_hard_break() {
+    verify_analysis("A\u{2028}B", |_| {})
+        .expect_boundary_list(vec![Boundary::Word, Boundary::Word, Boundary::Mandatory])
+        .expect_contributes_to_shaping_list(vec![true, false, true]);
+}
+
+#[test]
+fn test_paragraph_separator_is_hard_break() {
+    verify_analysis("A\u{2029}B", |_| {})
+        .expect_boundary_list(vec![Boundary::Word, Boundary::Word, Boundary::Mandatory])
+        .expect_contributes_to_shaping_list(vec![true, false, true]);
+}
+
+#[test]
 fn test_blank() {
     verify_analysis("", |_| {})
         .expect_boundary_list(vec![Boundary::Word])

--- a/parley_tests/tests/editor.rs
+++ b/parley_tests/tests/editor.rs
@@ -5,6 +5,7 @@
 
 use crate::test_name;
 use crate::util::TestEnv;
+use parley::Affinity;
 
 // TODO - Use CursorTest API for these tests
 
@@ -71,4 +72,47 @@ fn editor_double_newline() {
     let mut editor = env.editor("Hi, all!\n\nNext");
     env.driver(&mut editor).select_all();
     env.check_editor_snapshot(&mut editor);
+}
+
+#[test]
+fn editor_insert_line_endings_set_downstream_affinity() {
+    let mut env = TestEnv::new(test_name!(), None);
+
+    for (insert, expected_text) in [
+        ("\n", "A\nB"),
+        ("\r", "A\rB"),
+        ("\u{2028}", "A\u{2028}B"),
+        ("\u{2029}", "A\u{2029}B"),
+        ("X\n", "AX\nB"),
+        ("X\r", "AX\rB"),
+        ("X\u{2028}", "AX\u{2028}B"),
+        ("X\u{2029}", "AX\u{2029}B"),
+    ] {
+        let mut editor = env.editor("AB");
+        env.driver(&mut editor).move_right(); // between A and B
+        env.driver(&mut editor).insert_or_replace_selection(insert);
+
+        assert_eq!(editor.raw_text(), expected_text);
+
+        let sel = editor.raw_selection();
+        assert!(sel.is_collapsed());
+        assert_eq!(sel.focus().index(), expected_text.len() - 1);
+        assert_eq!(sel.focus().affinity(), Affinity::Downstream);
+    }
+}
+
+#[test]
+fn editor_insert_regular_text_set_upstream_affinity() {
+    let mut env = TestEnv::new(test_name!(), None);
+
+    let mut editor = env.editor("AB");
+    env.driver(&mut editor).move_right(); // between A and B
+    env.driver(&mut editor).insert_or_replace_selection("X");
+
+    assert_eq!(editor.raw_text(), "AXB");
+
+    let sel = editor.raw_selection();
+    assert!(sel.is_collapsed());
+    assert_eq!(sel.focus().index(), 2);
+    assert_eq!(sel.focus().affinity(), Affinity::Upstream);
 }


### PR DESCRIPTION
Unicode has a specific codepoint intended to signal an unambiguous line separator, `U+2028 LINE SEPARATOR` often abbreviated LS (along with `U+2029 PARAGRAPH SEPARATOR`, often abbreviated PS).

The interpretation of these for line breaking is defined in TR14 <https://www.unicode.org/reports/tr14/#BK>, which has this to say:

> `2028  LINE SEPARATOR`
> The text after the LINE SEPARATOR starts at the beginning of the line. This is similar to HTML `<br>`.
> 
> `2029  PARAGRAPH SEPARATOR`
> The text of the new paragraph starts at the beginning of the line. This character defines a paragraph break, causing suitable formatting to be applied, for example, interparagraph spacing or first line indentation. LINE SEPARATOR, FF, VT as well as CR, LF and NL do not define a paragraph break.