### PR TITLE
Return `ExactSizeIterator` from `Layout::lines`.

### DIFF
--- a/parley/src/layout/layout.rs
+++ b/parley/src/layout/layout.rs
@@ -96,7 +96,7 @@ impl<B: Brush> Layout<B> {
     }
 
     /// Returns an iterator over the lines in the layout.
-    pub fn lines(&self) -> impl Iterator<Item = Line<'_, B>> + '_ + Clone {
+    pub fn lines(&self) -> impl ExactSizeIterator<Item = Line<'_, B>> + '_ + Clone {
         self.data
             .lines
             .iter()


### PR DESCRIPTION
This enables some more optimizations for consumers of these iterators.