### PR TITLE
Add `From` conversions into `StyleProperty` for the remaining single-typed properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV] of 1.88.
 
+### Added
+
+#### Parley
+
+- `From` conversions into `StyleProperty` for `FontWidth`, `FontStyle`, `FontWeight`, `WordBreak`, `OverflowWrap`, and `TextWrapMode`, matching the existing conversions for font family, variations, features, and line height. (#643 by [@waywardmonkeys][])
+
 ## [0.10.0] - 2026-06-01
 
 This release has an [MSRV] of 1.88.
@@ -652,6 +658,7 @@ This release has an [MSRV][] of 1.70.
 [#621]: https://github.com/linebender/parley/pull/621
 [#626]: https://github.com/linebender/parley/pull/626
 [#632]: https://github.com/linebender/parley/pull/632
+[#643]: https://github.com/linebender/parley/pull/643
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.10.0...HEAD
 [0.10.0]: https://github.com/linebender/parley/compare/v0.9.0...v0.10.0

--- a/parley/src/style/mod.rs
+++ b/parley/src/style/mod.rs
@@ -241,3 +241,39 @@ impl<B: Brush> From<LineHeight> for StyleProperty<'_, B> {
         StyleProperty::LineHeight(value)
     }
 }
+
+impl<B: Brush> From<FontWidth> for StyleProperty<'_, B> {
+    fn from(value: FontWidth) -> Self {
+        StyleProperty::FontWidth(value)
+    }
+}
+
+impl<B: Brush> From<FontStyle> for StyleProperty<'_, B> {
+    fn from(value: FontStyle) -> Self {
+        StyleProperty::FontStyle(value)
+    }
+}
+
+impl<B: Brush> From<FontWeight> for StyleProperty<'_, B> {
+    fn from(value: FontWeight) -> Self {
+        StyleProperty::FontWeight(value)
+    }
+}
+
+impl<B: Brush> From<WordBreak> for StyleProperty<'_, B> {
+    fn from(value: WordBreak) -> Self {
+        StyleProperty::WordBreak(value)
+    }
+}
+
+impl<B: Brush> From<OverflowWrap> for StyleProperty<'_, B> {
+    fn from(value: OverflowWrap) -> Self {
+        StyleProperty::OverflowWrap(value)
+    }
+}
+
+impl<B: Brush> From<TextWrapMode> for StyleProperty<'_, B> {
+    fn from(value: TextWrapMode) -> Self {
+        StyleProperty::TextWrapMode(value)
+    }
+}


### PR DESCRIPTION
`StyleProperty` already had `From` impls for font family, variations, features, generic family, and line height, letting callers pass those directly to APIs that take `impl Into<StyleProperty>` (e.g. `RangedBuilder::push`). The single-typed scalar properties had no such conversions even though they are unambiguous.

Add `From<FontWidth>`, `From<FontStyle>`, `From<FontWeight>`, `From<WordBreak>`, `From<OverflowWrap>`, and `From<TextWrapMode>`. Properties whose inner type is a bare primitive shared across variants (`f32`, `Option<f32>`, `bool`, `brush`) are intentionally left out, as a `From` would be ambiguous there.