### PR TITLE
Point `tango` to git rev to fix paired benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,15 +141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,17 +1403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "goblin"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27c1b4369c2cd341b5de549380158b105a04c331be5db9110eef7b6d2742134"
-dependencies = [
- "log",
- "plain",
- "scroll",
-]
-
-[[package]]
 name = "gpu-allocator"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,6 +1923,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-types"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d203b1b00d03d1cee9ddcaf970d2ccdd40d8036d8fafef34a0b1b841486b232"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,6 +2172,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -2295,6 +2294,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -3448,26 +3460,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scroll"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sctk-adwaita"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3561,6 +3553,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "shared_memory"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8593196da75d9dc4f69349682bd4c2099f8cde114257d1ef7ef1b33d1aba54"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "nix",
+ "rand",
+ "win-sys",
 ]
 
 [[package]]
@@ -3804,23 +3809,23 @@ dependencies = [
 
 [[package]]
 name = "tango-bench"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257822358c6f206fed78bfe6369cf959063b0644d70f88df6b19f2dadc93423e"
+version = "0.7.2"
+source = "git+https://github.com/bazhenov/tango?rev=1d69f0728b707597409be0cc199e7a0173a666dd#1d69f0728b707597409be0cc199e7a0173a666dd"
 dependencies = [
- "alloca",
  "anyhow",
  "clap",
  "colorz",
  "glob-match",
- "goblin",
- "libloading",
+ "jsonrpc-types",
+ "libc",
  "log",
  "num-traits",
  "rand",
- "scroll",
- "tempfile",
+ "serde",
+ "serde_json",
+ "shared_memory",
  "thiserror 1.0.69",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4078,7 +4083,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -4716,12 +4721,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "win-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7b128a98c1cfa201b09eb49ba285887deb3cbe7466a98850eb1adabb452be5"
+dependencies = [
+ "windows 0.34.0",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45296b64204227616fdbf2614cefa4c236b98ee64dfaaaa435207ed99fe7829f"
+dependencies = [
+ "windows_aarch64_msvc 0.34.0",
+ "windows_i686_gnu 0.34.0",
+ "windows_i686_msvc 0.34.0",
+ "windows_x86_64_gnu 0.34.0",
+ "windows_x86_64_msvc 0.34.0",
 ]
 
 [[package]]
@@ -4975,6 +5002,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4984,6 +5017,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5011,6 +5050,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5020,6 +5065,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5044,6 +5095,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/parley_bench/Cargo.toml
+++ b/parley_bench/Cargo.toml
@@ -14,7 +14,7 @@ parley = { workspace = true, default-features = true }
 parley_dev = { workspace = true }
 glifo = { workspace = true, default-features = false, features = ["std", "vello_cpu", "png"] }
 skrifa = { workspace = true }
-tango-bench = "0.6"
+tango-bench = { git = "https://github.com/bazhenov/tango", rev = "1d69f0728b707597409be0cc199e7a0173a666dd" }
 vello_cpu = { workspace = true, default-features = false, features = ["std", "png", "text"] }
 
 

--- a/parley_bench/README.md
+++ b/parley_bench/README.md
@@ -23,5 +23,5 @@ cargo export target/benchmarks -- bench --bench=main
 # Apply changes to Parley
 
 # Compare changes with baseline
-cargo bench -q --bench=main -- compare target/benchmarks/main -p
+cargo bench -q --bench=main -- compare ../target/benchmarks/main
 ```

--- a/parley_bench/benches/main.rs
+++ b/parley_bench/benches/main.rs
@@ -3,7 +3,7 @@
 
 //! Parley benchmarks.
 
-use tango_bench::{tango_benchmarks, tango_main};
+use tango_bench::tango_benchmarks;
 
 use parley_bench::benches::{defaults, glyph_cache, styled};
 use parley_bench::fontique_benches::system_fonts_init;
@@ -23,4 +23,3 @@ tango_benchmarks!(
     draw_with_underline_warm_cache(),
     system_fonts_init()
 );
-tango_main!();


### PR DESCRIPTION
`tango` recently switched to running the paired comparison benchmarks in separate processes (https://github.com/bazhenov/tango/pull/78). This is fortunate, as it turns out to also fix an issue I encountered in https://github.com/linebender/parley/pull/634#discussion_r3449043356.

On current `main`, if I run `cargo export target/benchmarks -- bench --bench=main` followed by `cargo bench -q --bench=main -- compare target/benchmarks/main -p -t 4.`, I get the following!

```
Default Style - arabic 20 characters               [   8.9 us ...   8.9 us ]      +0.35%
Default Style - latin 20 characters                [   4.3 us ...   4.1 us ]      -3.50%*
Default Style - japanese 20 characters             [   8.2 us ...   8.1 us ]      -0.44%
Default Style - arabic 1 paragraph                 [  48.5 us ...  48.1 us ]      -0.66%
Default Style - latin 1 paragraph                  [  17.2 us ...  16.1 us ]      -6.52%*
Default Style - japanese 1 paragraph               [  71.3 us ...  69.6 us ]      -2.50%*
Default Style - arabic 4 paragraph                 [ 214.5 us ... 212.7 us ]      -0.86%
Default Style - latin 4 paragraph                  [  66.0 us ...  62.0 us ]      -5.96%*
Default Style - japanese 4 paragraph               [ 100.7 us ...  98.5 us ]      -2.18%*
Styled - arabic 20 characters                      [   9.9 us ...   9.9 us ]      +0.41%
Styled - latin 20 characters                       [   5.3 us ...   5.3 us ]      -1.01%*
Styled - japanese 20 characters                    [   8.8 us ...   8.7 us ]      -0.60%*
Styled - arabic 1 paragraph                        [  51.3 us ...  51.0 us ]      -0.60%
Styled - latin 1 paragraph                         [  21.4 us ...  20.9 us ]      -2.52%*
Styled - japanese 1 paragraph                      [  78.7 us ...  77.5 us ]      -1.52%*
Styled - arabic 4 paragraph                        [ 232.7 us ... 232.1 us ]      -0.27%
Styled - latin 4 paragraph                         [  83.2 us ...  80.6 us ]      -3.18%*
Styled - japanese 4 paragraph                      [ 109.7 us ... 108.3 us ]      -1.34%*
```

I.e., there are quite a few significant "improvements." This is without any code changes and isn't measurement noise. A possible explanation is there's a difference between the in-process code and the `dlopen`'d code performance that shows up at least on my machine. I don't think it's a P- vs E-core thing or something like that, as when I pin the threads to equally-powerful cores (same features, same max freq), the results stay like this.

Measured using the git revision of `tango`, the results are more reasonable.

```
$ cargo export target/benchmarks -- bench --bench=main
$ cargo bench -q --bench=main -- compare ../target/benchmarks/main -t 4.
Default Style - arabic 20 characters               [   8.7 us ...   8.7 us ]      -0.04%
Default Style - latin 20 characters                [   4.1 us ...   4.1 us ]      +1.76%*
Default Style - japanese 20 characters             [   7.9 us ...   8.0 us ]      +0.24%
Default Style - arabic 1 paragraph                 [  46.7 us ...  46.9 us ]      +0.47%
Default Style - latin 1 paragraph                  [  16.0 us ...  16.0 us ]      -0.08%
Default Style - japanese 1 paragraph               [  68.4 us ...  68.3 us ]      -0.10%
Default Style - arabic 4 paragraph                 [ 196.5 us ... 196.9 us ]      +0.23%
Default Style - latin 4 paragraph                  [  61.1 us ...  61.1 us ]      +0.10%
Default Style - japanese 4 paragraph               [  96.7 us ...  96.4 us ]      -0.32%
Styled - arabic 20 characters                      [   9.6 us ...   9.6 us ]      +0.19%
Styled - latin 20 characters                       [   5.2 us ...   5.3 us ]      +0.32%
Styled - japanese 20 characters                    [   8.5 us ...   8.4 us ]      -0.10%
Styled - arabic 1 paragraph                        [  49.1 us ...  49.0 us ]      -0.08%
Styled - latin 1 paragraph                         [  20.4 us ...  20.4 us ]      -0.05%
Styled - japanese 1 paragraph                      [  74.2 us ...  74.4 us ]      +0.22%
Styled - arabic 4 paragraph                        [ 216.0 us ... 215.8 us ]      -0.10%
Styled - latin 4 paragraph                         [  79.1 us ...  79.2 us ]      +0.19%
Styled - japanese 4 paragraph                      [ 105.2 us ... 105.4 us ]      +0.17%
```