### PR TITLE
Return `DoubleEndedIterator` from `Layout::lines`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ You can find its changes [documented below](#060---2025-11-24).
 
 This release has an [MSRV] of 1.88.
 
+### Added
+
+#### Parley
+
+- `Layout::lines` now returns an iterator that also implements `ExactSizeIterator` and `DoubleEndedIterator`. ([#554][], [#560][] by [@xStrom])
+
 ### Changed
 
 #### Parley
@@ -471,6 +477,8 @@ This release has an [MSRV][] of 1.70.
 [#468]: https://github.com/linebender/parley/pull/468
 [#528]: https://github.com/linebender/parley/pull/528
 [#532]: https://github.com/linebender/parley/pull/532
+[#554]: https://github.com/linebender/parley/pull/554
+[#560]: https://github.com/linebender/parley/pull/560
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.7.0...HEAD
 [0.7.0]: https://github.com/linebender/parley/compare/v0.6.0...v0.7.0

--- a/parley/src/layout/layout.rs
+++ b/parley/src/layout/layout.rs
@@ -96,7 +96,9 @@ impl<B: Brush> Layout<B> {
     }
 
     /// Returns an iterator over the lines in the layout.
-    pub fn lines(&self) -> impl ExactSizeIterator<Item = Line<'_, B>> + '_ + Clone {
+    pub fn lines(
+        &self,
+    ) -> impl ExactSizeIterator<Item = Line<'_, B>> + DoubleEndedIterator + '_ + Clone {
         self.data
             .lines
             .iter()


### PR DESCRIPTION
`DoubleEndedIterator` is in addition to the existing `ExactSizeIterator`.

This enables some more optimizations for consumers of these iterators.