### PR TITLE
Make line commit unconditional and remove try_commit_line macro

### DIFF
--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -1151,53 +1151,6 @@ impl<B: Brush> Drop for BreakLines<'_, B> {
     }
 }
 
-// fn cluster_range_is_valid(
-//     mut cluster_range: Range<usize>,
-//     state_cluster_range: Range<usize>,
-//     is_first: bool,
-//     is_last: bool,
-//     is_empty: bool,
-// ) -> bool {
-//     // Compute cluster range
-//     if is_first {
-//         cluster_range.start = state_cluster_range.start;
-//     }
-//     if is_last {
-//         cluster_range.end = state_cluster_range.end;
-//     }
-
-//     // Return true if cluster is valid. Else false.
-//     cluster_range.start < cluster_range.end
-//         || (cluster_range.start == cluster_range.end && is_empty)
-// }
-
-// fn should_commit_line<B: Brush>(
-//     layout: &LayoutData<B>,
-//     state: &mut LineState,
-//     is_last: bool,
-// ) -> bool {
-//     // Compute end cluster
-//     state.clusters.end = state.clusters.end.min(layout.clusters.len());
-//     if state.runs.end == 0 && is_last {
-//         state.runs.end = 1;
-//     }
-
-//     let last_run = state.runs.len() - 1;
-//     let is_empty = layout.text_len == 0;
-
-//     // Iterate over runs. Checking if any have a valid cluster range.
-//     let runs = &layout.runs[state.runs.clone()];
-//     runs.iter().enumerate().any(|(i, run_data)| {
-//         cluster_range_is_valid(
-//             run_data.cluster_range.clone(),
-//             state.clusters.clone(),
-//             i == 0,
-//             i == last_run,
-//             is_empty,
-//         )
-//     })
-// }
-
 fn commit_line<B: Brush>(
     layout: &Layout<B>,
     lines: &mut LineLayout,
@@ -1219,15 +1172,6 @@ fn commit_line<B: Brush>(
     let is_text_run = |item: &LayoutItem| item.kind == LayoutItemKind::TextRun;
     let first_run_pos = items_to_commit.iter().position(is_text_run).unwrap_or(0);
     let last_run_pos = items_to_commit.iter().rposition(is_text_run).unwrap_or(0);
-
-    // // Return if line contains no runs
-    // let (Some(first_run_pos), Some(last_run_pos)) = (first_run_pos, last_run_pos) else {
-    //     return false;
-    // };
-
-    //let runs = &layout.runs[state.runs.clone()];
-    // let start_run_idx = items_to_commit[first_run_pos].index;
-    // let end_run_idx = items_to_commit[last_run_pos].index;
 
     // Iterate over the items to commit
     // println!("\nCOMMIT LINE");
@@ -1307,13 +1251,6 @@ fn commit_line<B: Brush>(
     }
     // let end_run_idx = lines.line_items.last().map(|item| item.index).unwrap_or(0);
     let end_item_idx = lines.line_items.len();
-
-    // Return false and don't commit line if there were no items to process
-    // FIXME: support lines with only inlines boxes
-    // if start_item_idx == end_item_idx {
-    //     // } || first_run_pos == last_run_pos {
-    //     return false;
-    // }
 
     // Exclude the trailing space from justification space count.
     // Only subtract if the line actually ends with a space — with

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -194,20 +194,17 @@ impl BreakerState {
     pub fn append_cluster_to_line(&mut self, next_x: f32, clusters_height: f32) {
         self.line.items.end = self.item_idx + 1;
         self.line.clusters.end = self.cluster_idx + 1;
+        self.cluster_idx += 1;
         self.line.x = next_x;
         self.add_line_height(clusters_height);
-        // Would like to add:
-        // self.cluster_idx += 1;
     }
 
     /// Add inline box to line
     pub fn append_inline_box_to_line(&mut self, next_x: f32, box_height: f32) {
-        // self.item_idx += 1;
+        self.item_idx += 1;
         self.line.items.end += 1;
         self.line.x = next_x;
         self.add_line_height(box_height);
-        // Would like to add:
-        // self.item_idx += 1;
     }
 
     /// Store the current iteration state so that we can revert to it if we later want to take
@@ -230,6 +227,14 @@ impl BreakerState {
             cluster_idx: self.cluster_idx,
             state: self.line.clone(),
         });
+    }
+
+    /// Revert boundary state to prev state
+    fn reset_to(&mut self, prev_state: PrevBoundaryState) {
+        self.item_idx = prev_state.item_idx;
+        self.run_idx = prev_state.run_idx;
+        self.cluster_idx = prev_state.cluster_idx;
+        self.line = prev_state.state;
     }
 
     #[inline(always)]
@@ -321,7 +326,21 @@ impl<'a, B: Brush> BreakLines<'a, B> {
     }
 
     /// Reset state when a line has been committed
-    fn start_new_line(&mut self, reason: BreakReason) -> Option<YieldData> {
+    fn start_new_line(
+        &mut self,
+        reason: BreakReason,
+        max_advance: f32,
+        line_indent: f32,
+    ) -> Option<YieldData> {
+        commit_line(
+            self.layout,
+            &mut self.lines,
+            &mut self.state.line,
+            max_advance,
+            reason,
+            line_indent,
+        );
+
         let line_height = self.state.line.running_line_height;
         let line_y_start = self.state.line_y;
 
@@ -455,22 +474,6 @@ impl<'a, B: Brush> BreakLines<'a, B> {
 
         let max_advance = max_advance - line_indent;
 
-        // This macro simply calls the `commit_line` with the provided arguments and some parts of self.
-        // It exists solely to cut down on the boilerplate for accessing the self variables while
-        // keeping the borrow checker happy
-        macro_rules! try_commit_line {
-            ($break_reason:expr) => {
-                try_commit_line(
-                    self.layout,
-                    &mut self.lines,
-                    &mut self.state.line,
-                    max_advance,
-                    $break_reason,
-                    line_indent,
-                )
-            };
-        }
-
         // dbg!(&self.layout.items);
 
         // println!("\nBREAK NEXT");
@@ -497,7 +500,6 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                         // If the box is a `CustomOutOfFlow` box then we yield control flow back to the caller.
                         // It is then the caller's responsibility to handle placement of the box.
                         InlineBoxKind::CustomOutOfFlow => {
-                            self.state.item_idx += 1;
                             return Some(YieldData::InlineBoxBreak(BoxBreakData {
                                 inline_box_id: inline_box.id,
                                 inline_box_index: item.index,
@@ -522,8 +524,6 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                     {
                         // println!("BOX FITS");
 
-                        self.state.item_idx += 1;
-
                         self.state
                             .append_inline_box_to_line(next_x, height_contribution);
 
@@ -531,20 +531,16 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                         self.state.mark_line_break_opportunity();
                     } else {
                         // If we're at the start of the line, this box will never fit, so consume it and accept the overflow.
-                        if self.state.line.x == 0.0 {
+                        let reason = if self.state.line.x == 0.0 {
                             // println!("BOX EMERGENCY BREAK");
                             self.state
                                 .append_inline_box_to_line(next_x, height_contribution);
-                            if try_commit_line!(BreakReason::Emergency) {
-                                self.state.item_idx += 1;
-                                return self.start_new_line(BreakReason::Emergency);
-                            }
+                            BreakReason::Emergency
                         } else {
                             // println!("BOX BREAK");
-                            if try_commit_line!(BreakReason::Regular) {
-                                return self.start_new_line(BreakReason::Regular);
-                            }
-                        }
+                            BreakReason::Regular
+                        };
+                        return self.start_new_line(reason, max_advance, line_indent);
                     }
                 }
                 LayoutItemKind::TextRun => {
@@ -590,11 +586,11 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                             }
                             self.state
                                 .append_cluster_to_line(self.state.line.x, line_height);
-                            if try_commit_line!(BreakReason::Explicit) {
-                                // TODO: can this be hoisted out of the conditional?
-                                self.state.cluster_idx += 1;
-                                return self.start_new_line(BreakReason::Explicit);
-                            }
+                            return self.start_new_line(
+                                BreakReason::Explicit,
+                                max_advance,
+                                line_indent,
+                            );
                         } else if
                         // This text can contribute "emergency" line breaks.
                         style.overflow_wrap != OverflowWrap::Normal && !is_ligature_continuation
@@ -632,7 +628,6 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                                 return self.max_height_break_data(line_height);
                             }
                             self.state.append_cluster_to_line(next_x, line_height);
-                            self.state.cluster_idx += 1;
                             if is_space {
                                 self.state.line.num_spaces += 1;
                             }
@@ -651,30 +646,23 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                                     return self.max_height_break_data(line_height);
                                 }
                                 self.state.append_cluster_to_line(next_x, line_height);
-                                if try_commit_line!(BreakReason::Regular) {
-                                    // TODO: can this be hoisted out of the conditional?
-                                    self.state.cluster_idx += 1;
-                                    return self.start_new_line(BreakReason::Regular);
-                                }
+                                return self.start_new_line(
+                                    BreakReason::Regular,
+                                    max_advance,
+                                    line_indent,
+                                );
                             }
                             // Case: we have previously encountered a REGULAR line-breaking opportunity in the current line
                             //
                             // We "take" the line-breaking opportunity by starting a new line and resetting our
                             // item/run/cluster iteration state back to how it was when the line-breaking opportunity was encountered
                             else if let Some(prev) = self.state.prev_boundary.take() {
-                                // println!("REVERT");
-                                // debug_assert!(prev.state.x != 0.0);
-
-                                // Q: Why do we revert the line state here, but only revert the indexes if the commit succeeds?
-                                self.state.line = prev.state;
-                                if try_commit_line!(BreakReason::Regular) {
-                                    // Revert boundary state to prev state
-                                    self.state.item_idx = prev.item_idx;
-                                    self.state.run_idx = prev.run_idx;
-                                    self.state.cluster_idx = prev.cluster_idx;
-
-                                    return self.start_new_line(BreakReason::Regular);
-                                }
+                                self.state.reset_to(prev);
+                                return self.start_new_line(
+                                    BreakReason::Regular,
+                                    max_advance,
+                                    line_indent,
+                                );
                             }
                             // Case: we have previously encountered an EMERGENCY line-breaking opportunity in the current line
                             //
@@ -683,15 +671,12 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                             else if let Some(prev_emergency) =
                                 self.state.emergency_boundary.take()
                             {
-                                self.state.line = prev_emergency.state;
-                                if try_commit_line!(BreakReason::Emergency) {
-                                    // Revert boundary state to prev state
-                                    self.state.item_idx = prev_emergency.item_idx;
-                                    self.state.run_idx = prev_emergency.run_idx;
-                                    self.state.cluster_idx = prev_emergency.cluster_idx;
-
-                                    return self.start_new_line(BreakReason::Emergency);
-                                }
+                                self.state.reset_to(prev_emergency);
+                                return self.start_new_line(
+                                    BreakReason::Emergency,
+                                    max_advance,
+                                    line_indent,
+                                );
                             }
                             // Case: no line-breaking opportunities available
                             //
@@ -704,7 +689,6 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                                     return self.max_height_break_data(line_height);
                                 }
                                 self.state.append_cluster_to_line(next_x, line_height);
-                                self.state.cluster_idx += 1;
                             }
                         }
                     }
@@ -717,12 +701,8 @@ impl<'a, B: Brush> BreakLines<'a, B> {
         if self.state.line.items.end == 0 {
             self.state.line.items.end = 1;
         }
-        if try_commit_line!(BreakReason::None) {
-            self.done = true;
-            return self.start_new_line(BreakReason::None);
-        }
-
-        None
+        self.done = true;
+        self.start_new_line(BreakReason::None, max_advance, line_indent)
     }
 
     /// Computes the next line in the paragraph by character count.
@@ -746,20 +726,6 @@ impl<'a, B: Brush> BreakLines<'a, B> {
         // Track cluster count for this line
         let mut char_count: u32 = 0;
 
-        // This macro simply calls the `commit_line` with the provided arguments and some parts of self.
-        macro_rules! try_commit_line {
-            ($break_reason:expr) => {
-                try_commit_line(
-                    self.layout,
-                    &mut self.lines,
-                    &mut self.state.line,
-                    f32::MAX, // No advance limit
-                    $break_reason,
-                    line_indent,
-                )
-            };
-        }
-
         let item_count = self.layout.data.items.len();
         while self.state.item_idx < item_count {
             let item = &self.layout.data.items[self.state.item_idx];
@@ -769,7 +735,6 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                     let inline_box = &self.layout.data.inline_boxes[item.index];
 
                     if inline_box.kind != InlineBoxKind::InFlow {
-                        self.state.item_idx += 1;
                         self.state.append_inline_box_to_line(self.state.line.x, 0.0);
                         continue;
                     }
@@ -777,15 +742,12 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                     // Check if adding this box would exceed the limit
                     if char_count >= max_chars && max_chars != 0 {
                         // Break before this box
-                        if try_commit_line!(BreakReason::Regular) {
-                            self.start_new_line(BreakReason::Regular);
-                            return Some(());
-                        }
+                        self.start_new_line(BreakReason::Regular, f32::MAX, line_indent);
+                        return Some(());
                     }
 
                     // Compute the x position for the line width tracking
                     let next_x = self.state.line.x + inline_box.width;
-                    self.state.item_idx += 1;
                     self.state
                         .append_inline_box_to_line(next_x, inline_box.height);
                     char_count += 1;
@@ -800,13 +762,11 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                             BreakReason::Regular
                         };
 
-                        if try_commit_line!(break_reason) {
-                            if break_reason == BreakReason::None {
-                                self.done = true;
-                            }
-                            self.start_new_line(break_reason);
-                            return Some(());
+                        if break_reason == BreakReason::None {
+                            self.done = true;
                         }
+                        self.start_new_line(break_reason, f32::MAX, line_indent);
+                        return Some(());
                     }
                 }
                 LayoutItemKind::TextRun => {
@@ -820,11 +780,8 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                         let cluster = run.get(self.state.cluster_idx - cluster_start).unwrap();
 
                         // Check if we should break before this cluster
-                        if char_count >= max_chars
-                            && max_chars != 0
-                            && try_commit_line!(BreakReason::Regular)
-                        {
-                            self.start_new_line(BreakReason::Regular);
+                        if char_count >= max_chars && max_chars != 0 {
+                            self.start_new_line(BreakReason::Regular, f32::MAX, line_indent);
                             return Some(());
                         }
 
@@ -842,7 +799,6 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                         };
                         let line_height = run.metrics().line_height;
                         self.state.append_cluster_to_line(next_x, line_height);
-                        self.state.cluster_idx += 1;
                         char_count += 1;
 
                         if is_space {
@@ -866,13 +822,11 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                                 BreakReason::Regular
                             };
 
-                            if try_commit_line!(break_reason) {
-                                if break_reason == BreakReason::None {
-                                    self.done = true;
-                                }
-                                self.start_new_line(BreakReason::None);
-                                return Some(());
+                            if break_reason == BreakReason::None {
+                                self.done = true;
                             }
+                            self.start_new_line(break_reason, f32::MAX, line_indent);
+                            return Some(());
                         }
                     }
                     self.state.run_idx += 1;
@@ -885,13 +839,9 @@ impl<'a, B: Brush> BreakLines<'a, B> {
         if self.state.line.items.end == 0 {
             self.state.line.items.end = 1;
         }
-        if try_commit_line!(BreakReason::None) {
-            self.done = true;
-            self.start_new_line(BreakReason::None);
-            return Some(());
-        }
-
-        None
+        self.done = true;
+        self.start_new_line(BreakReason::None, f32::MAX, line_indent);
+        Some(())
     }
 
     /// Breaks all remaining lines with the specified maximum advance. This
@@ -1248,7 +1198,7 @@ impl<B: Brush> Drop for BreakLines<'_, B> {
 //     })
 // }
 
-fn try_commit_line<B: Brush>(
+fn commit_line<B: Brush>(
     layout: &Layout<B>,
     lines: &mut LineLayout,
     state: &mut LineState,


### PR DESCRIPTION
This refactors and simplifies the line-breaking code.

Changes made:

- Eliminate the "fake conditionality" from the `try_commit_line` function (it returned a `bool` as if it was conditional (which historically it used to be), but in reality it was always returned `true`). Rename it just `commit_line` to reflect this reality.
- Take advantage of this non-conditionality to make `start_new_line` call `commit_line` internally and remove the `try_commit_line` macro (the macro was to reduce boilerplate which no longer exists if commit_line is called from `start_new_line`).
- Breaking (low-level API): Make `append_cluster_to_line` increment `self.cluster_idx` (callers should no longer increment this themselves)
- Breaking (low-level API): Make `append_inline_box_to_line` increment `self.item_idx` (callers should no longer increment this themselves)