### PR TITLE
editing: move text input to document-space composition

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -10,4 +10,4 @@ trivial-copy-size-limit = 16
 # END LINEBENDER LINT SET
 
 # Don't warn about these identifiers when using clippy::doc_markdown.
-doc-valid-idents = ["OpenType", ".."]
+doc-valid-idents = ["AppKit", "OpenType", ".."]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,17 +20,17 @@ This release has an [MSRV] of 1.88.
 
 #### Parley
 
-- `PlainEditorDriver` now exposes UTF-8 document-range editing helpers for host-side text input and composition handling, plus delete-to-edge helpers for semantic edit-command integration.
-- `PlainEditorDriver::commit_composition` to explicitly commit an active composition.
-- `SplitString::to_utf8_range` and `TextIndexEncoding` to convert encoded offsets over visible editor text without allocating.
+- `PlainEditorDriver` now exposes UTF-8 document-range editing helpers for host-side text input and composition handling, plus delete-to-edge helpers for semantic edit-command integration. ([#595][] by [@waywardmonkeys][])
+- `PlainEditorDriver::commit_composition` to explicitly commit an active composition. ([#595][] by [@waywardmonkeys][])
+- `SplitString::to_utf8_range` and `TextIndexEncoding` to convert encoded offsets over visible editor text without allocating. ([#595][] by [@waywardmonkeys][])
 
 ### Changed
 
 #### Parley
 
-- Breaking change: removed legacy `PlainEditorDriver` composition mutation methods `set_compose`, `set_compose_byte_range`, `clear_compose`, and `finish_compose` in favor of the document-space editing API.
-- Breaking change: `PlainEditor::raw_compose` has been replaced by `PlainEditor::composition`, which exposes composing text and its document offset instead of raw-buffer byte ranges.
-- Breaking change: `PlainEditor::ime_cursor_area` has been renamed to `PlainEditor::text_input_area`.
+- Breaking change: removed legacy `PlainEditorDriver` composition mutation methods `set_compose`, `set_compose_byte_range`, `clear_compose`, and `finish_compose` in favor of the document-space editing API. ([#595][] by [@waywardmonkeys][])
+- Breaking change: `PlainEditor::raw_compose` has been replaced by `PlainEditor::composition`, which exposes composing text and its document offset instead of raw-buffer byte ranges. ([#595][] by [@waywardmonkeys][])
+- Breaking change: `PlainEditor::ime_cursor_area` has been renamed to `PlainEditor::text_input_area`. ([#595][] by [@waywardmonkeys][])
 
 ## [0.8.0] - 2026-03-27
 
@@ -578,6 +578,7 @@ This release has an [MSRV][] of 1.70.
 [#578]: https://github.com/linebender/parley/pull/578
 [#589]: https://github.com/linebender/parley/pull/589
 [#594]: https://github.com/linebender/parley/pull/594
+[#595]: https://github.com/linebender/parley/pull/595
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/linebender/parley/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ This release has an [MSRV] of 1.88.
 
 - `FallbackKey` now implements `From<Script>` for convenience. ([#594][] by [@xStrom][])
 
+#### Parley
+
+- `PlainEditorDriver` now exposes UTF-8 document-range editing helpers for host-side text input and composition handling, plus delete-to-edge helpers for semantic edit-command integration.
+- `PlainEditorDriver::commit_composition` to explicitly commit an active composition.
+- `SplitString::to_utf8_range` and `TextIndexEncoding` to convert encoded offsets over visible editor text without allocating.
+
+### Changed
+
+#### Parley
+
+- Breaking change: removed legacy `PlainEditorDriver` composition mutation methods `set_compose`, `set_compose_byte_range`, `clear_compose`, and `finish_compose` in favor of the document-space editing API.
+- Breaking change: `PlainEditor::raw_compose` has been replaced by `PlainEditor::composition`, which exposes composing text and its document offset instead of raw-buffer byte ranges.
+- Breaking change: `PlainEditor::ime_cursor_area` has been renamed to `PlainEditor::text_input_area`.
+
 ## [0.8.0] - 2026-03-27
 
 This release has an [MSRV] of 1.88.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4075,8 +4075,7 @@ dependencies = [
 [[package]]
 name = "ui-events"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e29e3e199888d594edd191c5917a2d5c1893b8bf20076c2bf4df7a40a2ee71"
+source = "git+https://github.com/endoli/ui-events.git?rev=5e840f0e39b412573aaec8debadd4be81c17d823#5e840f0e39b412573aaec8debadd4be81c17d823"
 dependencies = [
  "dpi",
  "keyboard-types",
@@ -4086,8 +4085,7 @@ dependencies = [
 [[package]]
 name = "ui-events-winit"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de12c5f7e256ff97aa9a710a5e2fb345bb59302c98d77a3d2f249100d92145d4"
+source = "git+https://github.com/endoli/ui-events.git?rev=5e840f0e39b412573aaec8debadd4be81c17d823#5e840f0e39b412573aaec8debadd4be81c17d823"
 dependencies = [
  "ui-events",
  "web-time",

--- a/examples/vello_editor/Cargo.toml
+++ b/examples/vello_editor/Cargo.toml
@@ -11,8 +11,10 @@ publish = false
 vello = "0.8.0"
 anyhow = "1.0.102"
 pollster = "0.4.0"
-ui-events-winit = "0.3"
-ui-events = "0.3"
+ui-events = { git = "https://github.com/endoli/ui-events.git", rev = "5e840f0e39b412573aaec8debadd4be81c17d823", package = "ui-events", default-features = false, features = [
+    "kurbo",
+] }
+ui-events-winit = { git = "https://github.com/endoli/ui-events.git", rev = "5e840f0e39b412573aaec8debadd4be81c17d823", package = "ui-events-winit", default-features = false }
 winit = "0.30.13"
 parley = { workspace = true, default-features = true, features = ["accesskit"] }
 peniko = { workspace = true }

--- a/examples/vello_editor/src/main.rs
+++ b/examples/vello_editor/src/main.rs
@@ -105,8 +105,8 @@ struct SimpleVelloApp<'s> {
     /// The last generation of the editor layout that we drew.
     last_drawn_generation: text::Generation,
 
-    /// The IME cursor area we last sent to the platform.
-    last_sent_ime_cursor_area: parley::BoundingBox,
+    /// The text input area we last sent to the platform.
+    last_sent_text_input_area: parley::BoundingBox,
 
     /// The event loop proxy required by the AccessKit winit adapter.
     event_loop_proxy: EventLoopProxy<accesskit_winit::Event>,
@@ -251,6 +251,9 @@ impl ApplicationHandler<accesskit_winit::Event> for SimpleVelloApp<'_> {
                     WindowEventTranslation::Pointer(p) => {
                         self.editor.handle_pointer_event(&p);
                     }
+                    WindowEventTranslation::Text(t) => {
+                        self.editor.handle_text_input_event(&t);
+                    }
                 }
             } else {
                 self.editor.handle_event(event.clone());
@@ -259,9 +262,9 @@ impl ApplicationHandler<accesskit_winit::Event> for SimpleVelloApp<'_> {
 
         if self.last_drawn_generation != self.editor.generation() {
             render_state.window.request_redraw();
-            let area = self.editor.editor().ime_cursor_area();
-            if self.last_sent_ime_cursor_area != area {
-                self.last_sent_ime_cursor_area = area;
+            let area = self.editor.editor().text_input_area();
+            if self.last_sent_text_input_area != area {
+                self.last_sent_text_input_area = area;
                 // Note: on X11 `set_ime_cursor_area` may cause the exclusion area to be obscured
                 // until https://github.com/rust-windowing/winit/pull/3966 is in the Winit release
                 // used by this example.
@@ -414,7 +417,7 @@ fn main() -> Result<()> {
         scene: Scene::new(),
         editor: text::Editor::new(text::LOREM),
         last_drawn_generation: text::Generation::default(),
-        last_sent_ime_cursor_area: parley::BoundingBox::new(f64::NAN, f64::NAN, f64::NAN, f64::NAN),
+        last_sent_text_input_area: parley::BoundingBox::new(f64::NAN, f64::NAN, f64::NAN, f64::NAN),
         event_loop_proxy: event_loop.create_proxy(),
         event_reducer: WindowEventReducer::default(),
     };

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -8,14 +8,16 @@ use web_time::Instant;
 
 use accesskit::{Node, TextDecoration, TextDecorationStyle, TreeUpdate};
 use core::default::Default;
-use parley::editing::SplitString;
+use parley::editing::{SplitString, TextIndexEncoding};
 use parley::layout::{PositionedLayoutItem, Style};
 use parley::{GenericFamily, StyleProperty};
+use std::ops::Range;
 use std::time::Duration;
 use ui_events::pointer::PointerButton;
 use ui_events::{
     keyboard::{Key, KeyboardEvent, NamedKey},
     pointer::{PointerButtonEvent, PointerEvent, PointerInfo, PointerState, PointerType},
+    text::{TextInputAction, TextInputEvent, TextRange, TextRangeEncoding, TextTargetRange},
 };
 use vello::{
     Scene,
@@ -23,7 +25,7 @@ use vello::{
     peniko::color::{AlphaColor, Srgb, palette},
     peniko::{Brush, Fill},
 };
-use winit::event::{Ime, WindowEvent};
+use winit::event::WindowEvent;
 
 pub use parley::editing::Generation;
 use parley::{FontContext, LayoutContext, PlainEditor, PlainEditorDriver};
@@ -334,26 +336,72 @@ impl Editor {
         }
     }
 
-    pub fn handle_event(&mut self, event: WindowEvent) {
+    /// Handle normalized text input events surfaced by `ui-events-winit`.
+    ///
+    /// On the current `winit` backend this example mostly exercises the
+    /// preedit/commit IME path. Richer platform-originated text events such as
+    /// selection updates, composing-region updates, or non-UTF-8 surrounding
+    /// deletes are still handled here for parity with Parley's host-facing API,
+    /// but they are not expected to originate from `winit` today.
+    pub fn handle_text_input_event(&mut self, event: &TextInputEvent) {
+        self.cursor_reset();
         match event {
-            WindowEvent::Resized(size) => {
-                self.editor
-                    .set_width(Some(size.width as f32 - 2_f32 * INSET));
+            TextInputEvent::Insert(insert) => {
+                let replacement = self.document_range_to_byte_range(insert.replacement_range);
+                let mut drv = self.driver();
+                let applied = drv.insert_or_replace(&insert.text, replacement, None);
+                debug_assert!(applied, "invalid insert range from text input event");
             }
-            WindowEvent::Ime(Ime::Disabled) => {
-                self.driver().clear_compose();
-            }
-            WindowEvent::Ime(Ime::Commit(text)) => {
-                self.driver().insert_or_replace_selection(&text);
-            }
-            WindowEvent::Ime(Ime::Preedit(text, cursor)) => {
-                if text.is_empty() {
-                    self.driver().clear_compose();
-                } else {
-                    self.driver().set_compose(&text, cursor);
+            TextInputEvent::DeleteBackward => self.driver().backdelete(),
+            TextInputEvent::DeleteForward => self.driver().delete(),
+            TextInputEvent::DeleteSurrounding(delete)
+                if delete.encoding == TextRangeEncoding::Utf8Bytes =>
+            {
+                let before = usize::try_from(delete.before_length).ok();
+                let after = usize::try_from(delete.after_length).ok();
+                if let (Some(before), Some(after)) = (before, after) {
+                    let applied = self.driver().delete_surrounding(before, after);
+                    debug_assert!(
+                        applied,
+                        "invalid surrounding delete range from text input event",
+                    );
                 }
             }
-            _ => {}
+            TextInputEvent::SetSelection(range) => {
+                if let Some(range) = self.document_range_to_byte_range(Some(*range)) {
+                    let applied = self.driver().set_document_selection(range);
+                    debug_assert!(applied, "invalid document selection from text input event");
+                }
+            }
+            TextInputEvent::SetComposingRegion(range) => {
+                if let Some(range) = self.document_range_to_byte_range(Some(*range)) {
+                    let applied = self.driver().set_composing_region(range);
+                    debug_assert!(applied, "invalid composing region from text input event");
+                }
+            }
+            TextInputEvent::CompositionUpdate(state) => {
+                let replacement = self.document_range_to_byte_range(state.replacement_range);
+                let mut drv = self.driver();
+                let applied = drv.update_composition(
+                    &state.text,
+                    replacement,
+                    Self::text_range_to_byte_range(state.selection),
+                );
+                debug_assert!(applied, "invalid composition update from text input event");
+            }
+            TextInputEvent::CompositionEnd => {
+                let _ = self.driver().clear_composition();
+            }
+            TextInputEvent::Action(TextInputAction::Newline) => self.driver().insert_newline(),
+            TextInputEvent::Action(_) => {}
+            TextInputEvent::DeleteSurrounding(_) => {}
+        }
+    }
+
+    pub fn handle_event(&mut self, event: WindowEvent) {
+        if let WindowEvent::Resized(size) = event {
+            self.editor
+                .set_width(Some(size.width as f32 - 2_f32 * INSET));
         }
     }
 
@@ -368,6 +416,28 @@ impl Editor {
     /// Return the current `Generation` of the layout.
     pub fn generation(&self) -> Generation {
         self.editor.generation()
+    }
+
+    fn document_range_to_byte_range(&self, range: Option<TextTargetRange>) -> Option<Range<usize>> {
+        range.and_then(|range| {
+            self.text().to_utf8_range(
+                range.range.start,
+                range.range.end,
+                match range.encoding {
+                    TextRangeEncoding::Utf8Bytes => TextIndexEncoding::Utf8Bytes,
+                    TextRangeEncoding::Utf16CodeUnits => TextIndexEncoding::Utf16CodeUnits,
+                    TextRangeEncoding::UnicodeCodePoints => TextIndexEncoding::UnicodeCodePoints,
+                },
+            )
+        })
+    }
+
+    fn text_range_to_byte_range(range: Option<TextRange>) -> Option<Range<usize>> {
+        range.and_then(|range| {
+            let start = usize::try_from(range.start).ok()?;
+            let end = usize::try_from(range.end).ok()?;
+            Some(start..end)
+        })
     }
 
     /// Draw into scene.

--- a/parley/src/editing/editor.rs
+++ b/parley/src/editing/editor.rs
@@ -319,7 +319,11 @@ where
         }
     }
 
-    /// Delete the selection or to the start of the physical line.
+    /// Delete the current selection, or delete backward to the start of the
+    /// current physical line when the selection is collapsed.
+    ///
+    /// This corresponds to semantic editing commands such as AppKit's
+    /// `deleteToBeginningOfLine:`.
     pub fn delete_to_line_start(&mut self) {
         self.refresh_layout();
         if self.editor.selection.is_collapsed() {
@@ -335,7 +339,11 @@ where
         }
     }
 
-    /// Delete the selection or to the end of the physical line.
+    /// Delete the current selection, or delete forward to the end of the
+    /// current physical line when the selection is collapsed.
+    ///
+    /// This corresponds to semantic editing commands such as AppKit's
+    /// `deleteToEndOfLine:`.
     pub fn delete_to_line_end(&mut self) {
         self.refresh_layout();
         if self.editor.selection.is_collapsed() {
@@ -351,7 +359,8 @@ where
         }
     }
 
-    /// Delete the selection or to the beginning of the document.
+    /// Delete the current selection, or delete backward to the beginning of
+    /// the document when the selection is collapsed.
     pub fn delete_to_text_start(&mut self) {
         if self.editor.selection.is_collapsed() {
             let end = self.editor.selection.focus().index();
@@ -362,7 +371,8 @@ where
         }
     }
 
-    /// Delete the selection or to the end of the document.
+    /// Delete the current selection, or delete forward to the end of the
+    /// document when the selection is collapsed.
     pub fn delete_to_text_end(&mut self) {
         if self.editor.selection.is_collapsed() {
             let start = self.editor.selection.focus().index();
@@ -375,19 +385,27 @@ where
     }
 
     /// Insert a newline at the current selection.
+    ///
+    /// This is useful for hosts that surface newline insertion as a semantic
+    /// editing action rather than ordinary text input.
     pub fn insert_newline(&mut self) {
         self.insert_or_replace_selection("\n");
     }
 
     /// Insert a horizontal tab at the current selection.
+    ///
+    /// This is useful for hosts that surface tab insertion as a semantic
+    /// editing action rather than ordinary text input.
     pub fn insert_tab(&mut self) {
         self.insert_or_replace_selection("\t");
     }
 
     /// Set the document selection using UTF-8 byte offsets over [`PlainEditor::text`].
     ///
-    /// Returns `false` if the provided range is reversed, out of bounds, or
-    /// does not land on character boundaries in the document text.
+    /// Returns `false` and leaves the editor unchanged if the provided range is
+    /// reversed, out of bounds, or does not land on UTF-8 scalar-value
+    /// boundaries in the document text. This does not promise grapheme-cluster
+    /// aware selection behavior.
     pub fn set_document_selection(&mut self, range: Range<usize>) -> bool {
         let Some(range) = self.editor.document_range_to_raw_range(range) else {
             return false;
@@ -403,8 +421,12 @@ where
 
     /// Set the composing region using UTF-8 byte offsets over [`PlainEditor::text`].
     ///
-    /// Returns `false` if the provided range is reversed, out of bounds, or
-    /// does not land on character boundaries in the document text.
+    /// Any existing composition, whether hidden preedit or a visible composing
+    /// region, is replaced by this new visible composing region.
+    ///
+    /// Returns `false` and leaves the editor unchanged if the provided range is
+    /// reversed, out of bounds, or does not land on UTF-8 scalar-value
+    /// boundaries in the document text.
     pub fn set_composing_region(&mut self, range: Range<usize>) -> bool {
         let Some(range) = self.editor.document_range_to_raw_range(range) else {
             return false;
@@ -424,7 +446,8 @@ where
     /// [`PlainEditor::text`]. The `selection_in_inserted_text` range is
     /// expressed in UTF-8 byte offsets over `text`.
     ///
-    /// Returns `false` if either range is invalid.
+    /// Returns `false` and leaves the editor unchanged if either range is
+    /// invalid.
     pub fn insert_or_replace(
         &mut self,
         text: &str,
@@ -473,9 +496,14 @@ where
     /// [`PlainEditor::text`]. The `selection_in_composition` range is
     /// expressed in UTF-8 byte offsets over `text`.
     ///
+    /// If `replacement` is provided, that document range is replaced. Otherwise
+    /// the current composition range is replaced if one exists; if not, the
+    /// current selection is replaced.
+    ///
     /// If `text` is empty, this clears any active composition.
     ///
-    /// Returns `false` if either range is invalid.
+    /// Returns `false` and leaves the editor unchanged if either range is
+    /// invalid.
     pub fn update_composition(
         &mut self,
         text: &str,
@@ -525,9 +553,11 @@ where
     /// document selection.
     ///
     /// The counts are measured in the space returned by [`PlainEditor::text`].
+    /// If the current selection is non-collapsed, it is included in the deleted
+    /// range.
     ///
-    /// Returns `false` if the current selection cannot be represented in that
-    /// document space.
+    /// Returns `false` and leaves the editor unchanged if the current selection
+    /// cannot be represented in that document space.
     pub fn delete_surrounding(&mut self, before: usize, after: usize) -> bool {
         if before == 0 && after == 0 {
             return true;
@@ -1485,6 +1515,8 @@ where
         }
         if let Some(compose) = &self.compose {
             if compose.range.is_empty() {
+                // A collapsed composition still affects editor state, but there
+                // is no visible composing span to underline in the layout.
                 self.layout = builder.build(&self.buffer);
                 self.layout.break_all_lines(self.width);
                 self.layout

--- a/parley/src/editing/editor.rs
+++ b/parley/src/editing/editor.rs
@@ -4,15 +4,9 @@
 //! A simple plain text editor and related types.
 
 use alloc::{borrow::ToOwned, string::String, vec::Vec};
-use core::{
-    cmp::PartialEq,
-    default::Default,
-    fmt::{Debug, Display},
-    num::NonZeroUsize,
-    ops::Range,
-};
+use core::{cmp::PartialEq, default::Default, fmt::Debug, num::NonZeroUsize, ops::Range};
 
-use crate::editing::{Cursor, Selection};
+use crate::editing::{Cursor, Selection, SplitString};
 use crate::layout::{Affinity, Alignment, AlignmentOptions, Layout};
 use crate::style::Brush;
 use crate::{BoundingBox, FontContext, LayoutContext, StyleProperty, StyleSet};
@@ -39,48 +33,30 @@ impl Generation {
     }
 }
 
-/// A string which is potentially discontiguous in memory.
+/// Active in-progress composition text.
 ///
-/// This is returned by [`PlainEditor::text`], as the IME preedit
-/// area needs to be efficiently excluded from its return value.
-#[derive(Debug, Clone, Copy)]
-pub struct SplitString<'source>([&'source str; 2]);
-
-impl<'source> SplitString<'source> {
-    /// Get the characters of this string.
-    pub fn chars(self) -> impl Iterator<Item = char> + 'source {
-        self.into_iter().flat_map(str::chars)
-    }
+/// This text may either be transient preedit text excluded from
+/// [`PlainEditor::text`] or an existing document range that is currently marked
+/// as composing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Composition<'source> {
+    /// The composing text.
+    pub text: &'source str,
+    /// The UTF-8 byte offset in [`PlainEditor::text`] where the composition is
+    /// currently located.
+    pub document_offset: usize,
 }
 
-impl PartialEq<&'_ str> for SplitString<'_> {
-    fn eq(&self, other: &&'_ str) -> bool {
-        let [a, b] = self.0;
-        let mid = a.len();
-        match other.split_at_checked(mid) {
-            Some((a_1, b_1)) => a_1 == a && b_1 == b,
-            None => false,
-        }
-    }
-}
-// We intentionally choose not to:
-// impl PartialEq<Self> for SplitString<'_> {}
-// for simplicity, as the impl wouldn't be useful and is non-trivial
-
-impl Display for SplitString<'_> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let [a, b] = self.0;
-        write!(f, "{a}{b}")
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompositionKind {
+    HiddenPreedit,
+    VisibleRegion,
 }
 
-/// Iterate through the source strings.
-impl<'source> IntoIterator for SplitString<'source> {
-    type Item = &'source str;
-    type IntoIter = <[&'source str; 2] as IntoIterator>::IntoIter;
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ActiveComposition {
+    range: Range<usize>,
+    kind: CompositionKind,
 }
 
 /// Basic plain text editor with a single style applied to the entire text.
@@ -99,9 +75,9 @@ where
     #[cfg(feature = "accesskit")]
     layout_access: LayoutAccessibility,
     selection: Selection,
-    /// Byte offsets of IME composing preedit text in the text buffer.
+    /// Byte offsets of active composition text in the text buffer.
     /// `None` if the IME is not currently composing.
-    compose: Option<Range<usize>>,
+    compose: Option<ActiveComposition>,
     /// Whether the cursor should be shown. The IME can request to hide the cursor.
     show_cursor: bool,
     width: Option<f32>,
@@ -343,88 +319,280 @@ where
         }
     }
 
-    // --- MARK: IME ---
-    /// Set the IME preedit composing text.
-    ///
-    /// This starts composing. Composing is reset by calling [`clear_compose`](Self::clear_compose).
-    /// Alternatively, the preedit text can be committed by calling [`finish_compose`](Self::finish_compose).
-    ///
-    /// The selection and preedit region can be manipulated independently while composing
-    /// is active.
-    ///
-    /// The preedit text replaces the current selection if this call starts composing.
-    ///
-    /// The selection is updated based on `cursor`, which contains the byte offsets relative to the
-    /// start of the preedit text. If `cursor` is `None`, the selection and caret are hidden.
-    pub fn set_compose(&mut self, text: &str, cursor: Option<(usize, usize)>) {
-        debug_assert!(!text.is_empty());
-        debug_assert!(cursor.map(|cursor| cursor.1 <= text.len()).unwrap_or(true));
-
-        let start = if let Some(preedit_range) = &self.editor.compose {
+    /// Delete the selection or to the start of the physical line.
+    pub fn delete_to_line_start(&mut self) {
+        self.refresh_layout();
+        if self.editor.selection.is_collapsed() {
+            let range = self
+                .editor
+                .selection
+                .line_start(&self.editor.layout, true)
+                .text_range();
             self.editor
-                .buffer
-                .replace_range(preedit_range.clone(), text);
-            preedit_range.start
+                .replace_range_with_selection(self.font_cx, self.layout_cx, range, "");
         } else {
-            if self.editor.selection.is_collapsed() {
-                self.editor
-                    .buffer
-                    .insert_str(self.editor.selection.text_range().start, text);
-            } else {
-                self.editor
-                    .buffer
-                    .replace_range(self.editor.selection.text_range(), text);
-            }
-            self.editor.selection.text_range().start
+            self.delete_selection();
+        }
+    }
+
+    /// Delete the selection or to the end of the physical line.
+    pub fn delete_to_line_end(&mut self) {
+        self.refresh_layout();
+        if self.editor.selection.is_collapsed() {
+            let range = self
+                .editor
+                .selection
+                .line_end(&self.editor.layout, true)
+                .text_range();
+            self.editor
+                .replace_range_with_selection(self.font_cx, self.layout_cx, range, "");
+        } else {
+            self.delete_selection();
+        }
+    }
+
+    /// Delete the selection or to the beginning of the document.
+    pub fn delete_to_text_start(&mut self) {
+        if self.editor.selection.is_collapsed() {
+            let end = self.editor.selection.focus().index();
+            self.editor
+                .replace_range_with_selection(self.font_cx, self.layout_cx, 0..end, "");
+        } else {
+            self.delete_selection();
+        }
+    }
+
+    /// Delete the selection or to the end of the document.
+    pub fn delete_to_text_end(&mut self) {
+        if self.editor.selection.is_collapsed() {
+            let start = self.editor.selection.focus().index();
+            let end = self.editor.buffer.len();
+            self.editor
+                .replace_range_with_selection(self.font_cx, self.layout_cx, start..end, "");
+        } else {
+            self.delete_selection();
+        }
+    }
+
+    /// Insert a newline at the current selection.
+    pub fn insert_newline(&mut self) {
+        self.insert_or_replace_selection("\n");
+    }
+
+    /// Insert a horizontal tab at the current selection.
+    pub fn insert_tab(&mut self) {
+        self.insert_or_replace_selection("\t");
+    }
+
+    /// Set the document selection using UTF-8 byte offsets over [`PlainEditor::text`].
+    ///
+    /// Returns `false` if the provided range is reversed, out of bounds, or
+    /// does not land on character boundaries in the document text.
+    pub fn set_document_selection(&mut self, range: Range<usize>) -> bool {
+        let Some(range) = self.editor.document_range_to_raw_range(range) else {
+            return false;
         };
-        self.editor.compose = Some(start..start + text.len());
-        self.editor.show_cursor = cursor.is_some();
+        self.refresh_layout();
+        self.editor.show_cursor = true;
+        self.editor.set_selection(Selection::new(
+            self.editor.cursor_at(range.start),
+            self.editor.cursor_at(range.end),
+        ));
+        true
+    }
+
+    /// Set the composing region using UTF-8 byte offsets over [`PlainEditor::text`].
+    ///
+    /// Returns `false` if the provided range is reversed, out of bounds, or
+    /// does not land on character boundaries in the document text.
+    pub fn set_composing_region(&mut self, range: Range<usize>) -> bool {
+        let Some(range) = self.editor.document_range_to_raw_range(range) else {
+            return false;
+        };
+        self.editor.compose = Some(ActiveComposition {
+            range,
+            kind: CompositionKind::VisibleRegion,
+        });
+        self.update_layout();
+        true
+    }
+
+    /// Insert text, optionally replacing a document range, and optionally set a
+    /// selection within the inserted text.
+    ///
+    /// The `replacement` range is expressed in UTF-8 byte offsets over
+    /// [`PlainEditor::text`]. The `selection_in_inserted_text` range is
+    /// expressed in UTF-8 byte offsets over `text`.
+    ///
+    /// Returns `false` if either range is invalid.
+    pub fn insert_or_replace(
+        &mut self,
+        text: &str,
+        replacement: Option<Range<usize>>,
+        selection_in_inserted_text: Option<Range<usize>>,
+    ) -> bool {
+        let selection_in_inserted_text = match selection_in_inserted_text {
+            Some(range) => {
+                let Some(range) = validate_text_range(text, range) else {
+                    return false;
+                };
+                Some(range)
+            }
+            None => None,
+        };
+        let replacement = match replacement {
+            Some(range) => {
+                let Some(range) = self.editor.document_range_to_raw_range(range) else {
+                    return false;
+                };
+                range
+            }
+            None => self.editor.selection.text_range(),
+        };
+        self.editor.replace_range_with_selection(
+            self.font_cx,
+            self.layout_cx,
+            replacement.clone(),
+            text,
+        );
+        self.editor.show_cursor = true;
+        if let Some(selection) = selection_in_inserted_text {
+            let start = replacement.start + selection.start;
+            let end = replacement.start + selection.end;
+            self.editor.set_selection(Selection::new(
+                self.editor.cursor_at(start),
+                self.editor.cursor_at(end),
+            ));
+        }
+        true
+    }
+
+    /// Apply a composition update atomically.
+    ///
+    /// The `replacement` range is expressed in UTF-8 byte offsets over
+    /// [`PlainEditor::text`]. The `selection_in_composition` range is
+    /// expressed in UTF-8 byte offsets over `text`.
+    ///
+    /// If `text` is empty, this clears any active composition.
+    ///
+    /// Returns `false` if either range is invalid.
+    pub fn update_composition(
+        &mut self,
+        text: &str,
+        replacement: Option<Range<usize>>,
+        selection_in_composition: Option<Range<usize>>,
+    ) -> bool {
+        if text.is_empty() {
+            return self.clear_composition();
+        }
+        let selection_in_composition = match selection_in_composition {
+            Some(range) => {
+                let Some(range) = validate_text_range(text, range) else {
+                    return false;
+                };
+                Some(range)
+            }
+            None => None,
+        };
+        let replacement = if let Some(range) = replacement {
+            let Some(range) = self.editor.document_range_to_raw_range(range) else {
+                return false;
+            };
+            range
+        } else if let Some(compose) = self.editor.compose.as_ref() {
+            compose.range.clone()
+        } else {
+            self.editor.selection.text_range()
+        };
+        let start = replacement.start;
+        self.editor.buffer.replace_range(replacement, text);
+        self.editor.compose = Some(ActiveComposition {
+            range: start..start + text.len(),
+            kind: CompositionKind::HiddenPreedit,
+        });
+        self.editor.show_cursor = selection_in_composition.is_some();
         self.update_layout();
 
-        // Select the location indicated by the IME. If `cursor` is none, collapse the selection to
-        // a caret at the start of the preedit text. As `self.editor.show_cursor` is `false`, it
-        // won't show up.
-        let cursor = cursor.unwrap_or((0, 0));
+        let selection = selection_in_composition.unwrap_or(0..0);
         self.editor.set_selection(Selection::new(
-            self.editor.cursor_at(start + cursor.0),
-            self.editor.cursor_at(start + cursor.1),
+            self.editor.cursor_at(start + selection.start),
+            self.editor.cursor_at(start + selection.end),
         ));
+        true
     }
 
-    /// Set the preedit range to a range of byte indices.
-    /// This leaves the selection and cursor unchanged.
+    /// Delete the requested number of UTF-8 bytes surrounding the current
+    /// document selection.
     ///
-    /// No-op if either index is not a char boundary.
-    pub fn set_compose_byte_range(&mut self, start: usize, end: usize) {
-        if self.editor.buffer.is_char_boundary(start) && self.editor.buffer.is_char_boundary(end) {
-            self.editor.compose = Some(start..end);
-            self.update_layout();
+    /// The counts are measured in the space returned by [`PlainEditor::text`].
+    ///
+    /// Returns `false` if the current selection cannot be represented in that
+    /// document space.
+    pub fn delete_surrounding(&mut self, before: usize, after: usize) -> bool {
+        if before == 0 && after == 0 {
+            return true;
         }
+        let Some(selection) = self.editor.document_selection_range() else {
+            return false;
+        };
+        let start = selection.start.saturating_sub(before);
+        let end = selection
+            .end
+            .saturating_add(after)
+            .min(self.editor.visible_text_len());
+        let Some(range) = self.editor.document_range_to_raw_range(start..end) else {
+            return false;
+        };
+        self.editor.buffer.replace_range(range.clone(), "");
+        self.editor.update_compose_for_replaced_range(range, 0);
+        self.editor.show_cursor = true;
+        self.update_layout();
+        let Some(caret) = self.editor.document_byte_to_raw_byte(start) else {
+            return false;
+        };
+        self.editor.set_selection(
+            Cursor::from_byte_index(&self.editor.layout, caret, Affinity::Downstream).into(),
+        );
+        true
     }
 
-    /// Stop IME composing.
+    /// Clear the active composition, if any.
     ///
-    /// This removes the IME preedit text, shows the cursor if it was hidden,
-    /// and moves the cursor to the start of the former preedit region.
-    pub fn clear_compose(&mut self) {
-        if let Some(preedit_range) = self.editor.compose.take() {
-            self.editor.buffer.replace_range(preedit_range.clone(), "");
-            self.editor.show_cursor = true;
-            self.update_layout();
-
-            self.editor
-                .set_selection(self.editor.cursor_at(preedit_range.start).into());
+    /// Hidden preedit text is removed from the buffer. Visible composing
+    /// regions over committed document text are preserved and simply lose the
+    /// composing mark.
+    ///
+    /// Returns `true` if a composition was active.
+    pub fn clear_composition(&mut self) -> bool {
+        let Some(compose) = self.editor.compose.take() else {
+            return false;
+        };
+        self.editor.show_cursor = true;
+        match compose.kind {
+            CompositionKind::HiddenPreedit => {
+                self.editor.buffer.replace_range(compose.range.clone(), "");
+                self.update_layout();
+                self.editor
+                    .set_selection(self.editor.cursor_at(compose.range.start).into());
+            }
+            CompositionKind::VisibleRegion => {
+                self.update_layout();
+            }
         }
+        true
     }
 
-    /// Commit the IME preedit text, if any.
+    /// Commit the active composition, if any, leaving the composed text in the
+    /// buffer and making it part of [`PlainEditor::text`].
     ///
-    /// This doesn't change the selection, but shows the cursor if
-    /// it was hidden.
-    pub fn finish_compose(&mut self) {
+    /// Returns `true` if a composition was active.
+    pub fn commit_composition(&mut self) -> bool {
         if self.editor.compose.take().is_some() {
             self.editor.show_cursor = true;
             self.update_layout();
+            true
+        } else {
+            false
         }
     }
 
@@ -832,22 +1000,34 @@ where
 
     /// Borrow the current selection. The indices returned by functions
     /// such as [`Selection::text_range`] refer to the raw text buffer,
-    /// including the IME preedit region, which can be accessed via
+    /// including any active hidden composition text, which can be accessed via
     /// [`PlainEditor::raw_text`].
     pub fn raw_selection(&self) -> &Selection {
         &self.selection
     }
 
-    /// Borrow the current IME preedit range, if any. These indices refer
-    /// to the raw text buffer, which can be accessed via [`PlainEditor::raw_text`].
-    pub fn raw_compose(&self) -> &Option<Range<usize>> {
-        &self.compose
+    /// Borrow the current active composition, if any.
+    ///
+    /// The composing text is exposed here together with its UTF-8 byte offset
+    /// in [`PlainEditor::text`], regardless of whether the composition is
+    /// transient hidden preedit text or a visible composing region over
+    /// existing document text.
+    pub fn composition(&self) -> Option<Composition<'_>> {
+        let compose = self.compose.as_ref()?;
+        Some(Composition {
+            text: &self.buffer[compose.range.clone()],
+            document_offset: self.raw_byte_to_document_byte(compose.range.start)?,
+        })
     }
 
     /// If the current selection is not collapsed, returns the text content of
     /// that selection.
+    ///
+    /// Returns `None` while hidden preedit composition text is active, as the
+    /// raw selection indices cannot be exposed as a stable contiguous document
+    /// slice in that state.
     pub fn selected_text(&self) -> Option<&str> {
-        if self.is_composing() {
+        if self.hidden_composition_range().is_some() {
             return None;
         }
         if !self.selection.is_collapsed() {
@@ -884,14 +1064,15 @@ where
 
     /// Get a rectangle bounding the text the user is currently editing.
     ///
-    /// This is useful for suggesting an exclusion area to the platform for, e.g., IME candidate
-    /// box placement. This bounds the area of the preedit text if present, otherwise it bounds the
-    /// selection on the focused line.
-    pub fn ime_cursor_area(&self) -> BoundingBox {
-        let (area, focus) = if let Some(preedit_range) = &self.compose {
+    /// This is useful for suggesting an exclusion area to the platform text
+    /// input system for candidate box placement. This bounds the area of the
+    /// active composition if present, otherwise it bounds the selection on the
+    /// focused line.
+    pub fn text_input_area(&self) -> BoundingBox {
+        let (area, focus) = if let Some(compose) = &self.compose {
             let selection = Selection::new(
-                self.cursor_at(preedit_range.start),
-                self.cursor_at(preedit_range.end),
+                self.cursor_at(compose.range.start),
+                self.cursor_at(compose.range.end),
             );
 
             // Bound the entire preedit text.
@@ -939,10 +1120,11 @@ where
 
     /// Borrow the text content of the buffer.
     ///
-    /// The return value is a `SplitString` because it
-    /// excludes the IME preedit region.
+    /// The return value is a `SplitString` because transient IME preedit text
+    /// is excluded. Visible composing regions over existing document text
+    /// remain part of the returned text.
     pub fn text(&self) -> SplitString<'_> {
-        if let Some(preedit_range) = &self.compose {
+        if let Some(preedit_range) = self.hidden_composition_range() {
             SplitString([
                 &self.buffer[..preedit_range.start],
                 &self.buffer[preedit_range.end..],
@@ -955,9 +1137,9 @@ where
     /// Borrow the text content of the buffer, including the IME preedit
     /// region if any.
     ///
-    /// Application authors should generally prefer [`text`](Self::text). That method excludes the
-    /// IME preedit contents, which are not meaningful for applications to access; the
-    /// in-progress IME content is not itself what the user intends to write.
+    /// Application authors should generally prefer [`text`](Self::text). That
+    /// method excludes transient IME preedit contents, which are not
+    /// meaningful for applications to access as committed document text.
     pub fn raw_text(&self) -> &str {
         &self.buffer
     }
@@ -1130,33 +1312,97 @@ where
         }
     }
 
-    fn update_compose_for_replaced_range(&mut self, old_range: Range<usize>, new_len: usize) {
-        if new_len == old_range.len() {
-            return;
+    fn visible_text_len(&self) -> usize {
+        self.buffer.len() - self.hidden_composition_range().map_or(0, Range::len)
+    }
+
+    fn document_byte_to_raw_byte(&self, index: usize) -> Option<usize> {
+        if let Some(compose) = self.hidden_composition_range() {
+            if index < compose.start {
+                self.buffer.is_char_boundary(index).then_some(index)
+            } else {
+                let suffix_index = index - compose.start;
+                let suffix = &self.buffer[compose.end..];
+                (suffix_index <= suffix.len() && suffix.is_char_boundary(suffix_index))
+                    .then_some(compose.end + suffix_index)
+            }
+        } else {
+            (index <= self.buffer.len() && self.buffer.is_char_boundary(index)).then_some(index)
         }
+    }
+
+    fn document_range_end_to_raw_byte(&self, index: usize) -> Option<usize> {
+        if let Some(compose) = self.hidden_composition_range() {
+            if index <= compose.start {
+                self.buffer.is_char_boundary(index).then_some(index)
+            } else {
+                let suffix_index = index - compose.start;
+                let suffix = &self.buffer[compose.end..];
+                (suffix_index <= suffix.len() && suffix.is_char_boundary(suffix_index))
+                    .then_some(compose.end + suffix_index)
+            }
+        } else {
+            (index <= self.buffer.len() && self.buffer.is_char_boundary(index)).then_some(index)
+        }
+    }
+
+    fn raw_byte_to_document_byte(&self, index: usize) -> Option<usize> {
+        if !(index <= self.buffer.len() && self.buffer.is_char_boundary(index)) {
+            return None;
+        }
+        if let Some(compose) = self.hidden_composition_range() {
+            if index <= compose.start {
+                Some(index)
+            } else if index >= compose.end {
+                Some(index - compose.len())
+            } else {
+                Some(compose.start)
+            }
+        } else {
+            Some(index)
+        }
+    }
+
+    fn document_range_to_raw_range(&self, range: Range<usize>) -> Option<Range<usize>> {
+        if range.start > range.end || range.end > self.visible_text_len() {
+            return None;
+        }
+        if range.start == range.end {
+            let raw = self.document_byte_to_raw_byte(range.start)?;
+            Some(raw..raw)
+        } else {
+            Some(
+                self.document_byte_to_raw_byte(range.start)?
+                    ..self.document_range_end_to_raw_byte(range.end)?,
+            )
+        }
+    }
+
+    fn document_selection_range(&self) -> Option<Range<usize>> {
+        let range = self.selection.text_range();
+        Some(
+            self.raw_byte_to_document_byte(range.start)?
+                ..self.raw_byte_to_document_byte(range.end)?,
+        )
+    }
+
+    fn update_compose_for_replaced_range(&mut self, old_range: Range<usize>, new_len: usize) {
         let Some(compose) = &mut self.compose else {
             return;
         };
-        if compose.end <= old_range.start {
-            return;
+        let new_start = transformed_range_start(compose.range.start, &old_range, new_len);
+        let new_end = transformed_range_end(compose.range.end, &old_range, new_len);
+        compose.range = new_start..new_end;
+        if compose.kind == CompositionKind::HiddenPreedit && compose.range.is_empty() {
+            self.compose = None;
         }
-        if compose.start >= old_range.end {
-            if new_len > old_range.len() {
-                let diff = new_len - old_range.len();
-                *compose = compose.start + diff..compose.end + diff;
-            } else {
-                let diff = old_range.len() - new_len;
-                *compose = compose.start - diff..compose.end - diff;
-            }
-            return;
-        }
-        if new_len < old_range.len() {
-            if compose.start >= (old_range.start + new_len) {
-                self.compose = None;
-                return;
-            }
-            compose.end = compose.end.min(old_range.start + new_len);
-        }
+    }
+
+    fn hidden_composition_range(&self) -> Option<&Range<usize>> {
+        self.compose
+            .as_ref()
+            .filter(|compose| compose.kind == CompositionKind::HiddenPreedit)
+            .map(|compose| &compose.range)
     }
 
     fn replace_selection(
@@ -1165,13 +1411,18 @@ where
         layout_cx: &mut LayoutContext<T>,
         s: &str,
     ) {
-        let range = self.selection.text_range();
+        self.replace_range_with_selection(font_cx, layout_cx, self.selection.text_range(), s);
+    }
+
+    fn replace_range_with_selection(
+        &mut self,
+        font_cx: &mut FontContext,
+        layout_cx: &mut LayoutContext<T>,
+        range: Range<usize>,
+        s: &str,
+    ) {
         let start = range.start;
-        if self.selection.is_collapsed() {
-            self.buffer.insert_str(start, s);
-        } else {
-            self.buffer.replace_range(range.clone(), s);
-        }
+        self.buffer.replace_range(range.clone(), s);
         self.update_compose_for_replaced_range(range, s.len());
 
         self.update_layout(font_cx, layout_cx);
@@ -1232,8 +1483,18 @@ where
         for prop in self.default_style.inner().values() {
             builder.push_default(prop.to_owned());
         }
-        if let Some(preedit_range) = &self.compose {
-            builder.push(StyleProperty::Underline(true), preedit_range.clone());
+        if let Some(compose) = &self.compose {
+            if compose.range.is_empty() {
+                self.layout = builder.build(&self.buffer);
+                self.layout.break_all_lines(self.width);
+                self.layout
+                    .align(self.width, self.alignment, AlignmentOptions::default());
+                self.selection = self.selection.refresh(&self.layout);
+                self.layout_dirty = false;
+                self.generation.nudge();
+                return;
+            }
+            builder.push(StyleProperty::Underline(true), compose.range.clone());
         }
         self.layout = builder.build(&self.buffer);
         self.layout.break_all_lines(self.width);
@@ -1282,5 +1543,33 @@ where
             node.clear_text_selection();
         }
         node.add_action(accesskit::Action::SetTextSelection);
+    }
+}
+
+fn validate_text_range(text: &str, range: Range<usize>) -> Option<Range<usize>> {
+    (range.start <= range.end && text.get(range.clone()).is_some()).then_some(range)
+}
+
+fn transformed_range_start(index: usize, replaced: &Range<usize>, inserted_len: usize) -> usize {
+    if index < replaced.start {
+        index
+    } else if index < replaced.end {
+        replaced.start
+    } else if inserted_len >= replaced.len() {
+        index + inserted_len - replaced.len()
+    } else {
+        index - (replaced.len() - inserted_len)
+    }
+}
+
+fn transformed_range_end(index: usize, replaced: &Range<usize>, inserted_len: usize) -> usize {
+    if index <= replaced.start {
+        index
+    } else if index <= replaced.end {
+        replaced.start + inserted_len
+    } else if inserted_len >= replaced.len() {
+        index + inserted_len - replaced.len()
+    } else {
+        index - (replaced.len() - inserted_len)
     }
 }

--- a/parley/src/editing/mod.rs
+++ b/parley/src/editing/mod.rs
@@ -4,7 +4,9 @@
 mod cursor;
 mod editor;
 mod selection;
+mod split_string;
 
 pub use self::cursor::*;
 pub use self::editor::*;
 pub use self::selection::*;
+pub use self::split_string::*;

--- a/parley/src/editing/split_string.rs
+++ b/parley/src/editing/split_string.rs
@@ -1,0 +1,161 @@
+// Copyright 2026 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use core::{fmt::Display, ops::Range};
+
+/// A string which is potentially discontiguous in memory.
+///
+/// This is returned by [`crate::PlainEditor::text`], as transient composition
+/// text may need to be efficiently excluded from its return value.
+#[derive(Debug, Clone, Copy)]
+pub struct SplitString<'source>(pub(crate) [&'source str; 2]);
+
+/// Text offset encoding for converting host-provided positions into UTF-8 byte
+/// ranges over visible editor text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TextIndexEncoding {
+    /// Offsets are already UTF-8 byte indices.
+    Utf8Bytes,
+    /// Offsets are UTF-16 code-unit indices.
+    Utf16CodeUnits,
+    /// Offsets are Unicode scalar-value counts.
+    UnicodeCodePoints,
+}
+
+impl<'source> SplitString<'source> {
+    /// Get the characters of this string.
+    pub fn chars(self) -> impl Iterator<Item = char> + 'source {
+        self.into_iter().flat_map(str::chars)
+    }
+
+    /// Convert encoded text offsets into a UTF-8 byte range over this visible
+    /// text.
+    ///
+    /// Returns `None` if the offsets are reversed, out of bounds, or do not
+    /// land on valid boundaries for the provided encoding.
+    pub fn to_utf8_range(
+        self,
+        start: u32,
+        end: u32,
+        encoding: TextIndexEncoding,
+    ) -> Option<Range<usize>> {
+        let start = self.offset_to_utf8(start, encoding)?;
+        let end = self.offset_to_utf8(end, encoding)?;
+        (start <= end).then_some(start..end)
+    }
+
+    fn len(self) -> usize {
+        self.0[0].len() + self.0[1].len()
+    }
+
+    fn is_char_boundary(self, offset: usize) -> bool {
+        let mut prefix = 0_usize;
+        for segment in self {
+            let end = prefix + segment.len();
+            if offset < end {
+                return segment.is_char_boundary(offset - prefix);
+            }
+            if offset == end {
+                return true;
+            }
+            prefix = end;
+        }
+        offset == prefix
+    }
+
+    fn offset_to_utf8(self, offset: u32, encoding: TextIndexEncoding) -> Option<usize> {
+        match encoding {
+            TextIndexEncoding::Utf8Bytes => split_utf8_offset_to_utf8_byte_offset(self, offset),
+            TextIndexEncoding::Utf16CodeUnits => {
+                split_utf16_offset_to_utf8_byte_offset(self, offset)
+            }
+            TextIndexEncoding::UnicodeCodePoints => {
+                split_code_point_offset_to_utf8_byte_offset(self, offset)
+            }
+        }
+    }
+}
+
+impl PartialEq<&'_ str> for SplitString<'_> {
+    fn eq(&self, other: &&'_ str) -> bool {
+        let [a, b] = self.0;
+        let mid = a.len();
+        match other.split_at_checked(mid) {
+            Some((a_1, b_1)) => a_1 == a && b_1 == b,
+            None => false,
+        }
+    }
+}
+
+// We intentionally choose not to:
+// impl PartialEq<Self> for SplitString<'_> {}
+// for simplicity, as the impl wouldn't be useful and is non-trivial
+
+impl Display for SplitString<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let [a, b] = self.0;
+        write!(f, "{a}{b}")
+    }
+}
+
+/// Iterate through the source strings.
+impl<'source> IntoIterator for SplitString<'source> {
+    type Item = &'source str;
+    type IntoIter = <[&'source str; 2] as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+fn split_utf8_offset_to_utf8_byte_offset(text: SplitString<'_>, utf8_offset: u32) -> Option<usize> {
+    let offset = usize::try_from(utf8_offset).ok()?;
+    (offset <= text.len() && text.is_char_boundary(offset)).then_some(offset)
+}
+
+fn split_utf16_offset_to_utf8_byte_offset(
+    text: SplitString<'_>,
+    utf16_offset: u32,
+) -> Option<usize> {
+    if utf16_offset == 0 {
+        return Some(0);
+    }
+    let target = usize::try_from(utf16_offset).ok()?;
+    let mut utf16_count = 0_usize;
+    let mut byte_offset = 0_usize;
+    for segment in text {
+        for ch in segment.chars() {
+            if utf16_count == target {
+                return Some(byte_offset);
+            }
+            utf16_count = utf16_count.checked_add(ch.len_utf16())?;
+            byte_offset = byte_offset.checked_add(ch.len_utf8())?;
+            if utf16_count == target {
+                return Some(byte_offset);
+            }
+        }
+    }
+    (utf16_count == target).then_some(byte_offset)
+}
+
+fn split_code_point_offset_to_utf8_byte_offset(
+    text: SplitString<'_>,
+    code_point_offset: u32,
+) -> Option<usize> {
+    if code_point_offset == 0 {
+        return Some(0);
+    }
+    let target = usize::try_from(code_point_offset).ok()?;
+    let mut code_point_count = 0_usize;
+    let mut byte_offset = 0_usize;
+    for segment in text {
+        for ch in segment.chars() {
+            if code_point_count == target {
+                return Some(byte_offset);
+            }
+            code_point_count = code_point_count.checked_add(1)?;
+            byte_offset = byte_offset.checked_add(ch.len_utf8())?;
+        }
+    }
+    (code_point_count == target).then_some(byte_offset)
+}

--- a/parley/src/editing/split_string.rs
+++ b/parley/src/editing/split_string.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 the Parley Authors
+// Copyright 2024 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use core::{fmt::Display, ops::Range};
@@ -18,7 +18,7 @@ pub enum TextIndexEncoding {
     Utf8Bytes,
     /// Offsets are UTF-16 code-unit indices.
     Utf16CodeUnits,
-    /// Offsets are Unicode scalar-value counts.
+    /// Offsets are Unicode scalar-value counts (`char`s in Rust terms).
     UnicodeCodePoints,
 }
 
@@ -126,6 +126,8 @@ fn split_utf16_offset_to_utf8_byte_offset(
     for segment in text {
         for ch in segment.chars() {
             if utf16_count == target {
+                // The requested UTF-16 boundary can fall exactly at a split
+                // seam, before the next segment contributes any code units.
                 return Some(byte_offset);
             }
             utf16_count = utf16_count.checked_add(ch.len_utf16())?;

--- a/parley_tests/tests/editor.rs
+++ b/parley_tests/tests/editor.rs
@@ -6,6 +6,7 @@
 use crate::test_name;
 use crate::util::TestEnv;
 use parley::Affinity;
+use parley::editing::Composition;
 
 // TODO - Use CursorTest API for these tests
 
@@ -115,4 +116,270 @@ fn editor_insert_regular_text_set_upstream_affinity() {
     assert!(sel.is_collapsed());
     assert_eq!(sel.focus().index(), 2);
     assert_eq!(sel.focus().affinity(), Affinity::Upstream);
+}
+
+#[test]
+fn editor_document_selection_accounts_for_compose_gap() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("abcd");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_document_selection(2..2));
+        assert!(drv.update_composition("XYZ", None, Some(3..3)));
+    }
+
+    assert_eq!(editor.raw_text(), "abXYZcd");
+    assert_eq!(editor.text(), "abcd");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_document_selection(2..4));
+    }
+
+    assert_eq!(editor.raw_selection().text_range(), 5..7);
+}
+
+#[test]
+fn editor_insert_or_replace_uses_document_ranges_while_composing() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("abcd");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_document_selection(2..2));
+        assert!(drv.update_composition("XYZ", None, Some(3..3)));
+        assert!(drv.insert_or_replace("Q", Some(2..4), None));
+    }
+
+    assert_eq!(editor.raw_text(), "abXYZQ");
+    assert_eq!(editor.text(), "abQ");
+    assert_eq!(
+        editor.composition(),
+        Some(Composition {
+            text: "XYZ",
+            document_offset: 2,
+        })
+    );
+}
+
+#[test]
+fn editor_delete_surrounding_uses_document_space_while_composing() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("abcd");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_document_selection(2..2));
+        assert!(drv.update_composition("XYZ", None, Some(3..3)));
+        assert!(drv.set_document_selection(4..4));
+        assert!(drv.delete_surrounding(2, 0));
+    }
+
+    assert_eq!(editor.raw_text(), "abXYZ");
+    assert_eq!(editor.text(), "ab");
+    assert_eq!(
+        editor.composition(),
+        Some(Composition {
+            text: "XYZ",
+            document_offset: 2,
+        })
+    );
+    assert_eq!(editor.raw_selection().text_range(), 5..5);
+}
+
+#[test]
+fn editor_update_and_clear_composition_are_atomic() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("hello");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_document_selection(5..5));
+        assert!(drv.update_composition("にほ", None, Some(3..3)));
+    }
+
+    assert_eq!(editor.raw_text(), "helloにほ");
+    assert_eq!(editor.text(), "hello");
+    assert_eq!(
+        editor.composition(),
+        Some(Composition {
+            text: "にほ",
+            document_offset: 5,
+        })
+    );
+    assert_eq!(editor.raw_selection().text_range(), 8..8);
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.commit_composition());
+    }
+
+    assert_eq!(editor.raw_text(), "helloにほ");
+    assert_eq!(editor.text(), "helloにほ");
+    assert_eq!(editor.composition(), None);
+    assert_eq!(editor.raw_selection().text_range(), 8..8);
+}
+
+#[test]
+fn editor_visible_composing_region_preserves_document_text() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("hello");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_composing_region(1..4));
+    }
+
+    assert_eq!(editor.raw_text(), "hello");
+    assert_eq!(editor.text(), "hello");
+    assert_eq!(
+        editor.composition(),
+        Some(Composition {
+            text: "ell",
+            document_offset: 1,
+        })
+    );
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.clear_composition());
+    }
+
+    assert_eq!(editor.raw_text(), "hello");
+    assert_eq!(editor.text(), "hello");
+    assert_eq!(editor.composition(), None);
+}
+
+#[test]
+fn editor_visible_composing_region_commit_only_clears_mark() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("hello");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_composing_region(1..4));
+        assert!(drv.commit_composition());
+    }
+
+    assert_eq!(editor.raw_text(), "hello");
+    assert_eq!(editor.text(), "hello");
+    assert_eq!(editor.composition(), None);
+}
+
+#[test]
+fn editor_collapsed_visible_composing_region_is_preserved() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("hello");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_composing_region(2..2));
+    }
+
+    assert_eq!(editor.raw_text(), "hello");
+    assert_eq!(editor.text(), "hello");
+    assert_eq!(
+        editor.composition(),
+        Some(Composition {
+            text: "",
+            document_offset: 2,
+        })
+    );
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.clear_composition());
+    }
+
+    assert_eq!(editor.raw_text(), "hello");
+    assert_eq!(editor.text(), "hello");
+    assert_eq!(editor.composition(), None);
+}
+
+#[test]
+fn editor_visible_composing_region_tracks_overlapping_replacements() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("hello");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_composing_region(1..4));
+        assert!(drv.insert_or_replace("X", Some(0..2), None));
+    }
+
+    assert_eq!(editor.raw_text(), "Xllo");
+    assert_eq!(editor.text(), "Xllo");
+    assert_eq!(
+        editor.composition(),
+        Some(Composition {
+            text: "Xll",
+            document_offset: 0,
+        })
+    );
+}
+
+#[test]
+fn editor_visible_composing_region_end_boundary_is_half_open() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("hello");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_composing_region(1..4));
+        assert!(drv.insert_or_replace("X", Some(4..4), None));
+    }
+
+    assert_eq!(editor.raw_text(), "hellXo");
+    assert_eq!(editor.text(), "hellXo");
+    assert_eq!(
+        editor.composition(),
+        Some(Composition {
+            text: "ell",
+            document_offset: 1,
+        })
+    );
+}
+
+#[test]
+fn editor_selected_text_is_available_for_visible_composition() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("hello");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_document_selection(1..4));
+        assert!(drv.set_composing_region(1..4));
+    }
+
+    assert_eq!(editor.selected_text(), Some("ell"));
+}
+
+#[test]
+fn editor_selected_text_is_hidden_for_preedit_composition() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("hello");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_document_selection(1..4));
+        assert!(drv.update_composition("XY", Some(1..4), Some(0..0)));
+        assert!(drv.set_document_selection(0..2));
+    }
+
+    assert_eq!(editor.selected_text(), None);
+}
+
+#[test]
+fn editor_delete_to_line_end_removes_to_physical_line_edge() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("ab\ncd");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        drv.move_right();
+        drv.delete_to_line_end();
+    }
+
+    assert_eq!(editor.raw_text(), "a\ncd");
 }

--- a/parley_tests/tests/mod.rs
+++ b/parley_tests/tests/mod.rs
@@ -29,6 +29,7 @@ mod editor;
 mod issues;
 mod line_break;
 mod lines;
+mod split_string;
 mod styles;
 mod text_indent;
 mod wrap;

--- a/parley_tests/tests/split_string.rs
+++ b/parley_tests/tests/split_string.rs
@@ -1,0 +1,95 @@
+// Copyright 2026 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! `SplitString` tests.
+
+use crate::test_name;
+use crate::util::TestEnv;
+use parley::editing::TextIndexEncoding;
+
+#[test]
+fn split_string_to_utf8_range_handles_hidden_compose_gap() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("a🙂b");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_document_selection(1..1));
+        assert!(drv.update_composition("XYZ", None, Some(0..0)));
+    }
+
+    let text = editor.text();
+    assert_eq!(text, "a🙂b");
+    assert_eq!(
+        text.to_utf8_range(1, 5, TextIndexEncoding::Utf8Bytes),
+        Some(1..5)
+    );
+    assert_eq!(
+        text.to_utf8_range(1, 3, TextIndexEncoding::Utf16CodeUnits),
+        Some(1..5)
+    );
+    assert_eq!(
+        text.to_utf8_range(1, 2, TextIndexEncoding::UnicodeCodePoints),
+        Some(1..5)
+    );
+}
+
+#[test]
+fn split_string_to_utf8_range_rejects_reversed_and_out_of_bounds_offsets() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("a🙂b");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_document_selection(1..1));
+        assert!(drv.update_composition("XYZ", None, Some(0..0)));
+    }
+
+    let text = editor.text();
+    assert_eq!(text.to_utf8_range(5, 1, TextIndexEncoding::Utf8Bytes), None);
+    assert_eq!(text.to_utf8_range(0, 7, TextIndexEncoding::Utf8Bytes), None);
+    assert_eq!(
+        text.to_utf8_range(0, 5, TextIndexEncoding::Utf16CodeUnits),
+        None
+    );
+    assert_eq!(
+        text.to_utf8_range(0, 5, TextIndexEncoding::UnicodeCodePoints),
+        None
+    );
+}
+
+#[test]
+fn split_string_to_utf8_range_rejects_invalid_utf8_boundaries_across_segments() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("🙂🙂");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_document_selection(4..4));
+        assert!(drv.update_composition("XYZ", None, Some(0..0)));
+    }
+
+    let text = editor.text();
+    assert_eq!(text, "🙂🙂");
+    assert_eq!(text.to_utf8_range(1, 4, TextIndexEncoding::Utf8Bytes), None);
+    assert_eq!(text.to_utf8_range(4, 5, TextIndexEncoding::Utf8Bytes), None);
+}
+
+#[test]
+fn split_string_to_utf8_range_handles_multibyte_utf16_range_across_segments() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("é🙂界");
+
+    {
+        let mut drv = env.driver(&mut editor);
+        assert!(drv.set_document_selection(6..6));
+        assert!(drv.update_composition("XYZ", None, Some(0..0)));
+    }
+
+    let text = editor.text();
+    assert_eq!(text, "é🙂界");
+    assert_eq!(
+        text.to_utf8_range(1, 4, TextIndexEncoding::Utf16CodeUnits),
+        Some(2..9)
+    );
+}


### PR DESCRIPTION
Rework `PlainEditor`’s text-input/composition model so host integrations can operate in document UTF-8 byte space instead of emulating Parley’s old raw preedit internals.

This changes the internal composition model from a single hidden-preedit span to two distinct states:

* hidden preedit text, which is excluded from `PlainEditor::text()`
* visible composing regions over existing document text, which remain part of `PlainEditor::text()`

On top of that model, add a host-facing editing surface on `PlainEditorDriver` for:

* setting document selection
* setting composing regions
* insert/replace with optional replacement ranges
* atomic composition updates
* surrounding delete in document space
* explicit composition commit/clear
* semantic delete-to-edge helpers for future edit-command integration

Move encoded-offset conversion over visible editor text into Parley itself via `SplitString::to_utf8_range` and `TextIndexEncoding`, so adapters do not need to allocate or duplicate range-conversion logic.

Also:

* remove the legacy mutating compose APIs
* replace `raw_compose` with `composition`
* rename `ime_cursor_area` to `text_input_area`
* migrate `examples/vello_editor` to the `ui-events` text-input path