### PR TITLE
Fix justification space count for non-space line breaks

### DIFF
--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -877,9 +877,18 @@ fn try_commit_line<B: Brush>(
     //     return false;
     // }
 
-    // Q: why this special case?
+    // Exclude the trailing space from justification space count.
+    // Only subtract if the line actually ends with a space — with
+    // WordBreak::BreakAll, regular breaks can land between non-space
+    // characters, in which case there is no trailing space to exclude.
     let mut num_spaces = state.num_spaces;
-    if break_reason == BreakReason::Regular {
+    if break_reason == BreakReason::Regular
+        && state.clusters.start < state.clusters.end
+        && layout.data.clusters[state.clusters.end - 1]
+            .info
+            .whitespace()
+            .is_space_or_nbsp()
+    {
         num_spaces = num_spaces.saturating_sub(1);
     }
 


### PR DESCRIPTION
When using `WordBreak::BreakAll`, lines can break between non-space characters. The trailing-space exclusion unconditionally subtracts 1 from `num_spaces` for all `BreakReason::Regular` breaks, even when the line does not end with a space. This produces an incorrect space count and corrupts justification spacing.

This fix adds a guard to only subtract when the last cluster on the line is actually a space or NBSP character.