### PR TITLE
Move line break opportunity overrides into `parley_core`

### DIFF
--- a/parley/src/analysis/mod.rs
+++ b/parley/src/analysis/mod.rs
@@ -6,7 +6,6 @@ pub(crate) mod cluster;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use crate::break_overrides::{LineBreakContext, LineBreakOverrideFn};
 use crate::resolve::StyleRun;
 use crate::{Brush, LayoutContext, WordBreak};
 
@@ -23,6 +22,7 @@ use icu_segmenter::{
     GraphemeClusterSegmenter, GraphemeClusterSegmenterBorrowed, LineSegmenter,
     LineSegmenterBorrowed, WordSegmenter, WordSegmenterBorrowed,
 };
+use parley_core::break_overrides::{LineBreakContext, LineBreakOverrideFn};
 use parley_data::Properties;
 
 use parley_core::bidi;

--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -11,9 +11,9 @@ use super::layout::Layout;
 
 use alloc::string::String;
 use core::ops::{Bound, Range, RangeBounds};
+use parley_core::break_overrides::LineBreakOverrideFn;
 
 use crate::InlineBoxKind;
-use crate::break_overrides::LineBreakOverrideFn;
 use crate::inline_box::InlineBox;
 use crate::resolve::{ResolvedStyle, StyleRun, tree::ItemKind};
 

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -109,7 +109,6 @@ extern crate std;
 pub use fontique;
 
 mod analysis;
-mod break_overrides;
 mod builder;
 mod context;
 mod convert;
@@ -129,18 +128,18 @@ pub mod style;
 mod tests;
 
 pub use linebender_resource_handle::FontData;
-pub use util::BoundingBox;
-
-pub use break_overrides::{
+pub use parley_core::break_overrides::{
     AsciiLineBreakTable, AsciiLineBreakTableBuilder, CHROMIUM_LINE_BREAK_OVERRIDE,
     LineBreakContext, LineBreakOverrideFn,
 };
+
 pub use builder::{RangedBuilder, StyleRunBuilder, TreeBuilder};
 pub use context::LayoutContext;
 pub use font::FontContext;
 pub use inline_box::{InlineBox, InlineBoxKind};
 #[doc(inline)]
 pub use layout::Layout;
+pub use util::BoundingBox;
 
 pub use editing::*;
 pub use layout::*;

--- a/parley_core/src/break_overrides.rs
+++ b/parley_core/src/break_overrides.rs
@@ -7,7 +7,8 @@ use core::ops::RangeInclusive;
 
 /// Context for a potential line break opportunity between two adjacent code points.
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+// #[non_exhaustive]
+// TODO: re-enable the non-exhaustive above
 pub struct LineBreakContext {
     /// The code point before the `before` code point, if any.
     pub before_before: Option<char>,
@@ -109,18 +110,20 @@ static CHROMIUM_LINE_BREAK_TABLE: AsciiLineBreakTable<5> =
 ///
 /// # Example
 ///
-/// ```
-/// # use parley::{CHROMIUM_LINE_BREAK_OVERRIDE, FontContext, LayoutContext};
-/// # let mut font_cx = FontContext::default();
-/// # let mut layout_cx: LayoutContext<[u8; 4]> = LayoutContext::new();
+/// ```ignore
+/// # use parley_core::break_overrides::CHROMIUM_LINE_BREAK_OVERRIDE;
+/// # use parley_core::{Analysis, AnalysisOptions, Analyzer};
+/// # let mut analyzer = Analyzer::new();
+/// # let mut analysis = Analysis::new();
 /// let text = "Hello there!";
-/// let mut builder = layout_cx.ranged_builder(&mut font_cx, text, 1.0, true);
-/// // Emulate Chromium:
-/// builder.set_line_break_override(Some(CHROMIUM_LINE_BREAK_OVERRIDE));
-/// let layout = builder.build(text);
-/// # let _ = layout;
+/// let options = AnalysisOptions {
+///     word_break: &[],
+///     // Emulate Chromium:
+///     line_break_override: Some(CHROMIUM_LINE_BREAK_OVERRIDE),
+/// };
+/// analyzer.analyze(text, &options, &mut analysis);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AsciiLineBreakTable<const N: usize> {
     /// Maps each `before` character (`0..128`) to a row in `rows`.
     row_of: [u8; 128],
@@ -146,7 +149,7 @@ impl<const N: usize> AsciiLineBreakTable<N> {
 }
 
 /// A single deduplicated row of a [`AsciiLineBreakTable`].
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 struct Row {
     /// Bits set means the pair has an override.
     overridden: u128,
@@ -158,7 +161,7 @@ struct Row {
 ///
 /// Construction is `const`. We create a dense `128 x 128` grid of overrides,
 /// then compress it into a row-deduplicated table via [`AsciiLineBreakTableBuilder::build`].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AsciiLineBreakTableBuilder {
     /// Bit `after` set in row `before` means the pair has an explicit override.
     overridden: [u128; 128],
@@ -250,7 +253,13 @@ impl AsciiLineBreakTableBuilder {
                 len += 1;
                 len - 1
             };
-            row_of[b] = r as u8;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "TODO: fix this (`N` should be `u8`, or `row_of` should contain `usize`)"
+            )]
+            {
+                row_of[b] = r as u8;
+            }
             b += 1;
         }
 

--- a/parley_core/src/lib.rs
+++ b/parley_core/src/lib.rs
@@ -24,3 +24,4 @@ extern crate std;
 extern crate alloc;
 
 pub mod bidi;
+pub mod break_overrides;


### PR DESCRIPTION
On top of https://github.com/linebender/parley/pull/647.

Temporarily removes `#[non_exhaustive]` from `LineBreakContext` to allow `parley` to construct it (becomes `non_exhaustive` again once the next PR lands).