### PR TITLE
Implement Debug for PlainEditor and its dependent types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ This release has an [MSRV] of 1.88.
 
 #### Parley
 
-- `PlainEditor`, `Layout`, `LayoutAccessibility`, and `Generation` now implement `Debug`. The `Layout` implementation prints a compact summary by default; the alternate form (`{:#?}`) prints the full underlying data. ([#615][] by [@NandishwarSingh][])
+- `PlainEditor`, `Layout`, `LayoutAccessibility`, and `Generation` now implement `Debug`. ([#615][] by [@NandishwarSingh][])
+  Note: The `Layout` implementation provides a compact summary by default; the alternate form (`{:#?}`) formats the full underlying data.
 
 ## [0.9.0] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This release has an [MSRV] of 1.88.
 
 #### Parley
 
-- `PlainEditor`, `Layout`, `LayoutAccessibility`, and `Generation` now implement `Debug`. ([#615][] by [@NandishwarSingh][])
+- `PlainEditor`, `Layout`, `LayoutAccessibility`, and `Generation` now implement `Debug`. The `Layout` implementation prints a compact summary by default; the alternate form (`{:#?}`) prints the full underlying data. ([#615][] by [@NandishwarSingh][])
 
 ## [0.9.0] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV] of 1.88.
 
+### Added
+
+#### Parley
+
+- `PlainEditor`, `Layout`, `LayoutAccessibility`, and `Generation` now implement `Debug`. ([#615][] by [@NandishwarSingh][])
+
 ## [0.9.0] - 2026-04-21
 
 This release has an [MSRV] of 1.88.
@@ -463,6 +469,7 @@ This release has an [MSRV][] of 1.70.
 [@jordanhalase]: https://github.com/jordanhalase
 [@kekelp]: https://github.com/kekelp
 [@mwcampbell]: https://github.com/mwcampbell
+[@NandishwarSingh]: https://github.com/NandishwarSingh
 [@nicoburns]: https://github.com/nicoburns
 [@NoahR02]: https://github.com/NoahR02
 [@ogoffart]: https://github.com/ogoffart
@@ -608,6 +615,7 @@ This release has an [MSRV][] of 1.70.
 [#600]: https://github.com/linebender/parley/pull/600
 [#605]: https://github.com/linebender/parley/pull/605
 [#609]: https://github.com/linebender/parley/pull/609
+[#615]: https://github.com/linebender/parley/pull/615
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.9.0...HEAD
 [0.9.0]: https://github.com/linebender/parley/compare/v0.8.0...v0.9.0

--- a/parley/src/editing/editor.rs
+++ b/parley/src/editing/editor.rs
@@ -29,7 +29,7 @@ use accesskit::{Node, NodeId, TreeUpdate};
 // so wrapping is fine. This could only fail if exactly
 // `u32::MAX` generations happen between drawing
 // operations. This is implausible and so can be ignored.
-#[derive(PartialEq, Eq, Default, Clone, Copy)]
+#[derive(PartialEq, Eq, Default, Clone, Copy, Debug)]
 pub struct Generation(u32);
 
 impl Generation {
@@ -88,7 +88,7 @@ impl<'source> IntoIterator for SplitString<'source> {
 /// Internally, this is a wrapper around a string buffer and its corresponding [`Layout`],
 /// which is kept up-to-date as needed.
 /// This layout is invalidated by a number.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PlainEditor<T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,

--- a/parley/src/layout/accessibility.rs
+++ b/parley/src/layout/accessibility.rs
@@ -53,7 +53,7 @@ fn add_span(update: &mut TreeUpdate, parent_node: &mut Node, id: NodeId, node: N
     parent_node.push_child(id);
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct LayoutAccessibility {
     // We define a span as a sequence of clusters, in logical order, that all
     // have an identical style. For each span we create an AccessKit node

--- a/parley/src/layout/layout.rs
+++ b/parley/src/layout/layout.rs
@@ -15,7 +15,7 @@ use crate::layout::{
 };
 
 /// Text layout.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Layout<B: Brush> {
     pub(crate) data: LayoutData<B>,
 }

--- a/parley/src/layout/layout.rs
+++ b/parley/src/layout/layout.rs
@@ -7,6 +7,7 @@ use crate::layout::alignment::unjustify;
 use crate::layout::data::LayoutData;
 use crate::style::Brush;
 use core::cmp::Ordering;
+use core::fmt;
 
 use crate::IndentOptions;
 use crate::layout::{
@@ -15,9 +16,33 @@ use crate::layout::{
 };
 
 /// Text layout.
-#[derive(Clone, Debug)]
+///
+/// The [`Debug`] implementation prints a compact summary by default
+/// (text length, dimensions, and counts of lines, runs, and styles) which is
+/// intended for one-off developer logging. Use the alternate form (`{:#?}`)
+/// to get the full pretty-printed dump of the underlying data.
+///
+/// [`Debug`]: core::fmt::Debug
+#[derive(Clone)]
 pub struct Layout<B: Brush> {
     pub(crate) data: LayoutData<B>,
+}
+
+impl<B: Brush> fmt::Debug for Layout<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            f.debug_struct("Layout").field("data", &self.data).finish()
+        } else {
+            f.debug_struct("Layout")
+                .field("text_len", &self.data.text_len)
+                .field("width", &self.data.width)
+                .field("height", &self.data.height)
+                .field("lines", &self.data.lines.len())
+                .field("runs", &self.data.runs.len())
+                .field("styles", &self.data.styles.len())
+                .finish_non_exhaustive()
+        }
+    }
 }
 
 impl<B: Brush> Layout<B> {

--- a/parley/src/layout/layout.rs
+++ b/parley/src/layout/layout.rs
@@ -17,10 +17,8 @@ use crate::layout::{
 
 /// Text layout.
 ///
-/// The [`Debug`] implementation prints a compact summary by default
-/// (text length, dimensions, and counts of lines, runs, and styles) which is
-/// intended for one-off developer logging. Use the alternate form (`{:#?}`)
-/// to get the full pretty-printed dump of the underlying data.
+/// The [`Debug`] implementation prints a compact summary by default.
+/// The alternate form (`{:#?}`) formats the full underlying data.
 ///
 /// [`Debug`]: core::fmt::Debug
 #[derive(Clone)]


### PR DESCRIPTION
Adds #[derive(Debug)] to PlainEditor along with the three field types that previously lacked it: Generation, LayoutAccessibility, and Layout. The Brush trait already requires Debug, so deriving Debug on Layout<B> and PlainEditor<T> is mechanical; all other field types either already derive Debug or are well-known core types that do.

This allows downstream code to wrap PlainEditor in structs that derive Debug, and makes editor state easier to inspect in logs.

Closes #546.