### PR TITLE
Fontique supports FreeBSD

### DIFF
--- a/fontique/Cargo.toml
+++ b/fontique/Cargo.toml
@@ -72,7 +72,7 @@ objc2-core-text = { version = "0.3.2", optional = true, default-features = false
     "CTFontCollection",
 ] }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os="freebsd"))'.dependencies]
 yeslogic-fontconfig-sys = { version = "6.0.0", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/fontique/src/backend/mod.rs
+++ b/fontique/src/backend/mod.rs
@@ -11,7 +11,7 @@ mod system;
 #[path = "coretext.rs"]
 mod system;
 
-#[cfg(all(feature = "system", target_os = "linux"))]
+#[cfg(all(feature = "system", any(target_os = "linux", target_os = "freebsd")))]
 #[path = "fontconfig.rs"]
 mod system;
 
@@ -40,6 +40,7 @@ pub(crate) use system::SystemFonts;
     not(any(
         target_os = "windows",
         target_os = "linux",
+        target_os = "freebsd",
         target_os = "android",
         target_vendor = "apple"
     ))

--- a/fontique/src/collection/mod.rs
+++ b/fontique/src/collection/mod.rs
@@ -831,7 +831,12 @@ impl Shared {
 #[test]
 #[cfg(all(
     feature = "std",
-    any(target_os = "linux", target_os = "macos", target_os = "windows")
+    any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "macos",
+        target_os = "windows"
+    )
 ))]
 fn make_shared_matches_local() {
     use crate::{Collection, CollectionOptions};
@@ -846,6 +851,8 @@ fn make_shared_matches_local() {
         "/Library/Fonts",
         #[cfg(target_os = "linux")]
         "/usr/share/fonts",
+        #[cfg(target_os = "freebsd")]
+        "/usr/local/share/fonts",
         #[cfg(target_os = "windows")]
         "C:\\Windows\\Fonts",
     ]


### PR DESCRIPTION
`fontconfig-rs` supports FreeBSD OS, so it can be added.