### PR TITLE
attributed_text: return ranges from attributes_at and attributes_for_range

### DIFF
--- a/attributed_text/src/attributed_text.rs
+++ b/attributed_text/src/attributed_text.rs
@@ -85,30 +85,31 @@ impl<T: Debug + TextStorage, Attr: Debug> AttributedText<T, Attr> {
         self.attributes.iter().map(|(range, attr)| (range, attr))
     }
 
-    /// Get an iterator over the attributes that apply at the given `index`.
+    /// Get an iterator over the attributes (and their ranges) that apply at the given `index`.
     ///
-    /// This doesn't handle conflicting attributes, it just reports everything.
-    ///
-    /// TODO: Decide if this should also return the spans' ranges.
-    pub fn attributes_at(&self, index: usize) -> impl Iterator<Item = &Attr> {
+    /// Attributes are yielded in the order they were applied. This doesn't handle conflicting
+    /// attributes, it just reports everything.
+    pub fn attributes_at(&self, index: usize) -> impl Iterator<Item = (&Range<usize>, &Attr)> {
         self.attributes.iter().filter_map(move |(attr_span, attr)| {
             if attr_span.contains(&index) {
-                Some(attr)
+                Some((attr_span, attr))
             } else {
                 None
             }
         })
     }
 
-    /// Get an iterator over the attributes that apply to the given `range`.
+    /// Get an iterator over the attributes (and their ranges) that overlap the given `range`.
     ///
-    /// This doesn't handle conflicting attributes, it just reports everything.
-    ///
-    /// TODO: Decide if this should also return the spans' ranges.
-    pub fn attributes_for_range(&self, range: Range<usize>) -> impl Iterator<Item = &Attr> {
+    /// Attributes are yielded in the order they were applied. This doesn't handle conflicting
+    /// attributes, it just reports everything.
+    pub fn attributes_for_range(
+        &self,
+        range: Range<usize>,
+    ) -> impl Iterator<Item = (&Range<usize>, &Attr)> {
         self.attributes.iter().filter_map(move |(attr_span, attr)| {
             if (attr_span.start < range.end) && (attr_span.end > range.start) {
-                Some(attr)
+                Some((attr_span, attr))
             } else {
                 None
             }
@@ -151,7 +152,49 @@ mod tests {
             TestAttribute::Remove,
         );
 
+        // Index 0 is outside both spans.
         assert!(at.attributes_at(0).collect::<Vec<_>>().is_empty());
+
+        // Index 2 is in both spans; returns ranges and attrs in application order.
+        let at_2: Vec<_> = at.attributes_at(2).collect();
+        assert_eq!(at_2.len(), 2);
+        assert_eq!(at_2[0], (&(1..3), &TestAttribute::Keep));
+        assert_eq!(at_2[1], (&(2..5), &TestAttribute::Remove));
+
+        // Index 4 is only in the second span.
+        let at_4: Vec<_> = at.attributes_at(4).collect();
+        assert_eq!(at_4.len(), 1);
+        assert_eq!(at_4[0], (&(2..5), &TestAttribute::Remove));
+    }
+
+    #[test]
+    fn attributes_for_range() {
+        let t = "Hello!";
+        let mut at = AttributedText::new(t);
+
+        at.apply_attribute(
+            TextRange::new(at.text(), 1..3).unwrap(),
+            TestAttribute::Keep,
+        );
+        at.apply_attribute(
+            TextRange::new(at.text(), 4..6).unwrap(),
+            TestAttribute::Remove,
+        );
+
+        // Range overlapping only the first span.
+        let r: Vec<_> = at.attributes_for_range(0..2).collect();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0], (&(1..3), &TestAttribute::Keep));
+
+        // Range overlapping both spans.
+        let r: Vec<_> = at.attributes_for_range(2..5).collect();
+        assert_eq!(r.len(), 2);
+        assert_eq!(r[0], (&(1..3), &TestAttribute::Keep));
+        assert_eq!(r[1], (&(4..6), &TestAttribute::Remove));
+
+        // Range between the two spans, overlapping neither.
+        let r: Vec<_> = at.attributes_for_range(3..4).collect();
+        assert!(r.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Consumers need span boundaries to implement resolution strategies (e.g. narrower-span-wins, cascade by specificity). Previously these methods returned only `&Attr`, forcing a re-scan through `attributes_iter()` to recover the range.