### PR TITLE
Move bidi algorithm into `parley_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2904,6 +2904,7 @@ dependencies = [
  "linebender_resource_handle",
  "oxipng",
  "parlance",
+ "parley_core",
  "parley_data",
  "parley_dev",
  "peniko",
@@ -2924,7 +2925,10 @@ dependencies = [
 
 [[package]]
 name = "parley_core"
-version = "0.0.0"
+version = "0.11.0"
+dependencies = [
+ "icu_properties",
+]
 
 [[package]]
 name = "parley_data"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ repository = "https://github.com/linebender/parley"
 parlance = { version = "0.1.0", default-features = false, path = "parlance" }
 fontique = { version = "0.11.0", default-features = false, path = "fontique" }
 parley = { version = "0.11.0", default-features = false, path = "parley" }
+parley_core = { version = "0.11.0", default-features = false, path = "parley_core" }
 parley_data = { version = "0.11.0", path = "parley_data", default-features = false }
 parley_data_gen = { path = "parley_data_gen" }
 parley_dev = { default-features = false, path = "parley_dev" }

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -32,6 +32,7 @@ skrifa = { workspace = true }
 linebender_resource_handle = { workspace = true }
 fontique = { workspace = true }
 parlance = { workspace = true }
+parley_core = { workspace = true }
 core_maths = { version = "0.1.1", optional = true }
 parley_data = { workspace = true, features = ["baked"] }
 accesskit = { workspace = true, optional = true }

--- a/parley/src/analysis/mod.rs
+++ b/parley/src/analysis/mod.rs
@@ -25,6 +25,8 @@ use icu_segmenter::{
 };
 use parley_data::Properties;
 
+use parley_core::bidi;
+
 pub(crate) struct AnalysisDataSources;
 
 impl AnalysisDataSources {
@@ -511,7 +513,7 @@ pub(crate) fn analyze_text<B: Brush>(
                 }
             };
 
-            needs_bidi_resolution |= crate::bidi::needs_bidi_resolution(bidi_class);
+            needs_bidi_resolution |= bidi::needs_bidi_resolution(bidi_class);
             // TODO: maybe extend Properties to u64 to fit BidiMirroringGlyph
             let bracket = lcx.analysis_data_sources.brackets().get(ch);
 

--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -5,6 +5,8 @@
 
 use alloc::{vec, vec::Vec};
 
+use parley_core::bidi::BidiResolver;
+
 use super::FontContext;
 use super::builder::{RangedBuilder, StyleRunBuilder};
 use super::resolve::tree::TreeStyleBuilder;
@@ -12,7 +14,6 @@ use super::resolve::{RangedStyleBuilder, ResolveContext, ResolvedStyle, StyleRun
 use super::style::{Brush, TextStyle};
 
 use crate::analysis::{AnalysisDataSources, CharInfo};
-use crate::bidi::BidiResolver;
 use crate::builder::TreeBuilder;
 use crate::inline_box::InlineBox;
 use crate::shape::ShapeContext;

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -109,7 +109,6 @@ extern crate std;
 pub use fontique;
 
 mod analysis;
-mod bidi;
 mod break_overrides;
 mod builder;
 mod context;

--- a/parley_core/Cargo.toml
+++ b/parley_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parley_core"
-version = "0.0.0"
+version = "0.11.0"
 description = "Parley Core provides low level APIs for implementing text layout."
 keywords = ["text", "layout"]
 categories = ["gui", "graphics"]
@@ -9,14 +9,15 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
-publish = false
-
 [package.metadata.docs.rs]
 all-features = true
 
 [features]
 default = ["std"]
 std = []
+
+[dependencies]
+icu_properties = { workspace = true, features = ["compiled_data"] }
 
 [lints]
 workspace = true

--- a/parley_core/src/bidi.rs
+++ b/parley_core/src/bidi.rs
@@ -7,11 +7,11 @@ use alloc::vec::Vec;
 use icu_properties::props::{BidiClass, BidiMirroringGlyph, BidiPairedBracketType};
 
 /// Type alias for a bidirectional level.
-pub(crate) type BidiLevel = u8;
+pub type BidiLevel = u8;
 
 /// Resolver for the Unicode bidirectional algorithm.
 #[derive(Clone, Default)]
-pub(crate) struct BidiResolver {
+pub struct BidiResolver {
     base_level: BidiLevel,
     levels: Vec<BidiLevel>,
     initial_types: Vec<BidiClass>,
@@ -23,9 +23,18 @@ pub(crate) struct BidiResolver {
     flags: u16,
 }
 
+impl core::fmt::Debug for BidiResolver {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BidiResolver")
+            .field("base_level", &self.base_level)
+            .field("levels", &self.levels)
+            .finish_non_exhaustive()
+    }
+}
+
 impl BidiResolver {
     /// Creates a new resolver.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             base_level: 0,
             levels: Vec::new(),
@@ -40,18 +49,18 @@ impl BidiResolver {
     }
 
     /// Returns the base level of the text.
-    pub(crate) fn base_level(&self) -> u8 {
+    pub fn base_level(&self) -> u8 {
         self.base_level
     }
 
     /// Returns the sequence of bidi levels corresponding to all characters in the
     /// paragraph.
-    pub(crate) fn levels(&self) -> &[BidiLevel] {
+    pub fn levels(&self) -> &[BidiLevel] {
         &self.levels
     }
 
     /// Clears the resolver state.
-    pub(crate) fn clear(&mut self) {
+    pub fn clear(&mut self) {
         self.initial_types.clear();
         self.levels.clear();
         self.types.clear();
@@ -63,7 +72,7 @@ impl BidiResolver {
 
     /// Resolves a paragraph with the specified base direction and
     /// precomputed types.
-    pub(crate) fn resolve(
+    pub fn resolve(
         &mut self,
         chars: impl Iterator<Item = (char, (BidiClass, BidiMirroringGlyph))>,
         base_level: Option<u8>,
@@ -240,8 +249,7 @@ impl BidiResolver {
                 } else {
                     (stack.embedding_level() + 2) & !1
                 };
-                if new_level <= MAX_STACK as u8 && overflow_isolates == 0 && overflow_embedding == 0
-                {
+                if new_level <= MAX_STACK && overflow_isolates == 0 && overflow_embedding == 0 {
                     if is_isolate {
                         valid_isolates += 1;
                     }
@@ -387,7 +395,7 @@ impl BidiResolver {
         }
     }
 
-    #[allow(clippy::needless_range_loop)]
+    #[expect(clippy::needless_range_loop, reason = "Deferred")]
     fn resolve_sequence(&mut self, level: u8, sos: BidiClass, eos: BidiClass, len: usize) {
         if len == 0 {
             return;
@@ -718,7 +726,7 @@ where
 
 /// Returns whether the character needs bidirectional resolution.
 #[inline(always)]
-pub(crate) fn needs_bidi_resolution(bidi_class: BidiClass) -> bool {
+pub fn needs_bidi_resolution(bidi_class: BidiClass) -> bool {
     mask(bidi_class) & BIDI_MASK != 0
 }
 
@@ -805,12 +813,12 @@ impl Run {
     }
 }
 
-const MAX_STACK: usize = 125;
+const MAX_STACK: u8 = 125;
 
 struct Stack {
-    embedding_level: [u8; MAX_STACK + 1],
-    override_status: [BidiClass; MAX_STACK + 1],
-    isolate_status: [bool; MAX_STACK + 1],
+    embedding_level: [u8; MAX_STACK as usize + 1],
+    override_status: [BidiClass; MAX_STACK as usize + 1],
+    isolate_status: [bool; MAX_STACK as usize + 1],
     depth: usize,
 }
 
@@ -818,9 +826,9 @@ impl Stack {
     fn new() -> Self {
         Self {
             depth: 0,
-            embedding_level: [0; MAX_STACK + 1],
-            override_status: [BidiClass::OtherNeutral; MAX_STACK + 1],
-            isolate_status: [false; MAX_STACK + 1],
+            embedding_level: [0; MAX_STACK as usize + 1],
+            override_status: [BidiClass::OtherNeutral; MAX_STACK as usize + 1],
+            isolate_status: [false; MAX_STACK as usize + 1],
         }
     }
 

--- a/parley_core/src/lib.rs
+++ b/parley_core/src/lib.rs
@@ -20,3 +20,7 @@
 #![no_std]
 #[cfg(feature = "std")]
 extern crate std;
+
+extern crate alloc;
+
+pub mod bidi;


### PR DESCRIPTION
Kicking off the sequence to end up at (roughly) the shape of https://github.com/linebender/parley/pull/634.

Instead of starting with `parley_data`, I figured to first move the bidi algorithm as it wires up the `parley` and `parley_core` crates plus handles some lints that `parley` suppressed and `parley_core` doesn't.

Two more PRs are ready: first, simply moving the line break opportunity overrides introduced in https://github.com/linebender/parley/pull/640 (similarly moving files and handling lints), second and more interestingly, migrating `parley`'s analysis without any real changes into `parley_core` and introducing  `parley_core::{Analysis, Analyzer}`.