### PR TITLE
fix(fontique): clear fallback_families cache on attribute change

### DIFF
--- a/fontique/src/collection/query.rs
+++ b/fontique/src/collection/query.rs
@@ -83,6 +83,9 @@ impl<'a> Query<'a> {
             for family in &mut self.state.families {
                 family.clear_fonts();
             }
+            for family in &mut self.state.fallback_families {
+                family.clear_fonts();
+            }
             self.attributes = attributes;
         }
     }


### PR DESCRIPTION
When font attributes change (for example weight/style for bold/italic), `Query::set_attributes()` cleared cached matches for primary families but did not clear the `fallback_families` cache.

If a run resolves through fallback fonts, this can reuse a stale fallback font match after an attribute change, so later segments may be shaped with the wrong fallback face/synthesis state. In practice this shows up as bold/italic being incorrectly applied, missing, or appearing order-dependent across text segments.

Clear the `fallback_families` cache alongside the regular families cache so fallback font resolution is recomputed for the updated attributes.