### PR TITLE
Fix going to start of text when moving up on single line

### DIFF
--- a/parley/src/editing/selection.rs
+++ b/parley/src/editing/selection.rs
@@ -274,7 +274,7 @@ impl Selection {
             .map(|(ix, _)| ix)
             .unwrap_or(line_limit);
         let new_line_index = line_index.saturating_add_signed(delta);
-        if delta < 0 && line_index.checked_add_signed(delta).is_none() && line_limit > 0 {
+        if delta < 0 && line_index.checked_add_signed(delta).is_none() {
             return self
                 .move_to_line(layout, 0, extend)
                 .line_start(layout, extend);


### PR DESCRIPTION
We expect `move_lines()` to move the cursor to the start of text if attempting to move up when on the first line. This usually works, however, if there is only one line of editable text this stops working. This fixes the issue.

Closes #608