### PR TITLE
attributed_text: add IntoIterator support for ActiveSpans

### DIFF
--- a/attributed_text/src/lib.rs
+++ b/attributed_text/src/lib.rs
@@ -26,7 +26,9 @@ mod error;
 mod text_range;
 mod text_storage;
 
-pub use crate::attribute_segments::{ActiveSpans, AttributeSegments, AttributeSegmentsWorkspace};
+pub use crate::attribute_segments::{
+    ActiveSpans, ActiveSpansIter, AttributeSegments, AttributeSegmentsWorkspace,
+};
 pub use crate::attributed_text::AttributedText;
 pub use crate::error::{BoundaryInfo, Endpoint, Error, ErrorKind};
 pub use crate::text_range::TextRange;


### PR DESCRIPTION
Implement `IntoIterator` for `&ActiveSpans` so callers can iterate with for loops without extra allocation.

Expose `ActiveSpansIter` and `ActiveSpansIterRev`, update docs with an `&active_spans` loop example, and add a unit test for reference iteration semantics.