### PR TITLE
Reset fallback cache when fallback families are modified

### DIFF
--- a/fontique/src/collection/mod.rs
+++ b/fontique/src/collection/mod.rs
@@ -432,6 +432,7 @@ impl Inner {
         families: impl Iterator<Item = FamilyId>,
     ) -> bool {
         self.sync_shared();
+        self.fallback_cache.reset();
         #[cfg(feature = "std")]
         if let Some(shared) = &self.shared {
             let result = shared.data.lock().unwrap().fallbacks.set(key, families);
@@ -451,6 +452,7 @@ impl Inner {
         families: impl Iterator<Item = FamilyId>,
     ) -> bool {
         self.sync_shared();
+        self.fallback_cache.reset();
         #[cfg(feature = "std")]
         if let Some(shared) = &self.shared {
             let result = shared.data.lock().unwrap().fallbacks.append(key, families);


### PR DESCRIPTION
`set_fallbacks` and `append_fallbacks` update `data.fallbacks` but do not invalidate `fallback_cache`. The cache is a single-entry store keyed by `(script, language)` and is only repopulated on a cache miss. When the same script is queried after a fallback update, stale cached families are returned, making newly registered fonts (e.g., a color emoji font loaded on demand) invisible until a different script forces a cache eviction.

This fix adds `self.fallback_cache.reset()` at the top of both `set_fallbacks` and `append_fallbacks` to ensure subsequent `fallback_families` calls see the updated data.