### PR TITLE
Release Parley and Fontique v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,39 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV] of 1.88.
 
+## [0.9.0] - 2026-04-21
+
+This release has an [MSRV] of 1.88.
+
 ### Added
+
+#### Parley
+
+- Enable floats and other advanced layouts ([#421][] by [@nicoburns][])
+
+  This does not affect users who are using the high-level `break_all_lines()` function to perform line breaking. However, it brings a number of additional advanced capabilities to users who are calling the `break_lines()` function to use the  `BreakLines` struct directly:
+
+  - Inline boxes now have an additional `InlineBoxKind` field. `InFlow` behaves like inline boxes in previous versions of Parley. `OutOfFlow` gets positioned like an `InFlow` box, but does not take up space (like `position:absolute` in CSS), and `CustomOutOfFlow` can be used in conjunction with the low-level `.break_lines()` API to implement floated boxes (like CSS `float`) which  position depends on the state of line breaking 
+  - Each line can have it's x/y/width/height set individually, and text will lay out into that box (the width for each line must be less than or equal to the width of the overall layout). This enables text to be laid out around "excluded regions", by setting a line box that avoids those regions. The logic for computing the positions of each line is left to the user.
 
 #### Fontique
 
 - `FallbackKey` now implements `From<Script>` for convenience. ([#594][] by [@xStrom][])
+
+### Changed
+
+- Upgrade hashbrown to 0.17 ([#506][] by [@waywardmonkeys][])
+- Upgrade to read-fonts to 0.39, skrifa 0.42, harfrust 0.6 ([#600][] by [@nicoburns][])
+
+### Fixed
+
+#### Parley
+
+- Fix going to start of text when moving up on single line ([#609][] by [@jordanhalase][])
+
+#### Fontique
+
+- Fix CJK text on macOS when PingFangUI contains hvgl outlines ([#598][] by [@dfrg][])
 
 ## [0.8.0] - 2026-03-27
 
@@ -423,6 +451,7 @@ This release has an [MSRV][] of 1.70.
 [@elbaro]: https://github.com/elbaro
 [@guiguiprim]: https://github.com/guiguiprim
 [@grebmeg]: https://github.com/grebmeg
+[@jordanhalase]: https://github.com/jordanhalase
 [@kekelp]: https://github.com/kekelp
 [@mwcampbell]: https://github.com/mwcampbell
 [@nicoburns]: https://github.com/nicoburns
@@ -527,6 +556,7 @@ This release has an [MSRV][] of 1.70.
 [#413]: https://github.com/linebender/parley/pull/413
 [#414]: https://github.com/linebender/parley/pull/414
 [#418]: https://github.com/linebender/parley/pull/418
+[#421]: https://github.com/linebender/parley/pull/421
 [#436]: https://github.com/linebender/parley/pull/436
 [#440]: https://github.com/linebender/parley/pull/440
 [#444]: https://github.com/linebender/parley/pull/444
@@ -537,6 +567,7 @@ This release has an [MSRV][] of 1.70.
 [#467]: https://github.com/linebender/parley/pull/467
 [#468]: https://github.com/linebender/parley/pull/468
 [#486]: https://github.com/linebender/parley/pull/486
+[#506]: https://github.com/linebender/parley/pull/506
 [#510]: https://github.com/linebender/parley/pull/510
 [#512]: https://github.com/linebender/parley/pull/512
 [#516]: https://github.com/linebender/parley/pull/516
@@ -564,6 +595,10 @@ This release has an [MSRV][] of 1.70.
 [#578]: https://github.com/linebender/parley/pull/578
 [#589]: https://github.com/linebender/parley/pull/589
 [#594]: https://github.com/linebender/parley/pull/594
+[#598]: https://github.com/linebender/parley/pull/598
+[#600]: https://github.com/linebender/parley/pull/600
+[#605]: https://github.com/linebender/parley/pull/605
+[#609]: https://github.com/linebender/parley/pull/609
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/linebender/parley/compare/v0.7.0...v0.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "hashbrown 0.17.0",
  "linebender_resource_handle",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "parley"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "accesskit",
  "core_maths",
@@ -2895,7 +2895,7 @@ version = "0.0.0"
 
 [[package]]
 name = "parley_data"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "icu_properties",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.8.0"
+version = "0.9.0"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
 rust-version = "1.88"
@@ -32,7 +32,7 @@ repository = "https://github.com/linebender/parley"
 [workspace.dependencies]
 accesskit = "0.24.0"
 bytemuck = { version = "1.25.0", default-features = false }
-fontique = { version = "0.8.0", default-features = false, path = "fontique" }
+fontique = { version = "0.9.0", default-features = false, path = "fontique" }
 harfrust = { version = "0.6.0", default-features = false }
 hashbrown = { version = "0.17.0", default-features = false, features = [
     "default-hasher",
@@ -45,8 +45,8 @@ icu_segmenter = { version = "2.1.2", default-features = false }
 linebender_resource_handle = { version = "0.1.1", default-features = false }
 packtab = { version = "1.8.0" }
 parlance = { version = "0.1.0", default-features = false, path = "parlance" }
-parley = { version = "0.8.0", default-features = false, path = "parley" }
-parley_data = { version = "0.8.0", path = "parley_data", default-features = false }
+parley = { version = "0.9.0", default-features = false, path = "parley" }
+parley_data = { version = "0.9.0", path = "parley_data", default-features = false }
 parley_data_gen = { path = "parley_data_gen" }
 parley_dev = { default-features = false, path = "parley_dev" }
 glifo = { git = "https://github.com/linebender/vello", rev = "5796226", default-features = false }


### PR DESCRIPTION
Prepare for Parley v0.9.0 release by bumping the version number and updating the changelog.

The following PR should be merged before this one:

- https://github.com/linebender/parley/pull/600

(this PR updates the changelog to include this change)

