### PR TITLE
Implement `From<Script>` for `FallbackKey`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV] of 1.88.
 
+### Added
+
+#### Fontique
+
+- `FallbackKey` now implements `From<Script>` for convenience. ([#594][] by [@xStrom][])
+
 ## [0.8.0] - 2026-03-27
 
 This release has an [MSRV] of 1.88.
@@ -557,6 +563,7 @@ This release has an [MSRV][] of 1.70.
 [#575]: https://github.com/linebender/parley/pull/575
 [#578]: https://github.com/linebender/parley/pull/578
 [#589]: https://github.com/linebender/parley/pull/589
+[#594]: https://github.com/linebender/parley/pull/594
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/linebender/parley/compare/v0.7.0...v0.8.0

--- a/fontique/src/fallback.rs
+++ b/fontique/src/fallback.rs
@@ -185,6 +185,12 @@ where
     }
 }
 
+impl From<Script> for FallbackKey {
+    fn from(value: Script) -> Self {
+        Self::new(value, None)
+    }
+}
+
 #[derive(Clone, Default, Debug)]
 struct PerScript {
     default: Option<FamilyList>,


### PR DESCRIPTION
There used to be a very generic implementation `impl<S> From<S> for FallbackKey where S: Into<Script>`. This was removed in #475 because it was too generic and didn't compile anymore. However, this makes the ergonomics worse for cases where you want to use only a script to derive the `FallbackKey`. You either have to do `FallbackKey::new(script, None)` or `(script, "")` and the latter does useless parsing work that could be skipped.

This PR restores the ergonomics of just passing a script, but without the generics so that it would actually compile.