### PR TITLE
Fix font family name override being ignored during registration

### DIFF
--- a/fontique/src/collection/mod.rs
+++ b/fontique/src/collection/mod.rs
@@ -750,7 +750,7 @@ impl CommonData {
                 font.apply_override(info_override);
             }
 
-            let name = self.family_names.get_or_insert(scratch_family_name);
+            let name = self.family_names.get_or_insert(family_name);
             families
                 .entry(name.id())
                 .or_insert_with(|| (name, Vec::default()))


### PR DESCRIPTION
When `FontInfoOverride.family_name` is provided, the overridden name should be used as the key for family grouping. Currently, `scratch_family_name` (the original name extracted from the font binary) is used instead, causing fonts registered with a custom family name to be filed under their original name and become unreachable by the override name.

This fix changes the grouping key from `scratch_family_name` to `family_name` (the post-override value) when inserting into the families map.