### PR TITLE
Restore the ability to use a different alignment width than breaking width

### DIFF
--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -371,6 +371,21 @@ impl<'a, B: Brush> BreakLines<'a, B> {
         &mut self.state
     }
 
+    /// Set the max-advance of the previous line.
+    ///
+    /// This is an escape-hatch for allowing a custom width for
+    /// alignment on each line, which is different to the breaking width.
+    ///
+    /// Should be used in combination with [`AlignmentOptions`](crate::AlignmentOptions::align_when_overflowing).
+    ///
+    /// This method changes a line's reported [`inline_max_coord`](LineMetrics::inline_max_coord), so
+    /// if you use this method and read that value, you should be cautious.
+    pub fn set_prior_line_width(&mut self, advance: f32) {
+        if let Some(line) = self.lines.lines.last_mut() {
+            line.metrics.inline_max_coord = line.metrics.inline_min_coord + advance;
+        }
+    }
+
     /// Reverts the to an externally saved state.
     pub fn revert_to(&mut self, state: BreakerState) {
         self.state = state;

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -380,6 +380,10 @@ impl<'a, B: Brush> BreakLines<'a, B> {
     ///
     /// This method changes a line's reported [`inline_max_coord`](LineMetrics::inline_max_coord), so
     /// if you use this method and read that value, you should be cautious.
+    // This escape hatch has not been carefully evaluated for unexpected consequences.
+    // It's current motivation is cases where Parley gives different line breaking results
+    // than blink, for reasons which haven't been fully understood.
+    #[doc(hidden)]
     pub fn set_prior_line_width(&mut self, advance: f32) {
         if let Some(line) = self.lines.lines.last_mut() {
             line.metrics.inline_max_coord = line.metrics.inline_min_coord + advance;


### PR DESCRIPTION
This is a minimal escape hatch which allows this functionality, which was removed in #421.

I do agree that this is hard to use correctly, which is why I have it explicitly documented as an escape hatch. For my use case, I am not expecting to have a huge difference from the breaking width, so the risk is minimal.