### PR TITLE
Fontique: fix panic on Windows 7

### DIFF
--- a/fontique/src/backend/dwrite.rs
+++ b/fontique/src/backend/dwrite.rs
@@ -10,6 +10,7 @@ use std::{
     os::windows::ffi::OsStringExt,
     path::PathBuf,
 };
+use windows::Win32::Foundation::STATUS_NOT_FOUND;
 use windows::{
     Win32::Graphics::DirectWrite::{
         DWRITE_FACTORY_TYPE_SHARED, DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE_NORMAL,
@@ -133,22 +134,24 @@ impl FontInfo {
 
 struct DWriteSystemFonts {
     collection: IDWriteFontCollection,
-    fallback: IDWriteFontFallback,
+    fallback: Option<IDWriteFontFallback>,
     map_buf: Vec<u16>,
 }
 
 impl DWriteSystemFonts {
-    fn new(update: bool) -> Option<Self> {
+    fn new(update: bool) -> windows_core::Result<Self> {
         unsafe {
-            let factory = DWriteCreateFactory::<IDWriteFactory>(DWRITE_FACTORY_TYPE_SHARED).ok()?;
+            let factory = DWriteCreateFactory::<IDWriteFactory>(DWRITE_FACTORY_TYPE_SHARED)?;
             let mut collection: Option<IDWriteFontCollection> = None;
-            factory
-                .GetSystemFontCollection(&mut collection, update)
-                .ok()?;
-            let collection = collection?;
-            let factory2: IDWriteFactory2 = factory.cast().ok()?;
-            let fallback = factory2.GetSystemFontFallback().ok()?;
-            Some(Self {
+            factory.GetSystemFontCollection(&mut collection, update)?;
+            let collection = collection.ok_or_else(|| {
+                windows_core::Error::new(STATUS_NOT_FOUND.to_hresult(), "no collection")
+            })?;
+            let fallback = factory
+                .cast::<IDWriteFactory2>()
+                .and_then(|f| f.GetSystemFontFallback())
+                .ok();
+            Ok(Self {
                 collection,
                 fallback,
                 map_buf: vec![],
@@ -209,32 +212,33 @@ impl DWriteSystemFonts {
             while cur_offset < text_len {
                 let mut mapped_len = 0;
                 let mut mapped_font = None;
-                if self
-                    .fallback
-                    .MapCharacters(
-                        &source,
-                        cur_offset as u32,
-                        (text_len - cur_offset) as u32,
-                        &self.collection,
-                        None,
-                        DWRITE_FONT_WEIGHT_REGULAR,
-                        DWRITE_FONT_STYLE_NORMAL,
-                        DWRITE_FONT_STRETCH_NORMAL,
-                        &mut mapped_len,
-                        &mut mapped_font,
-                        &mut 1.0,
-                    )
-                    .is_ok()
-                {
-                    if let Some(font) = mapped_font {
-                        let family = font.GetFontFamily().ok()?;
-                        let names = family.GetFamilyNames().ok()?;
-                        let name_len = names.GetStringLength(0).ok()? as usize;
-                        let mut name_buf = smallvec::SmallVec::<[u16; 128]>::default();
-                        name_buf.resize(name_len + 1, 0);
-                        names.GetString(0, &mut name_buf).ok()?;
-                        name_buf.pop();
-                        return Some(String::from_utf16_lossy(&name_buf));
+                if let Some(fallback) = self.fallback.as_ref() {
+                    if fallback
+                        .MapCharacters(
+                            &source,
+                            cur_offset as u32,
+                            (text_len - cur_offset) as u32,
+                            &self.collection,
+                            None,
+                            DWRITE_FONT_WEIGHT_REGULAR,
+                            DWRITE_FONT_STYLE_NORMAL,
+                            DWRITE_FONT_STRETCH_NORMAL,
+                            &mut mapped_len,
+                            &mut mapped_font,
+                            &mut 1.0,
+                        )
+                        .is_ok()
+                    {
+                        if let Some(font) = mapped_font {
+                            let family = font.GetFontFamily().ok()?;
+                            let names = family.GetFamilyNames().ok()?;
+                            let name_len = names.GetStringLength(0).ok()? as usize;
+                            let mut name_buf = smallvec::SmallVec::<[u16; 128]>::default();
+                            name_buf.resize(name_len + 1, 0);
+                            names.GetString(0, &mut name_buf).ok()?;
+                            name_buf.pop();
+                            return Some(String::from_utf16_lossy(&name_buf));
+                        }
                     }
                 }
                 cur_offset += 1;


### PR DESCRIPTION
This patch avoids a panic on Windows 7 (using the target `x86_64-win7-windows-msvc`,  yes I need to keep supporting Windows 7 :sweat: ). 

`IDWriteFactory2` is only available since Windows 8, so I just disabled the fallback mechanism on Windows 7, which is acceptable I believe. I also changed  `DWriteSystemFonts::new()` return type from `Option` to `Result`, which was helpful in having a useful panic message in the first place. I did not try to remove the `.unwrap()` that was panicking as it was in a more complex place where I wasn't sure how to avoid it properly.

I'm using `slint 1.15.3`  and  `fontique` is a intransitive dependency.   