### PR TITLE
Fix word deletion behavior with multiple spaces

### DIFF
--- a/parley/src/editing/editor.rs
+++ b/parley/src/editing/editor.rs
@@ -267,7 +267,7 @@ where
         if self.editor.selection.is_collapsed() {
             let focus = self.editor.selection.focus();
             let start = focus.index();
-            let end = focus.next_logical_word(&self.editor.layout).index();
+            let end = focus.next_visual_word(&self.editor.layout).index();
             if self.editor.buffer.get(start..end).is_some() {
                 self.editor.buffer.replace_range(start..end, "");
                 self.editor.update_compose_for_replaced_range(start..end, 0);
@@ -328,7 +328,7 @@ where
         if self.editor.selection.is_collapsed() {
             let focus = self.editor.selection.focus();
             let end = focus.index();
-            let start = focus.previous_logical_word(&self.editor.layout).index();
+            let start = focus.previous_visual_word(&self.editor.layout).index();
             if self.editor.buffer.get(start..end).is_some() {
                 self.editor.buffer.replace_range(start..end, "");
                 self.editor.update_compose_for_replaced_range(start..end, 0);


### PR DESCRIPTION
When using the delete word methods, if there are multiple spaces they are treated as a standalone word. Thus, when backdeleting with the cursor at the end of `word `, it deletes the whole thing, but with `word    `, it only deletes the four spaces.

I'm not sure of other implications, but I tested this fix locally and it seems to work fine with both single space gaps and multi space gaps, for forward and backward word deletion. It matches the native behavior of MacOS.