### PR TITLE
Add StyleSet::clear method

### DIFF
--- a/parley/src/style/styleset.rs
+++ b/parley/src/style/styleset.rs
@@ -73,4 +73,11 @@ impl<Brush: crate::Brush> StyleSet<Brush> {
     pub fn inner(&self) -> &HashMap<Discriminant<StyleProperty<Brush>>, StyleProperty<Brush>> {
         &self.0
     }
+
+    /// Clear all styles.
+    ///
+    /// All styles return to their default values.
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
 }


### PR DESCRIPTION
## Summary

Add a `clear()` method to `StyleSet` that removes all styles, returning them to their default values.

## Motivation

Currently, to clear all styles you have to use `retain(|_| false)` which is less clear in intent. A dedicated `clear()` method is more ergonomic and matches the standard library pattern.

## Changes

Added `StyleSet::clear(&mut self)` method that calls `self.0.clear()` on the underlying HashMap.

## Use case

This is needed by Dioxus/blitz to clear editor styles before applying new ones (https://github.com/DioxusLabs/blitz/blob/main/packages/blitz-dom/src/layout/construct.rs#L634).