### PR TITLE
Update to hashbrown 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,7 +1190,7 @@ dependencies = [
 name = "fontique"
 version = "0.8.0"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "linebender_resource_handle",
  "memmap2",
  "objc2 0.6.4",
@@ -1522,6 +1522,15 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
  "foldhash 0.2.0",
 ]
 
@@ -2849,7 +2858,7 @@ dependencies = [
  "core_maths",
  "fontique",
  "harfrust",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "icu_normalizer",
  "icu_properties",
  "icu_segmenter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,7 @@ accesskit = "0.24.0"
 bytemuck = { version = "1.25.0", default-features = false }
 fontique = { version = "0.8.0", default-features = false, path = "fontique" }
 harfrust = { version = "0.5.2", default-features = false }
-foldhash = { version = "0.2.0", default-features = false }
-hashbrown = { version = "0.16.1", default-features = false, features = [
+hashbrown = { version = "0.17.0", default-features = false, features = [
     "default-hasher",
     "raw-entry",
 ] }


### PR DESCRIPTION
(Also, remove a stale workspace dependency entry for `foldhash`.)