### PR TITLE
[parley_draw] Remove trivial dependencies on `vello_common`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,6 +2861,7 @@ dependencies = [
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
  "log",
+ "peniko",
  "png 0.17.16",
  "skrifa 0.40.0",
  "smallvec",

--- a/parley_draw/Cargo.toml
+++ b/parley_draw/Cargo.toml
@@ -31,6 +31,7 @@ bytemuck = { workspace = true }
 foldhash = { workspace = true }
 log = { version = "0.4", default-features = false }
 hashbrown = { workspace = true }
+peniko = { workspace = true }
 skrifa = { workspace = true }
 smallvec = { workspace = true }
 vello_common = { workspace = true }

--- a/parley_draw/src/atlas/key.rs
+++ b/parley_draw/src/atlas/key.rs
@@ -8,12 +8,12 @@
 //! COLR context color, and variable-font coordinates. Two keys that compare
 //! equal produce identical bitmaps and can safely share a single atlas entry.
 
+use crate::color::{AlphaColor, Srgb};
 use core::hash::{Hash, Hasher};
 #[cfg(not(feature = "std"))]
 use core_maths::CoreFloat as _;
 use skrifa::instance::NormalizedCoord;
 use smallvec::SmallVec;
-use vello_common::color::{AlphaColor, Srgb};
 
 /// Number of horizontal subpixel quantization buckets (valid range: 1–253).
 ///
@@ -165,7 +165,7 @@ pub fn subpixel_offset(quantized: u8) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    use vello_common::color::palette::css::BLACK;
+    use crate::color::palette::css::BLACK;
 
     use super::*;
 

--- a/parley_draw/src/glyph.rs
+++ b/parley_draw/src/glyph.rs
@@ -14,6 +14,8 @@ use crate::atlas::AtlasSlot;
 use crate::atlas::GlyphCacheKey;
 use crate::atlas::key::{SUBPIXEL_BITMAP, SUBPIXEL_COLR, pack_color};
 use crate::atlas::{GlyphCache, ImageCache};
+use crate::color::PremulRgba8;
+use crate::color::palette::css::BLACK;
 use crate::colr::convert_bounding_box;
 use crate::kurbo::Point;
 use crate::kurbo::Rect;
@@ -39,8 +41,6 @@ use skrifa::raw::TableProvider;
 use skrifa::{FontRef, OutlineGlyphCollection};
 use skrifa::{GlyphId, MetadataProvider};
 use smallvec::SmallVec;
-use vello_common::color::PremulRgba8;
-use vello_common::color::palette::css::BLACK;
 
 /// Pre-packed `BLACK` color as a `u32` for use in `GlyphCacheKey`.
 const BLACK_PACKED: u32 = PremulRgba8 {

--- a/parley_draw/src/lib.rs
+++ b/parley_draw/src/lib.rs
@@ -33,7 +33,8 @@ use png as _;
 #[cfg(feature = "std")]
 extern crate std;
 
-use vello_common::{color, kurbo, peniko, pixmap::Pixmap};
+use peniko::{self, color, kurbo};
+use vello_common::pixmap::Pixmap;
 
 pub mod atlas;
 mod colr;


### PR DESCRIPTION
Adds an explicit `peniko` dependency to `parley_draw` so that `peniko`, `kurbo`, and `color` types don't need to be imported via `vello_common`. Makes it easier to see where we're actually depending on `vello_common` in a deep way.