### PR TITLE
parley_draw: Properly support stroked paths in glyph cache

### DIFF
--- a/parley_draw/src/atlas/commands.rs
+++ b/parley_draw/src/atlas/commands.rs
@@ -57,6 +57,8 @@ pub enum AtlasCommand {
     SetPaintTransform(Affine),
     /// Fill a path with the current paint and transform.
     FillPath(Arc<BezPath>),
+    /// Stroke a path with the current paint and transform.
+    StrokePath(Arc<BezPath>),
     /// Fill a rectangle with the current paint and transform.
     FillRect(Rect),
     /// Push a clip layer defined by a path.
@@ -135,6 +137,13 @@ impl AtlasCommandRecorder {
     #[inline]
     pub fn fill_path(&mut self, path: &Arc<BezPath>) {
         self.commands.push(AtlasCommand::FillPath(Arc::clone(path)));
+    }
+
+    /// Stroke a path with the current paint and transform.
+    #[inline]
+    pub fn stroke_path(&mut self, path: &Arc<BezPath>) {
+        self.commands
+            .push(AtlasCommand::StrokePath(Arc::clone(path)));
     }
 
     /// Fill a rectangle with the current paint and transform.

--- a/parley_draw/src/atlas/key.rs
+++ b/parley_draw/src/atlas/key.rs
@@ -44,6 +44,8 @@ pub struct GlyphCacheKey {
     pub size_bits: u32,
     /// Whether hinting was applied.
     pub hinted: bool,
+    /// Whether this is a stroked glyph (as opposed to filled).
+    pub stroked: bool,
     /// Horizontal subpixel position (0 to SUBPIXEL_BUCKETS-1).
     pub subpixel_x: u8,
     /// Context color for COLR glyphs. Only used for rendering, not for Hash/Eq.
@@ -66,6 +68,7 @@ impl GlyphCacheKey {
         glyph_id: u32,
         size: f32,
         hinted: bool,
+        stroked: bool,
         fractional_x: f32,
         context_color: AlphaColor<Srgb>,
         context_color_packed: u32,
@@ -77,6 +80,7 @@ impl GlyphCacheKey {
             glyph_id,
             size_bits: size.to_bits(),
             hinted,
+            stroked,
             subpixel_x: quantize_subpixel(fractional_x),
             context_color,
             context_color_packed,
@@ -97,6 +101,7 @@ impl Hash for GlyphCacheKey {
         self.glyph_id.hash(state);
         self.size_bits.hash(state);
         self.hinted.hash(state);
+        self.stroked.hash(state);
         self.subpixel_x.hash(state);
         self.context_color_packed.hash(state);
     }
@@ -111,6 +116,7 @@ impl PartialEq for GlyphCacheKey {
             && self.font_index == other.font_index
             && self.size_bits == other.size_bits
             && self.hinted == other.hinted
+            && self.stroked == other.stroked
             && self.context_color_packed == other.context_color_packed
     }
 }
@@ -183,8 +189,8 @@ mod tests {
     #[test]
     fn test_key_equality() {
         let packed = pack_color(BLACK);
-        let key1 = GlyphCacheKey::new(1, 0, 42, 16.0, true, 0.3, BLACK, packed, &[]);
-        let key2 = GlyphCacheKey::new(1, 0, 42, 16.0, true, 0.3, BLACK, packed, &[]);
+        let key1 = GlyphCacheKey::new(1, 0, 42, 16.0, true, false, 0.3, BLACK, packed, &[]);
+        let key2 = GlyphCacheKey::new(1, 0, 42, 16.0, true, false, 0.3, BLACK, packed, &[]);
         assert_eq!(key1, key2);
     }
 
@@ -193,13 +199,14 @@ mod tests {
         let packed = pack_color(BLACK);
         // var_coords is excluded from Hash/Eq (two-level map handles it),
         // so keys differing only in var_coords are considered equal.
-        let key1 = GlyphCacheKey::new(1, 0, 42, 16.0, true, 0.3, BLACK, packed, &[]);
+        let key1 = GlyphCacheKey::new(1, 0, 42, 16.0, true, false, 0.3, BLACK, packed, &[]);
         let key2 = GlyphCacheKey::new(
             1,
             0,
             42,
             16.0,
             true,
+            false,
             0.3,
             BLACK,
             packed,

--- a/parley_draw/src/glyph.rs
+++ b/parley_draw/src/glyph.rs
@@ -288,6 +288,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone, C: GlyphCache>
         let cache_enabled = self.atlas_cache_enabled
             && hinted_size <= self.glyph_atlas.config().max_cached_font_size;
 
+        let stroked = matches!(style, Style::Stroke);
         let render_glyph: fn(&mut R, PreparedGlyph<'_>, &mut C, &mut ImageCache) = match style {
             Style::Fill => R::fill_glyph,
             Style::Stroke => R::stroke_glyph,
@@ -318,6 +319,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone, C: GlyphCache>
                     glyph.id,
                     hinted_size,
                     hinted,
+                    stroked,
                     fractional_x,
                     BLACK,
                     BLACK_PACKED,
@@ -355,6 +357,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone, C: GlyphCache>
                     glyph_id: glyph.id,
                     size_bits: hinted_size.to_bits(),
                     hinted: false,
+                    stroked: false,
                     subpixel_x: 0,
                     context_color,
                     context_color_packed,
@@ -432,6 +435,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone, C: GlyphCache>
                     glyph_id: glyph.id,
                     size_bits: bitmap_ppem.to_bits(),
                     hinted: false,
+                    stroked: false,
                     subpixel_x: 0,
                     context_color: BLACK,
                     context_color_packed: BLACK_PACKED,

--- a/parley_draw/src/renderers/vello_cpu.rs
+++ b/parley_draw/src/renderers/vello_cpu.rs
@@ -499,6 +499,11 @@ impl AtlasReplayTarget for RenderContext {
     }
 
     #[inline]
+    fn stroke_path(&mut self, path: &BezPath) {
+        Self::stroke_path(self, path);
+    }
+
+    #[inline]
     fn fill_rect(&mut self, rect: &Rect) {
         Self::fill_rect(self, rect);
     }

--- a/parley_draw/src/renderers/vello_hybrid.rs
+++ b/parley_draw/src/renderers/vello_hybrid.rs
@@ -423,6 +423,11 @@ impl AtlasReplayTarget for Scene {
     }
 
     #[inline]
+    fn stroke_path(&mut self, path: &BezPath) {
+        Self::stroke_path(self, path);
+    }
+
+    #[inline]
     fn fill_rect(&mut self, rect: &Rect) {
         Self::fill_rect(self, rect);
     }

--- a/parley_draw/src/renderers/vello_renderer.rs
+++ b/parley_draw/src/renderers/vello_renderer.rs
@@ -214,6 +214,7 @@ pub(crate) fn stroke_glyph<B: GlyphAtlasBackend>(
 fn render_outline_to_atlas(
     path: &Arc<BezPath>,
     subpixel_offset: f32,
+    stroked: bool,
     recorder: &mut AtlasCommandRecorder,
     dst_x: u16,
     dst_y: u16,
@@ -225,7 +226,11 @@ fn render_outline_to_atlas(
     ));
     recorder.set_transform(outline_transform);
     recorder.set_paint(BLACK);
-    recorder.fill_path(path);
+    if stroked {
+        recorder.stroke_path(path);
+    } else {
+        recorder.fill_path(path);
+    }
 }
 
 /// Record COLR glyph draw commands into the atlas command recorder.
@@ -264,6 +269,7 @@ fn insert_and_render_outline<B: GlyphAtlasBackend>(
     let raster_metrics = calculate_raster_metrics(&bounds);
 
     let subpixel_offset = subpixel_offset(cache_key.subpixel_x);
+    let stroked = cache_key.stroked;
 
     let Some((dst_x, dst_y, atlas_slot, recorder)) =
         glyph_atlas.insert(image_cache, cache_key, raster_metrics)
@@ -274,6 +280,7 @@ fn insert_and_render_outline<B: GlyphAtlasBackend>(
     render_outline_to_atlas(
         path,
         subpixel_offset,
+        stroked,
         recorder,
         dst_x,
         dst_y,
@@ -552,6 +559,8 @@ pub trait AtlasReplayTarget {
     fn set_paint_transform(&mut self, t: Affine);
     /// Fill a path with the current paint and transform.
     fn fill_path(&mut self, path: &BezPath);
+    /// Stroke a path with the current paint and transform.
+    fn stroke_path(&mut self, path: &BezPath);
     /// Fill a rectangle with the current paint and transform.
     fn fill_rect(&mut self, rect: &Rect);
     /// Push a clip layer defined by a path.
@@ -576,6 +585,7 @@ pub fn replay_atlas_commands(
             AtlasCommand::SetPaint(AtlasPaint::Gradient(g)) => target.set_paint_gradient(g),
             AtlasCommand::SetPaintTransform(t) => target.set_paint_transform(t),
             AtlasCommand::FillPath(p) => target.fill_path(&p),
+            AtlasCommand::StrokePath(p) => target.stroke_path(&p),
             AtlasCommand::FillRect(r) => target.fill_rect(&r),
             AtlasCommand::PushClipLayer(c) => target.push_clip_layer(&c),
             AtlasCommand::PushBlendLayer(m) => target.push_blend_layer(m),


### PR DESCRIPTION
They were not really supported before, and would just be treated as filled glyphs.