### PR TITLE
styled_text: add compact style spans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,14 @@ env:
   RUST_MIN_VER: "1.88"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  RUST_MIN_VER_PKGS: "-p parley -p parley_core -p parley_data -p parlance -p fontique -p attributed_text"
+  RUST_MIN_VER_PKGS: >-
+    -p parley
+    -p parley_core
+    -p parley_data
+    -p parlance
+    -p fontique
+    -p attributed_text
+    -p styled_text
   # List of features that depend on the standard library and will be excluded from no_std checks.
   FEATURES_DEPENDING_ON_STD: "std,default,png,system,vello_hybrid"
   # List of packages that can not target Wasm.
@@ -105,6 +112,10 @@ jobs:
 
       - name: Run cargo rdme (parlance)
         run: cargo rdme --check --heading-base-level=0 --workspace-project=parlance
+
+      - name: Run cargo rdme (styled_text)
+        run: cargo rdme --check --heading-base-level=0 --workspace-project=styled_text
+
 
   clippy-stable:
     name: cargo clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,6 +3823,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "styled_text"
+version = "0.1.0"
+dependencies = [
+ "attributed_text",
+]
+
+[[package]]
 name = "supports-color"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "parley_tests",
     "parley_tests/linebreaking_cases",
     "parley_tests/linebreaking_browser_recorder",
+    "styled_text",
     "examples/common",
     "examples/swash_render",
     "examples/tiny_skia_render",

--- a/styled_text/CHANGELOG.md
+++ b/styled_text/CHANGELOG.md
@@ -1,0 +1,19 @@
+<!-- Instructions
+
+This changelog follows the patterns described here: <https://keepachangelog.com/en/>.
+
+Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
+
+-->
+
+# Changelog
+
+No `styled_text` release from this repository has been published yet.
+
+## [Unreleased]
+
+This release has an [MSRV] of 1.88.
+
+[Unreleased]: https://github.com/linebender/parley/commits/main/styled_text
+
+[MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/styled_text/Cargo.toml
+++ b/styled_text/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "styled_text"
+version = "0.1.0"
+description = "Compact styled text spans built on attributed_text"
+keywords = ["text", "rich text", "style"]
+categories = ["graphics", "text"]
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+publish = false
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+
+[features]
+default = ["std"]
+std = ["attributed_text/std"]
+
+[dependencies]
+attributed_text = { path = "../attributed_text", default-features = false }
+
+[lints]
+workspace = true

--- a/styled_text/LICENSE-APACHE
+++ b/styled_text/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/styled_text/LICENSE-MIT
+++ b/styled_text/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/styled_text/README.md
+++ b/styled_text/README.md
@@ -1,0 +1,174 @@
+<div align="center">
+
+# Styled Text
+
+Compact styled text spans built on attributed_text.
+
+[![Linebender Zulip, #parley channel](https://img.shields.io/badge/Linebender-%23parley-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/205635-parley)
+[![dependency status](https://deps.rs/repo/github/linebender/parley/status.svg)](https://deps.rs/repo/github/linebender/parley)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+[![Build status](https://github.com/linebender/parley/workflows/CI/badge.svg)](https://github.com/linebender/parley/actions)
+[![Crates.io](https://img.shields.io/crates/v/styled_text.svg)](https://crates.io/crates/styled_text)
+[![Docs](https://docs.rs/styled_text/badge.svg)](https://docs.rs/styled_text)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=styled_text --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs should be evaluated here.
+See https://linebender.org/blog/doc-include/ for related discussion. -->
+<!-- cargo-rdme start -->
+
+Styled Text stores text with compact full-style identifiers.
+It builds on [`attributed_text`] for range storage and segment resolution,
+then adds interned style payloads for callers that need compact, reusable
+style data.
+
+The core idea is that each resolved text segment points at a [`StyleId`].
+The [`StyleSet`] behind that id stores complete style records, with
+layout-affecting payloads and paint-only payloads interned separately.
+That means a paint-only change can share layout style identity with the
+surrounding text, which is the information a shaping or layout cache usually
+wants.
+
+This is deliberately not a document model.
+It does not own shaping, font resolution, inline boxes, cascading, or
+renderer-specific style semantics.
+Callers choose their own layout and paint payload types, then adapt the
+resolved segments to Parley or another layout system.
+
+Unlike an API that sets individual style bits on ranges and leaves a later
+stage to interpret those bits, `styled_text` resolves patches into complete
+style records before lowering.
+That keeps the core crate independent of any toolkit's style vocabulary
+while giving downstream code a simple stream of text ranges and full styles.
+
+## Concepts
+
+- [`StyledText`] stores the text, the resolved [`StyleId`] spans, and the
+  shared [`StyleSet`].
+- [`StyleSet`] interns layout payloads, paint payloads, and the joined style
+  records that point at them.
+- [`StylePatch`] is the small trait callers implement to say how a partial
+  style change updates their own full style types.
+- [`StyledTextBuilder`] appends text and applies patches in the order they
+  were applied to the builder.
+- [`StyledSegmentsWorkspace`] is reusable scratch storage for iterating
+  resolved styled segments without reallocating every time.
+
+## Building styled text
+
+```rust
+use styled_text::{StylePatch, StyledSegmentsWorkspace, StyledTextBuilder};
+
+#[derive(Clone, Debug, PartialEq, Default)]
+struct LayoutStyle {
+    font_size: f32,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+struct PaintStyle {
+    rgba: [u8; 4],
+}
+
+#[derive(Clone, Debug, Default)]
+struct TextStyleChange {
+    font_size: Option<f32>,
+    rgba: Option<[u8; 4]>,
+}
+
+impl StylePatch<LayoutStyle, PaintStyle> for TextStyleChange {
+    fn apply_to(&self, layout: &mut LayoutStyle, paint: &mut PaintStyle) {
+        if let Some(font_size) = self.font_size {
+            layout.font_size = font_size;
+        }
+        if let Some(rgba) = self.rgba {
+            paint.rgba = rgba;
+        }
+    }
+}
+
+let mut text = StyledTextBuilder::new(
+    LayoutStyle { font_size: 16.0 },
+    PaintStyle { rgba: [0, 0, 0, 255] },
+);
+text.push("Hello ");
+let styled_range = text.push_with(
+    "styled",
+    TextStyleChange {
+        font_size: Some(28.0),
+        ..TextStyleChange::default()
+    },
+);
+text.apply(
+    styled_range,
+    TextStyleChange {
+        rgba: Some([220, 40, 40, 255]),
+        ..TextStyleChange::default()
+    },
+);
+text.push(" text");
+let styled = text.finish();
+
+let mut workspace = StyledSegmentsWorkspace::new();
+for segment in workspace.segments(&styled) {
+    let style = styled.style_set().segment_style(segment.style());
+    // Feed segment.range() and style into layout or painting code.
+}
+```
+
+## Features
+
+- `std` (enabled by default): Enables the `std` feature of
+  [`attributed_text`].
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This version of Styled Text has been verified to compile with **Rust 1.88** and later.
+
+Future versions of Styled Text might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some of Styled Text's dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
+
+## Community
+
+[![Linebender Zulip](https://img.shields.io/badge/Xi%20Zulip-%23parley-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/205635-parley)
+
+Discussion of Styled Text development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#parley channel](https://xi.zulipchat.com/#narrow/channel/205635-parley).
+All public content can be read without logging in.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any additional terms or conditions.
+
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: ../AUTHORS

--- a/styled_text/src/lib.rs
+++ b/styled_text/src/lib.rs
@@ -1,0 +1,132 @@
+// Copyright 2026 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Styled Text stores text with compact full-style identifiers.
+//! It builds on [`attributed_text`] for range storage and segment resolution,
+//! then adds interned style payloads for callers that need compact, reusable
+//! style data.
+//!
+//! The core idea is that each resolved text segment points at a [`StyleId`].
+//! The [`StyleSet`] behind that id stores complete style records, with
+//! layout-affecting payloads and paint-only payloads interned separately.
+//! That means a paint-only change can share layout style identity with the
+//! surrounding text, which is the information a shaping or layout cache usually
+//! wants.
+//!
+//! This is deliberately not a document model.
+//! It does not own shaping, font resolution, inline boxes, cascading, or
+//! renderer-specific style semantics.
+//! Callers choose their own layout and paint payload types, then adapt the
+//! resolved segments to Parley or another layout system.
+//!
+//! Unlike an API that sets individual style bits on ranges and leaves a later
+//! stage to interpret those bits, `styled_text` resolves patches into complete
+//! style records before lowering.
+//! That keeps the core crate independent of any toolkit's style vocabulary
+//! while giving downstream code a simple stream of text ranges and full styles.
+//!
+//! ## Concepts
+//!
+//! - [`StyledText`] stores the text, the resolved [`StyleId`] spans, and the
+//!   shared [`StyleSet`].
+//! - [`StyleSet`] interns layout payloads, paint payloads, and the joined style
+//!   records that point at them.
+//! - [`StylePatch`] is the small trait callers implement to say how a partial
+//!   style change updates their own full style types.
+//! - [`StyledTextBuilder`] appends text and applies patches in the order they
+//!   were applied to the builder.
+//! - [`StyledSegmentsWorkspace`] is reusable scratch storage for iterating
+//!   resolved styled segments without reallocating every time.
+//!
+//! ## Building styled text
+//!
+//! ```no_run
+//! use styled_text::{StylePatch, StyledSegmentsWorkspace, StyledTextBuilder};
+//!
+//! #[derive(Clone, Debug, PartialEq, Default)]
+//! struct LayoutStyle {
+//!     font_size: f32,
+//! }
+//!
+//! #[derive(Clone, Debug, PartialEq, Default)]
+//! struct PaintStyle {
+//!     rgba: [u8; 4],
+//! }
+//!
+//! #[derive(Clone, Debug, Default)]
+//! struct TextStyleChange {
+//!     font_size: Option<f32>,
+//!     rgba: Option<[u8; 4]>,
+//! }
+//!
+//! impl StylePatch<LayoutStyle, PaintStyle> for TextStyleChange {
+//!     fn apply_to(&self, layout: &mut LayoutStyle, paint: &mut PaintStyle) {
+//!         if let Some(font_size) = self.font_size {
+//!             layout.font_size = font_size;
+//!         }
+//!         if let Some(rgba) = self.rgba {
+//!             paint.rgba = rgba;
+//!         }
+//!     }
+//! }
+//!
+//! let mut text = StyledTextBuilder::new(
+//!     LayoutStyle { font_size: 16.0 },
+//!     PaintStyle { rgba: [0, 0, 0, 255] },
+//! );
+//! text.push("Hello ");
+//! let styled_range = text.push_with(
+//!     "styled",
+//!     TextStyleChange {
+//!         font_size: Some(28.0),
+//!         ..TextStyleChange::default()
+//!     },
+//! );
+//! text.apply(
+//!     styled_range,
+//!     TextStyleChange {
+//!         rgba: Some([220, 40, 40, 255]),
+//!         ..TextStyleChange::default()
+//!     },
+//! );
+//! text.push(" text");
+//! let styled = text.finish();
+//!
+//! let mut workspace = StyledSegmentsWorkspace::new();
+//! for segment in workspace.segments(&styled) {
+//!     let style = styled.style_set().segment_style(segment.style());
+//!     // Feed segment.range() and style into layout or painting code.
+//! }
+//! ```
+//!
+//! ## Features
+//!
+//! - `std` (enabled by default): Enables the `std` feature of
+//!   [`attributed_text`].
+
+// LINEBENDER LINT SET - lib.rs - v3
+// See https://linebender.org/wiki/canonical-lints/
+// These lints shouldn't apply to examples or tests.
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// These lints shouldn't apply to examples.
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
+#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
+// END LINEBENDER LINT SET
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![no_std]
+
+extern crate alloc;
+
+mod segments;
+mod style_set;
+mod text;
+mod text_builder;
+
+pub use attributed_text::{Error, TextChunk, TextRange, TextStorage};
+pub use segments::{StyledSegment, StyledSegmentsWorkspace};
+pub use style_set::{
+    LayoutStyleId, PaintStyleId, SegmentStyle, StyleId, StyleRecord, StyleSet, StyleSetBuilder,
+};
+pub use text::StyledText;
+pub use text_builder::{StylePatch, StyledTextBuilder};

--- a/styled_text/src/segments.rs
+++ b/styled_text/src/segments.rs
@@ -1,0 +1,118 @@
+// Copyright 2026 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use core::fmt::Debug;
+
+use attributed_text::{AttributeSegmentsWorkspace, TextRange, TextStorage};
+
+use crate::{StyleId, StyledText};
+
+/// A resolved styled segment.
+///
+/// Segments are non-empty, contiguous byte ranges. Their style is the effective
+/// style identifier after resolving overlapping applied style spans. The last
+/// writer is the most recently applied span that is active for the segment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StyledSegment {
+    range: TextRange,
+    style: StyleId,
+}
+
+impl StyledSegment {
+    /// Returns the byte range covered by this segment.
+    #[must_use]
+    #[inline]
+    pub const fn range(self) -> TextRange {
+        self.range
+    }
+
+    /// Returns the resolved compact style identifiers.
+    #[must_use]
+    #[inline]
+    pub const fn style(self) -> StyleId {
+        self.style
+    }
+}
+
+/// Reusable allocation workspace for styled segment resolution.
+///
+/// Reuse this value across layout or painting passes to amortize allocation in
+/// the underlying attributed-text segmentation step.
+#[derive(Clone, Debug, Default)]
+pub struct StyledSegmentsWorkspace {
+    attributes: AttributeSegmentsWorkspace,
+}
+
+impl StyledSegmentsWorkspace {
+    /// Creates an empty styled-segment workspace.
+    #[must_use]
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Iterates over resolved styled segments.
+    pub fn segments<'a, T, L, P>(
+        &'a mut self,
+        text: &'a StyledText<T, L, P>,
+    ) -> impl Iterator<Item = StyledSegment> + 'a
+    where
+        T: Debug + TextStorage,
+    {
+        let base_style = text.base_style();
+        let mut inner = self.attributes.segments(text.attributed());
+
+        core::iter::from_fn(move || {
+            let segment = inner.next_segment()?;
+            let range = segment.range();
+            // Active spans are in application order, so the last one wins.
+            let style = segment
+                .active_spans()
+                .iter()
+                .next_back()
+                .map_or(base_style, |(_range, style)| *style);
+            Some(StyledSegment { range, style })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use super::StyledSegmentsWorkspace;
+    use crate::{StyleSetBuilder, StyledText};
+
+    #[test]
+    fn resolves_last_applied_style() {
+        let mut builder = StyleSetBuilder::<&'static str, &'static str>::new();
+        let base = builder.intern_style("base", "black");
+        let bold_red = builder.intern_style("bold", "red");
+        let italic_blue = builder.intern_style("italic", "blue");
+        let styles = Arc::new(builder.finish());
+
+        let mut text = StyledText::new("abcd", styles, base);
+        text.apply_style_bytes(0..3, bold_red)
+            .expect("valid style range");
+        text.apply_style_bytes(1..2, italic_blue)
+            .expect("valid style range");
+
+        let mut workspace = StyledSegmentsWorkspace::new();
+        let segments = workspace
+            .segments(&text)
+            .map(|segment| (segment.range().as_range(), segment.style()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            segments,
+            vec![
+                (0..1, bold_red),
+                (1..2, italic_blue),
+                (2..3, bold_red),
+                (3..4, base),
+            ]
+        );
+    }
+}

--- a/styled_text/src/style_set.rs
+++ b/styled_text/src/style_set.rs
@@ -1,0 +1,426 @@
+// Copyright 2026 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec::Vec;
+use core::fmt;
+
+/// Identifier for an interned layout-affecting style payload.
+///
+/// Layout styles are intended for data that can affect shaping or line layout,
+/// such as font size, font family, spacing, or wrapping policy.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LayoutStyleId(u32);
+
+impl LayoutStyleId {
+    fn from_index(index: usize) -> Self {
+        let index = u32::try_from(index).expect("too many interned layout styles");
+        Self(index)
+    }
+
+    /// Returns this identifier as a zero-based table index.
+    #[must_use]
+    #[inline]
+    pub const fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl fmt::Debug for LayoutStyleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("LayoutStyleId").field(&self.0).finish()
+    }
+}
+
+/// Identifier for an interned paint-only style payload.
+///
+/// Paint styles are intended for data that should not invalidate shaping, such
+/// as color or renderer-specific paint metadata.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PaintStyleId(u32);
+
+impl PaintStyleId {
+    fn from_index(index: usize) -> Self {
+        let index = u32::try_from(index).expect("too many interned paint styles");
+        Self(index)
+    }
+
+    /// Returns this identifier as a zero-based table index.
+    #[must_use]
+    #[inline]
+    pub const fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl fmt::Debug for PaintStyleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PaintStyleId").field(&self.0).finish()
+    }
+}
+
+/// Identifier for an interned full style.
+///
+/// This is the compact style identity stored on text spans and resolved
+/// segments. Internally, each full style points at separately interned layout
+/// and paint payloads.
+///
+/// An id is an index into one specific [`StyleSet`] and carries no provenance.
+/// Using it with a different set resolves to an unrelated style or, in
+/// [`StyleSet::segment_style`], panics. Only use an id with the set it came from.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StyleId(u32);
+
+impl StyleId {
+    fn from_index(index: usize) -> Self {
+        let index = u32::try_from(index).expect("too many interned styles");
+        Self(index)
+    }
+
+    /// Returns this identifier as a zero-based table index.
+    #[must_use]
+    #[inline]
+    pub const fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl fmt::Debug for StyleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("StyleId").field(&self.0).finish()
+    }
+}
+
+/// Interned component identifiers for a full style.
+///
+/// This record is exposed for diagnostics, invalidation decisions, and adapters
+/// that need to know whether two full styles share the same layout or paint
+/// payload. Text spans should store [`StyleId`], not this component record.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct StyleRecord {
+    layout: LayoutStyleId,
+    paint: PaintStyleId,
+}
+
+impl StyleRecord {
+    /// Returns the interned layout payload identifier.
+    #[must_use]
+    #[inline]
+    pub const fn layout_id(self) -> LayoutStyleId {
+        self.layout
+    }
+
+    /// Returns the interned paint payload identifier.
+    #[must_use]
+    #[inline]
+    pub const fn paint_id(self) -> PaintStyleId {
+        self.paint
+    }
+}
+
+/// Interned style payloads used by [`StyledText`](crate::StyledText).
+///
+/// Text spans use one compact [`StyleId`]. This set keeps full style identity
+/// stable while still deduplicating layout and paint payloads separately.
+#[derive(Clone, Debug, Default)]
+pub struct StyleSet<L, P> {
+    styles: Vec<StyleRecord>,
+    layout: Vec<L>,
+    paint: Vec<P>,
+}
+
+impl<L, P> StyleSet<L, P> {
+    /// Creates an empty style set.
+    #[must_use]
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            styles: Vec::new(),
+            layout: Vec::new(),
+            paint: Vec::new(),
+        }
+    }
+
+    /// Returns the interned full-style record for `id`.
+    #[must_use]
+    #[inline]
+    pub fn get_style(&self, id: StyleId) -> Option<StyleRecord> {
+        self.styles.get(id.index()).copied()
+    }
+
+    /// Returns the interned layout payload for `id`.
+    #[must_use]
+    #[inline]
+    pub fn get_layout(&self, id: LayoutStyleId) -> Option<&L> {
+        self.layout.get(id.index())
+    }
+
+    /// Returns the interned paint payload for `id`.
+    #[must_use]
+    #[inline]
+    pub fn get_paint(&self, id: PaintStyleId) -> Option<&P> {
+        self.paint.get(id.index())
+    }
+
+    /// Returns the number of interned full styles.
+    #[must_use]
+    #[inline]
+    pub fn style_len(&self) -> usize {
+        self.styles.len()
+    }
+
+    /// Returns the number of interned layout payloads.
+    #[must_use]
+    #[inline]
+    pub fn layout_len(&self) -> usize {
+        self.layout.len()
+    }
+
+    /// Returns the number of interned paint payloads.
+    #[must_use]
+    #[inline]
+    pub fn paint_len(&self) -> usize {
+        self.paint.len()
+    }
+
+    /// Returns `true` if there are no interned full styles.
+    #[must_use]
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.styles.is_empty()
+    }
+
+    /// Iterates over all full-style identifiers in table order.
+    pub fn style_ids(&self) -> impl ExactSizeIterator<Item = StyleId> + Clone {
+        (0..self.styles.len()).map(StyleId::from_index)
+    }
+
+    /// Resolves a compact style identifier into borrowed payloads from this set,
+    /// returning `None` if the id is not interned here.
+    ///
+    /// Use this for ids that may not belong to this set; see
+    /// [`segment_style`](Self::segment_style) for the panicking convenience.
+    #[must_use]
+    pub fn try_segment_style(&self, id: StyleId) -> Option<SegmentStyle<'_, L, P>> {
+        let record = self.get_style(id)?;
+        Some(SegmentStyle {
+            id,
+            record,
+            layout: self.get_layout(record.layout_id())?,
+            paint: self.get_paint(record.paint_id())?,
+        })
+    }
+
+    /// Resolves a compact style identifier into borrowed payloads from this set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `id` (or one of its component ids) is not interned in this set,
+    /// which happens when an id from a different [`StyleSet`] is used here. Use
+    /// [`try_segment_style`](Self::try_segment_style) for ids that may not belong
+    /// to this set.
+    #[must_use]
+    pub fn segment_style(&self, id: StyleId) -> SegmentStyle<'_, L, P> {
+        self.try_segment_style(id)
+            .expect("style id must be interned in this style set")
+    }
+}
+
+/// Borrowed style payloads for a resolved segment.
+#[derive(Debug, PartialEq)]
+pub struct SegmentStyle<'a, L, P> {
+    id: StyleId,
+    record: StyleRecord,
+    layout: &'a L,
+    paint: &'a P,
+}
+
+impl<L, P> Clone for SegmentStyle<'_, L, P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<L, P> Copy for SegmentStyle<'_, L, P> {}
+
+impl<'a, L, P> SegmentStyle<'a, L, P> {
+    /// Returns the compact full-style identifier.
+    #[must_use]
+    #[inline]
+    pub const fn id(self) -> StyleId {
+        self.id
+    }
+
+    /// Returns the interned component identifiers for this full style.
+    #[must_use]
+    #[inline]
+    pub const fn record(self) -> StyleRecord {
+        self.record
+    }
+
+    /// Returns the resolved layout-style identifier.
+    #[must_use]
+    #[inline]
+    pub const fn layout_id(self) -> LayoutStyleId {
+        self.record.layout_id()
+    }
+
+    /// Returns the resolved paint-style identifier.
+    #[must_use]
+    #[inline]
+    pub const fn paint_id(self) -> PaintStyleId {
+        self.record.paint_id()
+    }
+
+    /// Returns the resolved layout payload.
+    #[must_use]
+    #[inline]
+    pub const fn layout(self) -> &'a L {
+        self.layout
+    }
+
+    /// Returns the resolved paint payload.
+    #[must_use]
+    #[inline]
+    pub const fn paint(self) -> &'a P {
+        self.paint
+    }
+}
+
+/// Builder for [`StyleSet`] values.
+///
+/// Interning is currently a linear search over retained vectors. That keeps the
+/// first slice dependency-free and compact; callers can reuse a builder during
+/// style collection to amortize allocations.
+#[derive(Clone, Debug, Default)]
+pub struct StyleSetBuilder<L, P> {
+    styles: Vec<StyleRecord>,
+    layout: Vec<L>,
+    paint: Vec<P>,
+}
+
+impl<L, P> StyleSetBuilder<L, P> {
+    /// Creates an empty style-set builder.
+    #[must_use]
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            styles: Vec::new(),
+            layout: Vec::new(),
+            paint: Vec::new(),
+        }
+    }
+
+    /// Creates a builder with capacity for full styles and their component payloads.
+    #[must_use]
+    #[inline]
+    pub fn with_capacity(style_capacity: usize) -> Self {
+        Self {
+            styles: Vec::with_capacity(style_capacity),
+            layout: Vec::with_capacity(style_capacity),
+            paint: Vec::with_capacity(style_capacity),
+        }
+    }
+
+    /// Removes all interned styles and payloads while keeping allocated storage.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.styles.clear();
+        self.layout.clear();
+        self.paint.clear();
+    }
+
+    /// Finishes the builder and returns the style set.
+    #[must_use]
+    #[inline]
+    pub fn finish(self) -> StyleSet<L, P> {
+        StyleSet {
+            styles: self.styles,
+            layout: self.layout,
+            paint: self.paint,
+        }
+    }
+
+    fn intern_style_record(&mut self, record: StyleRecord) -> StyleId {
+        if let Some(index) = self.styles.iter().position(|existing| *existing == record) {
+            return StyleId::from_index(index);
+        }
+
+        let index = self.styles.len();
+        self.styles.push(record);
+        StyleId::from_index(index)
+    }
+}
+
+impl<L: PartialEq, P> StyleSetBuilder<L, P> {
+    fn intern_layout(&mut self, style: L) -> LayoutStyleId {
+        if let Some(index) = self.layout.iter().position(|existing| existing == &style) {
+            return LayoutStyleId::from_index(index);
+        }
+
+        let index = self.layout.len();
+        self.layout.push(style);
+        LayoutStyleId::from_index(index)
+    }
+}
+
+impl<L, P: PartialEq> StyleSetBuilder<L, P> {
+    fn intern_paint(&mut self, style: P) -> PaintStyleId {
+        if let Some(index) = self.paint.iter().position(|existing| existing == &style) {
+            return PaintStyleId::from_index(index);
+        }
+
+        let index = self.paint.len();
+        self.paint.push(style);
+        PaintStyleId::from_index(index)
+    }
+}
+
+impl<L: PartialEq, P: PartialEq> StyleSetBuilder<L, P> {
+    /// Interns layout and paint payloads as a full style and returns its identifier.
+    pub fn intern_style(&mut self, layout: L, paint: P) -> StyleId {
+        let layout = self.intern_layout(layout);
+        let paint = self.intern_paint(paint);
+        self.intern_style_record(StyleRecord { layout, paint })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+
+    use super::StyleSetBuilder;
+
+    #[test]
+    fn builder_interns_equal_payloads_and_full_styles() {
+        let mut builder = StyleSetBuilder::<u8, u16>::new();
+        let normal_red = builder.intern_style(12, 0xff00_u16);
+        let normal_red_again = builder.intern_style(12, 0xff00_u16);
+        let normal_blue = builder.intern_style(12, 0x00ff_u16);
+
+        assert_eq!(normal_red, normal_red_again);
+        assert_ne!(normal_red, normal_blue);
+
+        let styles = builder.finish();
+        assert_eq!(styles.style_len(), 2);
+        assert_eq!(styles.layout_len(), 1);
+        assert_eq!(styles.paint_len(), 2);
+
+        let style = styles.segment_style(normal_red);
+        assert_eq!(style.layout(), &12);
+        assert_eq!(style.paint(), &0xff00_u16);
+    }
+
+    #[test]
+    fn segment_style_is_copy_for_non_copy_payloads() {
+        let mut builder = StyleSetBuilder::<String, String>::new();
+        let style_id = builder.intern_style(String::from("layout"), String::from("paint"));
+        let styles = builder.finish();
+
+        let style = styles.segment_style(style_id);
+        let layout = style.layout();
+        let paint = style.paint();
+
+        assert_eq!(layout, "layout");
+        assert_eq!(paint, "paint");
+    }
+}

--- a/styled_text/src/text.rs
+++ b/styled_text/src/text.rs
@@ -1,0 +1,216 @@
+// Copyright 2026 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::sync::Arc;
+use core::fmt::Debug;
+use core::ops::Range;
+
+use attributed_text::{AttributedText, Error, TextChunk, TextRange, TextStorage};
+
+use crate::{StyleId, StyleSet};
+
+/// Text plus compact style spans.
+///
+/// The text storage can be contiguous (`&str`, `String`, `Arc<str>`) or chunked.
+/// Style payloads live in a shared [`StyleSet`], while each applied span stores
+/// only compact identifiers.
+///
+/// The [`StyleSet`] is a frozen palette: it is shared (`Arc`) and only grown
+/// through the builder, so it cannot gain new styles once a `StyledText` holds
+/// it. Mutation here means reassigning ranges to styles that are *already*
+/// interned — for example clearing and reapplying syntax-highlight spans over a
+/// fixed theme with [`clear_styles`](Self::clear_styles) and
+/// [`apply_style`](Self::apply_style). To introduce new styles, rebuild through
+/// [`StyledTextBuilder`](crate::StyledTextBuilder) or a fresh [`StyleSet`].
+///
+/// [`StyleId`]s are indices into one specific [`StyleSet`] and carry no
+/// provenance; using an id with a different set is incorrect and only
+/// debug-asserted. Likewise a [`TextRange`](crate::TextRange) is valid only for
+/// the text it was validated against and is invalidated by
+/// [`set_text`](Self::set_text).
+#[derive(Debug)]
+pub struct StyledText<T: Debug + TextStorage, L, P> {
+    attributed: AttributedText<T, StyleId>,
+    styles: Arc<StyleSet<L, P>>,
+    base_style: StyleId,
+}
+
+impl<T: Debug + TextStorage, L, P> StyledText<T, L, P> {
+    pub(crate) fn from_attributed_parts(
+        attributed: AttributedText<T, StyleId>,
+        styles: Arc<StyleSet<L, P>>,
+        base_style: StyleId,
+    ) -> Self {
+        Self {
+            attributed,
+            styles,
+            base_style,
+        }
+    }
+
+    /// Creates styled text from text storage, a shared style set, and a base style.
+    ///
+    /// The base style identifier must come from `styles`.
+    #[must_use]
+    pub fn new(text: T, styles: Arc<StyleSet<L, P>>, base_style: StyleId) -> Self {
+        debug_assert!(
+            styles.get_style(base_style).is_some(),
+            "base style id must be interned in styles"
+        );
+        Self::from_attributed_parts(AttributedText::new(text), styles, base_style)
+    }
+
+    /// Borrow the underlying attributed text.
+    ///
+    /// This exposes the internal `StyleId`-attributed representation and is
+    /// crate-internal so the representation can change without a breaking change.
+    #[must_use]
+    #[inline]
+    pub(crate) const fn attributed(&self) -> &AttributedText<T, StyleId> {
+        &self.attributed
+    }
+
+    /// Borrow the underlying text storage.
+    #[must_use]
+    #[inline]
+    pub fn text(&self) -> &T {
+        self.attributed.text()
+    }
+
+    /// Replaces the underlying text and clears applied style spans.
+    #[inline]
+    pub fn set_text(&mut self, text: T) {
+        self.attributed.set_text(text);
+    }
+
+    /// Borrow the shared style set.
+    #[must_use]
+    #[inline]
+    pub fn style_set(&self) -> &StyleSet<L, P> {
+        &self.styles
+    }
+
+    /// Borrow the shared style set handle.
+    #[must_use]
+    #[inline]
+    pub fn style_set_arc(&self) -> &Arc<StyleSet<L, P>> {
+        &self.styles
+    }
+
+    /// Returns the base style used when no active span is present.
+    #[must_use]
+    #[inline]
+    pub const fn base_style(&self) -> StyleId {
+        self.base_style
+    }
+
+    /// Updates the base style used by segment resolution.
+    ///
+    /// The style identifier must come from this text's [`StyleSet`].
+    #[inline]
+    pub fn set_base_style(&mut self, base_style: StyleId) {
+        self.debug_assert_style_is_in_set(base_style);
+        self.base_style = base_style;
+    }
+
+    /// Returns the text length in bytes.
+    #[must_use]
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.attributed.len()
+    }
+
+    /// Returns `true` if the underlying text is empty.
+    #[must_use]
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.attributed.is_empty()
+    }
+
+    /// Borrow the underlying text as `&str` when the storage is contiguous.
+    #[must_use]
+    #[inline]
+    pub fn as_str(&self) -> Option<&str> {
+        self.attributed.as_str()
+    }
+
+    /// Iterates over borrowed text chunks covering `range`.
+    pub fn chunks(&self, range: TextRange) -> impl Iterator<Item = TextChunk<'_>> {
+        self.attributed.chunks(range)
+    }
+
+    /// Validates a byte range against the underlying text storage.
+    #[inline]
+    pub fn validate_range(&self, range: Range<usize>) -> Result<TextRange, Error> {
+        self.text().validate_range(range)
+    }
+
+    /// Applies compact style identifiers to a validated range.
+    ///
+    /// The style identifier must come from this text's [`StyleSet`].
+    #[inline]
+    pub fn apply_style(&mut self, range: TextRange, style: StyleId) {
+        self.debug_assert_style_is_in_set(style);
+        self.attributed.apply_attribute(range, style);
+    }
+
+    /// Applies compact style identifiers to a byte range after validation.
+    ///
+    /// The style identifier must come from this text's [`StyleSet`].
+    #[inline]
+    pub fn apply_style_bytes(&mut self, range: Range<usize>, style: StyleId) -> Result<(), Error> {
+        let range = self.validate_range(range)?;
+        self.apply_style(range, style);
+        Ok(())
+    }
+
+    /// Removes all applied style spans.
+    #[inline]
+    pub fn clear_styles(&mut self) {
+        self.attributed.clear_attributes();
+    }
+
+    /// Returns the number of applied style spans.
+    #[must_use]
+    #[inline]
+    pub fn style_spans_len(&self) -> usize {
+        self.attributed.attributes_len()
+    }
+
+    /// Iterates over all applied style spans in application order.
+    #[inline]
+    pub fn style_spans(&self) -> impl ExactSizeIterator<Item = (TextRange, &StyleId)> {
+        self.attributed.attributes_iter()
+    }
+
+    fn debug_assert_style_is_in_set(&self, style: StyleId) {
+        debug_assert!(
+            self.styles.get_style(style).is_some(),
+            "style id must be interned in this text's style set"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+
+    use crate::{StyleSetBuilder, StyledText};
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "style id must be interned in this text's style set")]
+    fn apply_style_rejects_out_of_set_style_in_debug() {
+        let mut first = StyleSetBuilder::<u8, ()>::new();
+        let base = first.intern_style(0, ());
+        let styles = Arc::new(first.finish());
+
+        let mut second = StyleSetBuilder::<u8, ()>::new();
+        second.intern_style(0, ());
+        let foreign = second.intern_style(1, ());
+
+        let mut text = StyledText::new("abc", styles, base);
+        let range = text.validate_range(0..1).expect("valid range");
+        text.apply_style(range, foreign);
+    }
+}

--- a/styled_text/src/text_builder.rs
+++ b/styled_text/src/text_builder.rs
@@ -1,0 +1,393 @@
+// Copyright 2026 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::ops::Range;
+
+use attributed_text::{AttributeSegmentsWorkspace, AttributedText, Error, TextRange, TextStorage};
+
+use crate::{StyleId, StyleSetBuilder, StyledText};
+
+/// A partial style patch that can be applied to full layout and paint styles.
+///
+/// This trait is intentionally generic. Toolkits can define their own patch
+/// type with whatever fields make sense, then merge those patches into their
+/// own full style payloads during [`StyledTextBuilder::finish`].
+pub trait StylePatch<L, P> {
+    /// Applies this patch to the current full layout and paint styles.
+    fn apply_to(&self, layout: &mut L, paint: &mut P);
+}
+
+impl<L, P> StylePatch<L, P> for () {
+    #[inline]
+    fn apply_to(&self, _layout: &mut L, _paint: &mut P) {}
+}
+
+/// Builder for constructing compact styled text from text and style patches.
+///
+/// This is the higher-level construction API. Callers append text and record
+/// partial style patches against byte ranges. At [`finish`](Self::finish), the
+/// builder composes overlapping patches in the order they were applied,
+/// interns the resulting full layout and paint payloads, then returns
+/// [`StyledText`].
+///
+/// The resolved output remains the low-level representation: text plus compact
+/// [`StyleId`] spans. Individual style fields are a construction detail of the
+/// caller's patch type; the stored spans refer to complete styles.
+#[derive(Debug)]
+pub struct StyledTextBuilder<L, P, Patch = ()> {
+    text: String,
+    patches: Vec<(TextRange, Patch)>,
+    base_layout: L,
+    base_paint: P,
+}
+
+impl<L, P, Patch> StyledTextBuilder<L, P, Patch> {
+    /// Creates an empty builder with base layout and paint styles.
+    #[must_use]
+    pub fn new(base_layout: L, base_paint: P) -> Self {
+        Self {
+            text: String::new(),
+            patches: Vec::new(),
+            base_layout,
+            base_paint,
+        }
+    }
+
+    /// Creates an empty builder with retained capacity for text and patches.
+    #[must_use]
+    pub fn with_capacity(
+        base_layout: L,
+        base_paint: P,
+        text_capacity: usize,
+        patch_capacity: usize,
+    ) -> Self {
+        Self {
+            text: String::with_capacity(text_capacity),
+            patches: Vec::with_capacity(patch_capacity),
+            base_layout,
+            base_paint,
+        }
+    }
+
+    /// Reserves capacity for additional text bytes and style patches.
+    ///
+    /// This is useful when the text length is known but the patch type should be
+    /// inferred from later [`push_with`](Self::push_with) or [`apply`](Self::apply)
+    /// calls.
+    pub fn reserve(&mut self, additional_text: usize, additional_patches: usize) {
+        self.text.reserve(additional_text);
+        self.patches.reserve(additional_patches);
+    }
+
+    /// Creates a builder from existing text.
+    #[must_use]
+    pub fn from_text(text: impl Into<String>, base_layout: L, base_paint: P) -> Self {
+        Self {
+            text: text.into(),
+            patches: Vec::new(),
+            base_layout,
+            base_paint,
+        }
+    }
+
+    /// Returns the current text.
+    #[must_use]
+    #[inline]
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// Returns the current text length in bytes.
+    #[must_use]
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.text.len()
+    }
+
+    /// Returns `true` if the current text is empty.
+    #[must_use]
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
+
+    /// Returns the number of applied style patches.
+    #[must_use]
+    #[inline]
+    pub fn patch_len(&self) -> usize {
+        self.patches.len()
+    }
+
+    /// Validates a byte range against the current text.
+    #[inline]
+    pub fn validate_range(&self, range: Range<usize>) -> Result<TextRange, Error> {
+        self.text.validate_range(range)
+    }
+
+    /// Appends unstyled text and returns its range.
+    ///
+    /// "Unstyled" means no additional patch is applied; the range still inherits
+    /// the base style and any later overlapping patches.
+    pub fn push(&mut self, text: &str) -> TextRange {
+        let start = self.text.len();
+        self.text.push_str(text);
+        TextRange::new_unchecked(start, self.text.len())
+    }
+
+    /// Applies a patch to a validated range.
+    pub fn apply(&mut self, range: TextRange, patch: Patch) {
+        if !range.is_empty() {
+            self.patches.push((range, patch));
+        }
+    }
+
+    /// Applies a patch to a byte range after validation.
+    pub fn apply_bytes(&mut self, range: Range<usize>, patch: Patch) -> Result<(), Error> {
+        let range = self.validate_range(range)?;
+        self.apply(range, patch);
+        Ok(())
+    }
+
+    /// Appends text, applies a patch to that appended range, and returns the range.
+    pub fn push_with(&mut self, text: &str, patch: Patch) -> TextRange {
+        let range = self.push(text);
+        self.apply(range, patch);
+        range
+    }
+}
+
+impl<L, P, Patch> StyledTextBuilder<L, P, Patch>
+where
+    L: Clone + PartialEq,
+    P: Clone + PartialEq,
+    Patch: StylePatch<L, P>,
+{
+    /// Finishes the builder and returns compact resolved styled text.
+    ///
+    /// Overlapping patches are applied in the order they were applied to the
+    /// builder over a clone of the base layout and paint styles for each
+    /// resolved non-base segment.
+    #[must_use]
+    pub fn finish(self) -> StyledText<String, L, P> {
+        let Self {
+            text,
+            patches,
+            base_layout,
+            base_paint,
+        } = self;
+
+        let mut style_builder = StyleSetBuilder::with_capacity(patches.len().saturating_add(1));
+        let base_style = style_builder.intern_style(base_layout.clone(), base_paint.clone());
+
+        let resolved_text = if patches.is_empty() {
+            AttributedText::new(text)
+        } else {
+            let mut resolved_spans = Vec::new();
+            let mut workspace = AttributeSegmentsWorkspace::new();
+            let mut pending: Option<(TextRange, StyleId)> = None;
+
+            workspace.for_each_span_segment_unchecked(text.len(), &patches, |range, active| {
+                if active.is_empty() {
+                    if let Some(pending) = pending.take() {
+                        resolved_spans.push(pending);
+                    }
+                    return;
+                }
+
+                let mut layout = base_layout.clone();
+                let mut paint = base_paint.clone();
+                for &patch_index in active {
+                    patches[patch_index as usize]
+                        .1
+                        .apply_to(&mut layout, &mut paint);
+                }
+
+                let style = style_builder.intern_style(layout, paint);
+                if style == base_style {
+                    if let Some(pending) = pending.take() {
+                        resolved_spans.push(pending);
+                    }
+                    return;
+                }
+
+                match pending.take() {
+                    Some((pending_range, pending_style))
+                        if pending_style == style && pending_range.end() == range.start() =>
+                    {
+                        pending = Some((
+                            TextRange::new_unchecked(pending_range.start(), range.end()),
+                            style,
+                        ));
+                    }
+                    Some(pending_span) => {
+                        resolved_spans.push(pending_span);
+                        pending = Some((range, style));
+                    }
+                    None => {
+                        pending = Some((range, style));
+                    }
+                }
+            });
+
+            if let Some(pending) = pending {
+                resolved_spans.push(pending);
+            }
+
+            AttributedText::from_attributes_unchecked(text, resolved_spans)
+        };
+
+        StyledText::from_attributed_parts(
+            resolved_text,
+            Arc::new(style_builder.finish()),
+            base_style,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::{StylePatch, StyledSegmentsWorkspace, StyledTextBuilder};
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct Layout {
+        size: u8,
+        underline: bool,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct Paint(u8);
+
+    #[derive(Clone, Copy, Default)]
+    struct Patch {
+        size: Option<u8>,
+        underline: Option<bool>,
+        paint: Option<u8>,
+    }
+
+    impl StylePatch<Layout, Paint> for Patch {
+        fn apply_to(&self, layout: &mut Layout, paint: &mut Paint) {
+            if let Some(size) = self.size {
+                layout.size = size;
+            }
+            if let Some(underline) = self.underline {
+                layout.underline = underline;
+            }
+            if let Some(color) = self.paint {
+                paint.0 = color;
+            }
+        }
+    }
+
+    static LAYOUT_CLONES: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct CountedLayout(u8);
+
+    impl Clone for CountedLayout {
+        fn clone(&self) -> Self {
+            LAYOUT_CLONES.fetch_add(1, Ordering::Relaxed);
+            Self(self.0)
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct CountedPaint(u8);
+
+    #[derive(Clone, Copy)]
+    struct CountedPatch(u8);
+
+    impl StylePatch<CountedLayout, CountedPaint> for CountedPatch {
+        fn apply_to(&self, layout: &mut CountedLayout, _paint: &mut CountedPaint) {
+            layout.0 = self.0;
+        }
+    }
+
+    #[test]
+    fn builder_merges_overlapping_patches_by_property() {
+        let base_layout = Layout {
+            size: 16,
+            underline: false,
+        };
+        let mut builder = StyledTextBuilder::new(base_layout, Paint(1));
+        let all = builder.push("abcd");
+        builder.apply(
+            all,
+            Patch {
+                size: Some(12),
+                ..Patch::default()
+            },
+        );
+        builder
+            .apply_bytes(
+                1..3,
+                Patch {
+                    underline: Some(true),
+                    paint: Some(2),
+                    ..Patch::default()
+                },
+            )
+            .expect("valid range");
+
+        let styled = builder.finish();
+        let mut workspace = StyledSegmentsWorkspace::new();
+        let segments = workspace
+            .segments(&styled)
+            .map(|segment| {
+                let style = styled.style_set().segment_style(segment.style());
+                (segment.range().as_range(), *style.layout(), *style.paint())
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            segments,
+            vec![
+                (
+                    0..1,
+                    Layout {
+                        size: 12,
+                        underline: false
+                    },
+                    Paint(1)
+                ),
+                (
+                    1..3,
+                    Layout {
+                        size: 12,
+                        underline: true
+                    },
+                    Paint(2)
+                ),
+                (
+                    3..4,
+                    Layout {
+                        size: 12,
+                        underline: false
+                    },
+                    Paint(1)
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn builder_skips_base_style_clone_for_unpatched_segments() {
+        let mut builder = StyledTextBuilder::new(CountedLayout(1), CountedPaint(1));
+        builder.push("abcdef");
+        builder
+            .apply_bytes(2..4, CountedPatch(2))
+            .expect("valid range");
+
+        LAYOUT_CLONES.store(0, Ordering::Relaxed);
+        let styled = builder.finish();
+
+        assert_eq!(LAYOUT_CLONES.load(Ordering::Relaxed), 2);
+        assert_eq!(styled.style_set().style_len(), 2);
+    }
+}


### PR DESCRIPTION
Add `styled_text` as a first-slice crate for compact styled text storage.

The core crate stores resolved complete styles as compact `StyleId` spans over `attributed_text`, with layout and paint payloads interned separately so paint-only changes can share layout identity. It includes a builder that resolves overlapping patch ranges and reusable segment workspaces for downstream layout or paint passes.

This intentionally leaves lowering to Parley, cascading, editing policy, and application-specific style vocabularies outside the core `styled_text` crate.