### PR TITLE
Add `complex-scripts` feature for CJK and Southeast Asian line/word breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This release has an [MSRV] of 1.88.
 
 #### Parley
 
+- `complex-scripts` Cargo feature to enable dictionary-based line and word breaking for complex scripts (CJK, Thai, Khmer, Lao, Myanmar). When disabled, the lightweight segmenter is used (no change in default behavior).
 - `PlainEditor`, `Layout`, `LayoutAccessibility`, and `Generation` now implement `Debug`. ([#615][] by [@NandishwarSingh][])
   Note: The `Layout` implementation provides a compact summary by default; the alternate form (`{:#?}`) formats the full underlying data.
 

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -23,6 +23,9 @@ libm = ["fontique/libm", "peniko/libm", "skrifa/libm", "dep:core_maths"]
 # Enables support for system font backends
 system = ["std", "fontique/system"]
 accesskit = ["dep:accesskit"]
+# Enables dictionary-based line and word breaking for complex scripts (CJK, Thai, Khmer, Lao, Myanmar).
+# When disabled, a lightweight segmenter is used that falls back to character-level breaks for those scripts.
+complex-scripts = []
 
 [dependencies]
 skrifa = { workspace = true }

--- a/parley/src/analysis/mod.rs
+++ b/parley/src/analysis/mod.rs
@@ -43,32 +43,33 @@ impl AnalysisDataSources {
 
     #[inline(always)]
     fn word_segmenter(&self) -> WordSegmenterBorrowed<'static> {
-        const { WordSegmenter::new_for_non_complex_scripts(WordBreakInvariantOptions::default()) }
+        #[cfg(feature = "complex-scripts")]
+        {
+            WordSegmenter::new_dictionary(WordBreakInvariantOptions::default())
+        }
+        #[cfg(not(feature = "complex-scripts"))]
+        {
+            const { WordSegmenter::new_for_non_complex_scripts(WordBreakInvariantOptions::default()) }
+        }
     }
 
     #[inline(always)]
     fn line_segmenter(&self, word_break_strength: WordBreak) -> LineSegmenterBorrowed<'static> {
         match word_break_strength {
             WordBreak::Normal => {
-                const {
-                    let mut opt = LineBreakOptions::default();
-                    opt.word_option = Some(LineBreakWordOption::Normal);
-                    LineSegmenter::new_for_non_complex_scripts(opt)
-                }
+                let mut opt = LineBreakOptions::default();
+                opt.word_option = Some(LineBreakWordOption::Normal);
+                line_segmenter_impl(opt)
             }
             WordBreak::BreakAll => {
-                const {
-                    let mut opt = LineBreakOptions::default();
-                    opt.word_option = Some(LineBreakWordOption::BreakAll);
-                    LineSegmenter::new_for_non_complex_scripts(opt)
-                }
+                let mut opt = LineBreakOptions::default();
+                opt.word_option = Some(LineBreakWordOption::BreakAll);
+                line_segmenter_impl(opt)
             }
             WordBreak::KeepAll => {
-                const {
-                    let mut opt = LineBreakOptions::default();
-                    opt.word_option = Some(LineBreakWordOption::KeepAll);
-                    LineSegmenter::new_for_non_complex_scripts(opt)
-                }
+                let mut opt = LineBreakOptions::default();
+                opt.word_option = Some(LineBreakWordOption::KeepAll);
+                line_segmenter_impl(opt)
             }
         }
     }
@@ -92,6 +93,18 @@ impl AnalysisDataSources {
     fn brackets(&self) -> CodePointMapDataBorrowed<'_, BidiMirroringGlyph> {
         const { CodePointMapData::new() }
     }
+}
+
+#[cfg(feature = "complex-scripts")]
+#[inline(always)]
+fn line_segmenter_impl(opt: LineBreakOptions<'_>) -> LineSegmenterBorrowed<'static> {
+    LineSegmenter::new_dictionary(opt)
+}
+
+#[cfg(not(feature = "complex-scripts"))]
+#[inline(always)]
+fn line_segmenter_impl(opt: LineBreakOptions<'_>) -> LineSegmenterBorrowed<'static> {
+    LineSegmenter::new_for_non_complex_scripts(opt)
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

Adds a `complex-scripts` Cargo feature that switches the line and word segmenters from the lightweight `new_for_non_complex_scripts()` to `new_dictionary()`, enabling proper dictionary-based line and word breaking for complex scripts:

- **CJK** (Chinese, Japanese) — uses the `cjdict` dictionary for word-boundary detection
- **Southeast Asian** (Thai, Khmer, Lao, Myanmar) — uses per-language dictionaries

When the feature is disabled (default), behavior is unchanged: the lightweight segmenter is used, which falls back to character-level breaks for the above scripts.

## Motivation

Without this feature, rendering CJK text produces a runtime warning from ICU4X:

```
ICU4X data error: No segmentation model for language: ja
```

This occurs because `new_for_non_complex_scripts()` does not include the `cjdict` dictionary data. CJK text still renders, but line breaks are character-level rather than word-level.

## Usage

```toml
parley = { features = ["complex-scripts"] }
```

## Changes

- `parley/Cargo.toml`: add `complex-scripts` feature flag
- `parley/src/analysis/mod.rs`: cfg-gate `line_segmenter` and `word_segmenter` to use `LineSegmenter::new_dictionary()` / `WordSegmenter::new_dictionary()` when enabled
- `CHANGELOG.md`: document new feature

## Testing

Both configurations compile cleanly:
- `cargo check -p parley` — default (no feature)
- `cargo check -p parley --features complex-scripts` — with feature enabled