### PR TITLE
Migrate analysis from `parley` to `parley_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2900,12 +2900,10 @@ dependencies = [
  "hashbrown 0.17.1",
  "icu_normalizer",
  "icu_properties",
- "icu_segmenter",
  "linebender_resource_handle",
  "oxipng",
  "parlance",
  "parley_core",
- "parley_data",
  "parley_dev",
  "peniko",
  "skrifa 0.43.2",
@@ -2927,7 +2925,11 @@ dependencies = [
 name = "parley_core"
 version = "0.11.0"
 dependencies = [
+ "icu_normalizer",
  "icu_properties",
+ "icu_segmenter",
+ "parlance",
+ "parley_data",
 ]
 
 [[package]]

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -34,13 +34,11 @@ fontique = { workspace = true }
 parlance = { workspace = true }
 parley_core = { workspace = true }
 core_maths = { version = "0.1.1", optional = true }
-parley_data = { workspace = true, features = ["baked"] }
 accesskit = { workspace = true, optional = true }
 hashbrown = { workspace = true }
 harfrust = { workspace = true }
 icu_normalizer = { workspace = true, features = ["compiled_data"] }
 icu_properties = { workspace = true, features = ["compiled_data"] }
-icu_segmenter = { workspace = true, features = ["compiled_data"] }
 
 [dev-dependencies]
 parley_dev = { workspace = true }

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -18,14 +18,21 @@ workspace = true
 
 [features]
 default = ["system"]
-std = ["fontique/std", "harfrust/std", "peniko/std", "skrifa/std", "parlance/std"]
+std = [
+    "fontique/std",
+    "harfrust/std",
+    "parley_core/std",
+    "peniko/std",
+    "skrifa/std",
+    "parlance/std",
+]
 libm = ["fontique/libm", "harfrust/libm", "peniko/libm", "skrifa/libm", "dep:core_maths"]
 # Enables support for system font backends
 system = ["std", "fontique/system"]
 accesskit = ["dep:accesskit"]
 # Enables dictionary-based line and word breaking for complex scripts (CJK, Thai, Khmer, Lao, Myanmar).
 # When disabled, a lightweight segmenter is used that falls back to character-level breaks for those scripts.
-complex-scripts = []
+complex-scripts = ["parley_core/complex-scripts"]
 
 [dependencies]
 skrifa = { workspace = true }

--- a/parley/src/analysis.rs
+++ b/parley/src/analysis.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 the Parley Authors
+// Copyright 2026 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 pub(crate) mod cluster;

--- a/parley/src/analysis.rs
+++ b/parley/src/analysis.rs
@@ -10,6 +10,8 @@ use parley_core::break_overrides::LineBreakOverrideFn;
 
 use parley_core::{AnalysisDataSources, AnalysisOptions};
 
+use parlance::WordBreak;
+
 pub(crate) fn analyze_text<B: Brush>(
     lcx: &mut LayoutContext<B>,
     text: &str,
@@ -17,15 +19,14 @@ pub(crate) fn analyze_text<B: Brush>(
 ) {
     let text = if text.is_empty() { " " } else { text };
 
-    // Collect the style runs word breaks. Gaps are `WordBreak::Normal`, so only non-`Normal`s need
+    // Collect the style runs' word breaks. Gaps are `WordBreak::Normal`, so only non-`Normal`s need
     // an entry.
     lcx.word_break.clear();
-    lcx.word_break.extend(lcx.style_runs.iter().map(|sr| {
-        (
-            sr.range.clone(),
-            lcx.style_table[sr.style_index as usize].word_break,
-        )
-    }));
+    lcx.word_break
+        .extend(lcx.style_runs.iter().filter_map(|sr| {
+            let word_break = lcx.style_table[sr.style_index as usize].word_break;
+            (word_break != WordBreak::Normal).then(|| (sr.range.clone(), word_break))
+        }));
 
     let options = AnalysisOptions {
         word_break: &lcx.word_break,

--- a/parley/src/analysis.rs
+++ b/parley/src/analysis.rs
@@ -1,0 +1,57 @@
+// Copyright 2025 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+pub(crate) mod cluster;
+
+use crate::{Brush, LayoutContext};
+
+use icu_properties::props::{GeneralCategory, Script};
+use parley_core::break_overrides::LineBreakOverrideFn;
+
+use parley_core::{AnalysisDataSources, AnalysisOptions};
+
+pub(crate) fn analyze_text<B: Brush>(
+    lcx: &mut LayoutContext<B>,
+    text: &str,
+    line_break_override: Option<&LineBreakOverrideFn>,
+) {
+    let text = if text.is_empty() { " " } else { text };
+
+    // Collect the style runs word breaks. Gaps are `WordBreak::Normal`, so only non-`Normal`s need
+    // an entry.
+    lcx.word_break.clear();
+    lcx.word_break.extend(lcx.style_runs.iter().map(|sr| {
+        (
+            sr.range.clone(),
+            lcx.style_table[sr.style_index as usize].word_break,
+        )
+    }));
+
+    let options = AnalysisOptions {
+        word_break: &lcx.word_break,
+        line_break_override,
+    };
+    lcx.analyzer.analyze(text, &options, &mut lcx.analysis);
+
+    // Pair the char infos with style indices (which we set later in the builder).
+    lcx.info.clear();
+    lcx.info
+        .extend(lcx.analysis.char_info().iter().map(|&ci| (ci, 0)));
+}
+
+/// All characters contribute to shaping except:
+/// - Control characters
+/// - Format characters, unless they use the "Inherited" script
+#[inline(always)]
+pub(crate) fn contributes_to_shaping(general_category: GeneralCategory, script: Script) -> bool {
+    if matches!(
+        general_category,
+        GeneralCategory::Control
+            | GeneralCategory::LineSeparator
+            | GeneralCategory::ParagraphSeparator
+    ) {
+        return false;
+    }
+
+    !(general_category == GeneralCategory::Format && script != Script::Inherited)
+}

--- a/parley/src/analysis.rs
+++ b/parley/src/analysis.rs
@@ -33,11 +33,6 @@ pub(crate) fn analyze_text<B: Brush>(
         line_break_override,
     };
     lcx.analyzer.analyze(text, &options, &mut lcx.analysis);
-
-    // Pair the char infos with style indices (which we set later in the builder).
-    lcx.info.clear();
-    lcx.info
-        .extend(lcx.analysis.char_info().iter().map(|&ci| (ci, 0)));
 }
 
 /// All characters contribute to shaping except:

--- a/parley/src/analysis.rs
+++ b/parley/src/analysis.rs
@@ -42,6 +42,8 @@ pub(crate) fn analyze_text<B: Brush>(
 /// All characters contribute to shaping except:
 /// - Control characters
 /// - Format characters, unless they use the "Inherited" script
+// TODO: this function is duplicated at the time of writing, as it also exists in `parley_core`.
+// Once more of `parley` is moved to `parley_core`, this function should be removable.
 #[inline(always)]
 pub(crate) fn contributes_to_shaping(general_category: GeneralCategory, script: Script) -> bool {
     if matches!(

--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -307,7 +307,7 @@ fn build_into_layout<B: Brush>(
     layout.data.clear();
     layout.data.scale = scale;
     layout.data.quantize = quantize;
-    layout.data.base_level = lcx.bidi.base_level();
+    layout.data.base_level = lcx.analysis.paragraph_level();
     layout.data.text_len = text.len();
 
     let mut char_index = 0;
@@ -336,7 +336,7 @@ fn build_into_layout<B: Brush>(
             &lcx.style_table,
             &lcx.inline_boxes,
             &lcx.info,
-            lcx.bidi.levels(),
+            lcx.analysis.bidi_levels(),
             &mut lcx.scx,
             text,
             layout,

--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -310,10 +310,12 @@ fn build_into_layout<B: Brush>(
     layout.data.base_level = lcx.analysis.paragraph_level();
     layout.data.text_len = text.len();
 
+    lcx.char_style_indices
+        .resize(lcx.analysis.char_info().len(), 0);
     let mut char_index = 0;
     for style_run in &lcx.style_runs {
         for _ in text[style_run.range.clone()].chars() {
-            lcx.info[char_index].1 = style_run.style_index;
+            lcx.char_style_indices[char_index] = style_run.style_index;
             char_index += 1;
         }
     }
@@ -335,7 +337,8 @@ fn build_into_layout<B: Brush>(
             query,
             &lcx.style_table,
             &lcx.inline_boxes,
-            &lcx.info,
+            lcx.analysis.char_info(),
+            &lcx.char_style_indices,
             lcx.analysis.bidi_levels(),
             &mut lcx.scx,
             text,

--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -8,7 +8,7 @@ use core::ops::Range;
 use alloc::{vec, vec::Vec};
 
 use parlance::WordBreak;
-use parley_core::{Analysis, AnalysisDataSources, Analyzer, CharInfo};
+use parley_core::{Analysis, AnalysisDataSources, Analyzer};
 
 use super::FontContext;
 use super::builder::{RangedBuilder, StyleRunBuilder};
@@ -38,8 +38,8 @@ pub struct LayoutContext<B: Brush = [u8; 4]> {
     pub(crate) ranged_style_builder: RangedStyleBuilder<B>,
     pub(crate) tree_style_builder: TreeStyleBuilder<B>,
 
-    // u16: style index for character
-    pub(crate) info: Vec<(CharInfo, u16)>,
+    /// Style index for each character, parallel to [`Analysis::char_info`].
+    pub(crate) char_style_indices: Vec<u16>,
     pub(crate) scx: ShapeContext,
 
     // Unicode analysis data sources (provided by icu)
@@ -58,7 +58,7 @@ impl<B: Brush> LayoutContext<B> {
             word_break: Vec::new(),
             ranged_style_builder: RangedStyleBuilder::default(),
             tree_style_builder: TreeStyleBuilder::default(),
-            info: vec![],
+            char_style_indices: vec![],
             analysis_data_sources: AnalysisDataSources::new(),
             scx: ShapeContext::default(),
         }
@@ -194,7 +194,6 @@ impl<B: Brush> LayoutContext<B> {
         self.style_table.clear();
         self.style_runs.clear();
         self.inline_boxes.clear();
-        self.info.clear();
     }
 }
 

--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -3,9 +3,12 @@
 
 //! Context for layout.
 
+use core::ops::Range;
+
 use alloc::{vec, vec::Vec};
 
-use parley_core::bidi::BidiResolver;
+use parlance::WordBreak;
+use parley_core::{Analysis, AnalysisDataSources, Analyzer, CharInfo};
 
 use super::FontContext;
 use super::builder::{RangedBuilder, StyleRunBuilder};
@@ -13,7 +16,6 @@ use super::resolve::tree::TreeStyleBuilder;
 use super::resolve::{RangedStyleBuilder, ResolveContext, ResolvedStyle, StyleRun};
 use super::style::{Brush, TextStyle};
 
-use crate::analysis::{AnalysisDataSources, CharInfo};
 use crate::builder::TreeBuilder;
 use crate::inline_box::InlineBox;
 use crate::shape::ShapeContext;
@@ -26,7 +28,11 @@ pub struct LayoutContext<B: Brush = [u8; 4]> {
     pub(crate) style_table: Vec<ResolvedStyle<B>>,
     pub(crate) style_runs: Vec<StyleRun>,
     pub(crate) inline_boxes: Vec<InlineBox>,
-    pub(crate) bidi: BidiResolver,
+
+    // Reusable text analysis
+    pub(crate) analyzer: Analyzer,
+    pub(crate) analysis: Analysis,
+    pub(crate) word_break: Vec<(Range<usize>, WordBreak)>,
 
     // Reusable style builders (to amortise allocations)
     pub(crate) ranged_style_builder: RangedStyleBuilder<B>,
@@ -47,7 +53,9 @@ impl<B: Brush> LayoutContext<B> {
             style_table: vec![],
             style_runs: vec![],
             inline_boxes: vec![],
-            bidi: BidiResolver::new(),
+            analyzer: Analyzer::new(),
+            analysis: Analysis::new(),
+            word_break: Vec::new(),
             ranged_style_builder: RangedStyleBuilder::default(),
             tree_style_builder: TreeStyleBuilder::default(),
             info: vec![],
@@ -187,7 +195,6 @@ impl<B: Brush> LayoutContext<B> {
         self.style_runs.clear();
         self.inline_boxes.clear();
         self.info.clear();
-        self.bidi.clear();
     }
 }
 

--- a/parley/src/convert.rs
+++ b/parley/src/convert.rs
@@ -1,9 +1,8 @@
 // Copyright 2024 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::analysis::AnalysisDataSources;
-
 use icu_properties::props::Script;
+use parley_core::AnalysisDataSources;
 
 pub(crate) fn script_to_fontique(
     script: Script,

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -390,8 +390,9 @@ impl<B: Brush> LayoutData<B> {
         word_spacing: f32,
         letter_spacing: f32,
         source_text: &str,
-        char_infos: &[(CharInfo, u16)], // From text analysis
-        text_range: Range<usize>,       // The text range this run covers
+        char_infos: &[CharInfo], // From text analysis
+        char_style_indices: &[u16],
+        text_range: Range<usize>, // The text range this run covers
         coords: &[harfrust::NormalizedCoord],
     ) {
         let coords_start = self.coords.len();
@@ -493,6 +494,7 @@ impl<B: Brush> LayoutData<B> {
                 glyph_infos,
                 glyph_positions,
                 char_infos,
+                char_style_indices,
                 source_text.char_indices(),
             );
         } else {
@@ -504,6 +506,7 @@ impl<B: Brush> LayoutData<B> {
                 glyph_infos,
                 glyph_positions,
                 char_infos,
+                char_style_indices,
                 source_text.char_indices().rev(),
             );
             // Reverse clusters into logical order for RTL
@@ -655,16 +658,18 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
     scale_factor: f32,
     glyph_infos: &[harfrust::GlyphInfo],
     glyph_positions: &[harfrust::GlyphPosition],
-    char_infos: &[(CharInfo, u16)],
+    char_infos: &[CharInfo],
+    char_style_indices: &[u16],
     char_indices_iter: I,
 ) -> f32 {
+    let char_info_at = |i: usize| (char_infos[i], char_style_indices[i]);
     let mut char_indices_iter = char_indices_iter.peekable();
     let mut cluster_start_char = char_indices_iter.next().unwrap();
     let mut total_glyphs: u32 = 0;
     let mut cluster_glyph_offset: u32 = 0;
     let start_cluster_id = glyph_infos.first().unwrap().cluster;
     let mut cluster_id = start_cluster_id;
-    let mut char_info = char_infos[cluster_id as usize];
+    let mut char_info = char_info_at(cluster_id as usize);
     let mut run_advance = 0.0;
     let mut cluster_advance = 0.0;
     // If the current cluster might be a single-glyph, zero-offset cluster, we defer
@@ -755,8 +760,8 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
                         break;
                     }
                     let char_info_ = match direction {
-                        Direction::Ltr => char_infos[(cluster_id + i) as usize],
-                        Direction::Rtl => char_infos[(cluster_id + num_components - i) as usize],
+                        Direction::Ltr => char_info_at((cluster_id + i) as usize),
+                        Direction::Rtl => char_info_at((cluster_id + num_components - i) as usize),
                     };
                     push_cluster(
                         clusters,
@@ -775,7 +780,7 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
             cluster_advance = 0.0;
             last_cluster_id = cluster_id;
             cluster_id = glyph_info.cluster;
-            char_info = char_infos[cluster_id as usize];
+            char_info = char_info_at(cluster_id as usize);
             pending_inline_glyph = None;
         }
 
@@ -838,8 +843,8 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
                     break;
                 }
                 let component_char_info = match direction {
-                    Direction::Ltr => char_infos[(cluster_id + i) as usize],
-                    Direction::Rtl => char_infos[(cluster_id + num_components - i) as usize],
+                    Direction::Ltr => char_info_at((cluster_id + i) as usize),
+                    Direction::Rtl => char_info_at((cluster_id + num_components - i) as usize),
                 };
                 push_cluster(
                     clusters,

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -9,9 +9,9 @@ use crate::{FontData, IndentOptions, InlineBoxKind, LineHeight, OverflowWrap, Te
 use core::ops::Range;
 
 use alloc::vec::Vec;
+use parley_core::{Boundary, CharInfo};
 
 use crate::analysis::cluster::Whitespace;
-use crate::analysis::{Boundary, CharInfo};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) struct ClusterData {

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -9,7 +9,6 @@ use alloc::vec::Vec;
 #[allow(unused_imports)]
 use core_maths::CoreFloat;
 
-use crate::analysis::Boundary;
 use crate::analysis::cluster::Whitespace;
 use crate::data::ClusterData;
 use crate::layout::{
@@ -20,6 +19,7 @@ use crate::style::Brush;
 use crate::{InlineBoxKind, OverflowWrap, TextWrapMode};
 
 use core::ops::Range;
+use parley_core::Boundary;
 
 #[derive(Default)]
 struct LineLayout {

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -8,12 +8,12 @@ use alloc::vec::Vec;
 use core::mem;
 use core::ops::RangeInclusive;
 use harfrust::ShapeOptions;
+use parley_core::{AnalysisDataSources, CharInfo};
 
 use super::layout::Layout;
 use super::resolve::{ResolveContext, Resolved, ResolvedStyle};
 use super::style::{Brush, FontFeature, FontVariation};
 use crate::analysis::cluster::{Char, CharCluster, Status};
-use crate::analysis::{AnalysisDataSources, CharInfo};
 use crate::convert::script_to_harfrust;
 use crate::inline_box::InlineBox;
 use crate::lru_cache::LruCache;

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -67,7 +67,8 @@ pub(crate) fn shape_text<'a, B: Brush>(
     mut fq: Query<'a>,
     styles: &'a [ResolvedStyle<B>],
     inline_boxes: &[InlineBox],
-    infos: &[(CharInfo, u16)],
+    char_info: &[CharInfo],
+    char_style_indices: &[u16],
     levels: &[u8],
     scx: &mut ShapeContext,
     mut text: &str,
@@ -90,15 +91,15 @@ pub(crate) fn shape_text<'a, B: Brush>(
     }
 
     // Setup mutable state for iteration
-    let initial_style_index = infos.first().map_or(0, |(_, style_index)| *style_index);
+    let initial_style_index = char_style_indices.first().copied().unwrap_or(0);
     let mut style = &styles[initial_style_index as usize];
     let mut item = Item {
         style_index: initial_style_index,
         size: style.font_size,
         level: levels.first().copied().unwrap_or(0),
-        script: infos
+        script: char_info
             .iter()
-            .map(|x| x.0.script)
+            .map(|x| x.script)
             .find(|&script| real_script(script))
             .unwrap_or(Script::Latin),
         locale: style.locale,
@@ -115,8 +116,10 @@ pub(crate) fn shape_text<'a, B: Brush>(
     let mut current_box = inline_box_iter.next();
 
     // Iterate over characters in the text
-    for ((char_index, (byte_index, ch)), (info, style_index)) in
-        text.char_indices().enumerate().zip(infos)
+    for ((char_index, (byte_index, ch)), (info, style_index)) in text
+        .char_indices()
+        .enumerate()
+        .zip(char_info.iter().zip(char_style_indices))
     {
         let mut break_run = false;
         let mut script = info.script;
@@ -173,7 +176,8 @@ pub(crate) fn shape_text<'a, B: Brush>(
                 text,
                 &text_range,
                 &char_range,
-                infos,
+                char_info,
+                char_style_indices,
                 layout,
                 analysis_data_sources,
             );
@@ -209,7 +213,8 @@ pub(crate) fn shape_text<'a, B: Brush>(
             text,
             &text_range,
             &char_range,
-            infos,
+            char_info,
+            char_style_indices,
             layout,
             analysis_data_sources,
         );
@@ -228,7 +233,7 @@ pub(crate) fn shape_text<'a, B: Brush>(
 // for the given grapheme `segment_text`, consuming items from `item_infos_iter`.
 fn fill_cluster_in_place(
     segment_text: &str,
-    item_infos_iter: &mut core::slice::Iter<'_, (CharInfo, u16)>,
+    item_infos_iter: &mut impl Iterator<Item = (CharInfo, u16)>,
     code_unit_offset_in_string: &mut usize,
     char_cluster: &mut CharCluster,
 ) {
@@ -274,7 +279,7 @@ fn fill_cluster_in_place(
             ch,
             contributes_to_shaping,
             glyph_id: 0,
-            style_index: *style_index,
+            style_index,
             is_control_character: info.is_control(),
         });
     }
@@ -297,13 +302,18 @@ fn shape_item<'a, B: Brush>(
     text: &str,
     text_range: &core::ops::Range<usize>,
     char_range: &core::ops::Range<usize>,
-    infos: &[(CharInfo, u16)],
+    char_info: &[CharInfo],
+    char_style_indices: &[u16],
     layout: &mut Layout<B>,
     analysis_data_sources: &AnalysisDataSources,
 ) {
     let item_text = &text[text_range.clone()];
-    let item_infos = &infos[char_range.start..char_range.end]; // Only process current item
-    let first_style_index = item_infos[0].1;
+
+    // Only process current item
+    let item_char_info = &char_info[char_range.start..char_range.end];
+    let item_char_style_indices = &char_style_indices[char_range.start..char_range.end];
+    let first_style_index = item_char_style_indices[0];
+
     let fb_script = convert::script_to_fontique(item.script, analysis_data_sources);
     let mut font_selector =
         FontSelector::new(fq, rcx, styles, first_style_index, fb_script, item.locale);
@@ -311,7 +321,10 @@ fn shape_item<'a, B: Brush>(
     let grapheme_cluster_boundaries = analysis_data_sources
         .grapheme_segmenter()
         .segment_str(item_text);
-    let mut item_infos_iter = item_infos.iter();
+    let mut item_infos_iter = item_char_info
+        .iter()
+        .copied()
+        .zip(item_char_style_indices.iter().copied());
     let mut code_unit_offset_in_string = text_range.start;
     let char_cluster = &mut scx.char_cluster;
 
@@ -474,8 +487,10 @@ fn shape_item<'a, B: Brush>(
         let char_start = char_range.start + item_text[..segment_start_offset].chars().count();
         let segment_char_start = char_start - char_range.start;
         let segment_char_count = segment_text.chars().count();
-        let segment_infos =
-            &item_infos[segment_char_start..(segment_char_start + segment_char_count)];
+        let segment_char_info =
+            &item_char_info[segment_char_start..(segment_char_start + segment_char_count)];
+        let segment_char_style_indices =
+            &item_char_style_indices[segment_char_start..(segment_char_start + segment_char_count)];
 
         // Push harfrust-shaped run for the entire segment
         layout.data.push_run(
@@ -489,7 +504,8 @@ fn shape_item<'a, B: Brush>(
             item.word_spacing,
             item.letter_spacing,
             segment_text,
-            segment_infos,
+            segment_char_info,
+            segment_char_style_indices,
             (text_range.start + segment_start_offset)..(text_range.start + segment_end_offset),
             harf_shaper.coords(),
         );

--- a/parley/src/tests/test_analysis.rs
+++ b/parley/src/tests/test_analysis.rs
@@ -17,9 +17,10 @@ impl TestContext {
     fn expect_boundary_list(self, expected: Vec<Boundary>) -> Self {
         let actual: Vec<_> = self
             .layout_context
-            .info
+            .analysis
+            .char_info()
             .iter()
-            .map(|(info, _)| info.boundary)
+            .map(|info| info.boundary)
             .collect();
         assert_eq!(actual, expected, "Boundary list mismatch");
         self
@@ -34,9 +35,10 @@ impl TestContext {
     fn expect_script_list(self, expected: Vec<Script>) -> Self {
         let actual: Vec<_> = self
             .layout_context
-            .info
+            .analysis
+            .char_info()
             .iter()
-            .map(|(info, _)| info.script)
+            .map(|info| info.script)
             .collect();
         assert_eq!(actual, expected, "Script list mismatch");
         self
@@ -45,9 +47,10 @@ impl TestContext {
     fn expect_grapheme_cluster_break_list(self, expected: Vec<GraphemeClusterBreak>) -> Self {
         let actual: Vec<_> = self
             .layout_context
-            .info
+            .analysis
+            .char_info()
             .iter()
-            .map(|(info, _)| info.grapheme_cluster_break)
+            .map(|info| info.grapheme_cluster_break)
             .collect();
         assert_eq!(actual, expected, "Grapheme cluster break list mismatch");
         self
@@ -56,9 +59,10 @@ impl TestContext {
     fn expect_is_control_list(self, expected: Vec<bool>) -> Self {
         let actual: Vec<_> = self
             .layout_context
-            .info
+            .analysis
+            .char_info()
             .iter()
-            .map(|(info, _)| info.is_control())
+            .map(|info| info.is_control())
             .collect();
         assert_eq!(actual, expected, "Is control list mismatch");
         self
@@ -67,9 +71,10 @@ impl TestContext {
     fn expect_contributes_to_shaping_list(self, expected: Vec<bool>) -> Self {
         let actual: Vec<_> = self
             .layout_context
-            .info
+            .analysis
+            .char_info()
             .iter()
-            .map(|(info, _)| info.contributes_to_shaping())
+            .map(|info| info.contributes_to_shaping())
             .collect();
         assert_eq!(actual, expected, "Contributes to shaping list mismatch");
         self
@@ -78,9 +83,10 @@ impl TestContext {
     fn expect_force_normalize_list(self, expected: Vec<bool>) -> Self {
         let actual: Vec<_> = self
             .layout_context
-            .info
+            .analysis
+            .char_info()
             .iter()
-            .map(|(info, _)| info.force_normalize())
+            .map(|info| info.force_normalize())
             .collect();
         assert_eq!(actual, expected, "Force normalize list mismatch");
         self
@@ -89,9 +95,10 @@ impl TestContext {
     fn expect_is_emoji_or_pictograph_list(self, expected: Vec<bool>) -> Self {
         let actual: Vec<_> = self
             .layout_context
-            .info
+            .analysis
+            .char_info()
             .iter()
-            .map(|(info, _)| info.is_emoji_or_pictograph())
+            .map(|info| info.is_emoji_or_pictograph())
             .collect();
         assert_eq!(actual, expected, "Is emoji or pictograph list mismatch");
         self
@@ -100,9 +107,10 @@ impl TestContext {
     fn expect_is_variation_selector_list(self, expected: Vec<bool>) -> Self {
         let actual: Vec<_> = self
             .layout_context
-            .info
+            .analysis
+            .char_info()
             .iter()
-            .map(|(info, _)| info.is_variation_selector())
+            .map(|info| info.is_variation_selector())
             .collect();
         assert_eq!(actual, expected, "Is variation selector list mismatch");
         self
@@ -110,9 +118,10 @@ impl TestContext {
 
     fn boundary_list(&self) -> Vec<Boundary> {
         self.layout_context
-            .info
+            .analysis
+            .char_info()
             .iter()
-            .map(|(info, _)| info.boundary)
+            .map(|info| info.boundary)
             .collect()
     }
 }

--- a/parley/src/tests/test_analysis.rs
+++ b/parley/src/tests/test_analysis.rs
@@ -1,11 +1,11 @@
 // Copyright 2025 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::analysis::Boundary;
 use crate::{FontContext, LayoutContext, RangedBuilder, StyleProperty, WordBreak};
 use alloc::{vec, vec::Vec};
 use fontique::FontWeight;
 use icu_properties::props::{GraphemeClusterBreak, Script};
+use parley_core::Boundary;
 
 #[derive(Default)]
 struct TestContext {
@@ -26,7 +26,7 @@ impl TestContext {
     }
 
     fn expect_bidi_embed_level_list(self, expected: Vec<u8>) -> Self {
-        let actual = self.layout_context.bidi.levels();
+        let actual = self.layout_context.analysis.bidi_levels();
         assert_eq!(actual, expected, "Bidi embed level list mismatch");
         self
     }

--- a/parley_core/Cargo.toml
+++ b/parley_core/Cargo.toml
@@ -15,9 +15,17 @@ all-features = true
 [features]
 default = ["std"]
 std = []
+# Enables dictionary-based line and word breaking for complex scripts (CJK, Thai, Khmer, Lao, Myanmar).
+# When disabled, a lightweight segmenter is used that falls back to character-level breaks for those scripts.
+complex-scripts = []
 
 [dependencies]
+parlance = { workspace = true }
+parley_data = { workspace = true, features = ["baked"] }
+
+icu_normalizer = { workspace = true, features = ["compiled_data"] }
 icu_properties = { workspace = true, features = ["compiled_data"] }
+icu_segmenter = { workspace = true, features = ["compiled_data"] }
 
 [lints]
 workspace = true

--- a/parley_core/src/analysis.rs
+++ b/parley_core/src/analysis.rs
@@ -48,6 +48,7 @@ impl Analysis {
     /// Create a reusable [`Analysis`].
     ///
     /// Pass this to [`Analyzer::analyze`].
+    #[inline]
     pub fn new() -> Self {
         Self::default()
     }
@@ -60,6 +61,7 @@ impl Analysis {
     }
 
     /// The per-character info in source order.
+    #[inline(always)]
     pub fn char_info(&self) -> &[CharInfo] {
         &self.info
     }
@@ -67,11 +69,13 @@ impl Analysis {
     /// The bidi level for each character, parallel to [`Self::char_info`].
     ///
     /// Empty when the whole paragraph is left-to-right.
+    #[inline(always)]
     pub fn bidi_levels(&self) -> &[u8] {
         &self.levels
     }
 
     /// The base bidi level of the paragraph of text.
+    #[inline(always)]
     pub fn paragraph_level(&self) -> u8 {
         self.paragraph_level
     }

--- a/parley_core/src/analysis.rs
+++ b/parley_core/src/analysis.rs
@@ -1,13 +1,13 @@
 // Copyright 2025 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-pub(crate) mod cluster;
+//! Text analysis.
+//!
+//! Analysis is performed prior to shaping and is independent of fonts, turning a `&str` into
+//! [`Analysis`].
 
 use alloc::vec::Vec;
-use core::marker::PhantomData;
-
-use crate::resolve::StyleRun;
-use crate::{Brush, LayoutContext, WordBreak};
+use core::ops::Range;
 
 use icu_normalizer::properties::{
     CanonicalComposition, CanonicalCompositionBorrowed, CanonicalDecomposition,
@@ -22,25 +22,79 @@ use icu_segmenter::{
     GraphemeClusterSegmenter, GraphemeClusterSegmenterBorrowed, LineSegmenter,
     LineSegmenterBorrowed, WordSegmenter, WordSegmenterBorrowed,
 };
-use parley_core::break_overrides::{LineBreakContext, LineBreakOverrideFn};
+use parlance::WordBreak;
 use parley_data::Properties;
 
-use parley_core::bidi;
+use crate::bidi;
+use crate::break_overrides::LineBreakContext;
+use crate::{AnalysisOptions, Analyzer};
 
-pub(crate) struct AnalysisDataSources;
+/// The result of [`Analyzer::analyze`].
+#[derive(Debug, Default)]
+pub struct Analysis {
+    /// Info for each character.
+    pub(crate) info: Vec<CharInfo>,
+
+    /// Bidi level for each character, parallel to `info`.
+    ///
+    /// Empty if the text is all LTR.
+    pub(crate) levels: Vec<u8>,
+
+    /// The base bidi level of the paragraph of text.
+    pub(crate) paragraph_level: u8,
+}
+
+impl Analysis {
+    /// Create a reusable [`Analysis`].
+    ///
+    /// Pass this to [`Analyzer::analyze`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Clear the result while retaining capacity.
+    pub(crate) fn clear(&mut self) {
+        self.info.clear();
+        self.levels.clear();
+        self.paragraph_level = 0;
+    }
+
+    /// The per-character info in source order.
+    pub fn char_info(&self) -> &[CharInfo] {
+        &self.info
+    }
+
+    /// The bidi level for each character, parallel to [`Self::char_info`].
+    ///
+    /// Empty when the whole paragraph is left-to-right.
+    pub fn bidi_levels(&self) -> &[u8] {
+        &self.levels
+    }
+
+    /// The base bidi level of the paragraph of text.
+    pub fn paragraph_level(&self) -> u8 {
+        self.paragraph_level
+    }
+}
+
+// TODO: Make `pub(crate)` once `parley_core` owns shaping.
+#[doc(hidden)]
+#[expect(missing_debug_implementations, reason = "Will become private")]
+pub struct AnalysisDataSources;
 
 impl AnalysisDataSources {
-    pub(crate) fn new() -> Self {
+    #[expect(clippy::new_without_default, reason = "Will become private")]
+    pub fn new() -> Self {
         Self
     }
 
     #[inline(always)]
-    pub(crate) fn properties(&self, c: char) -> Properties {
+    pub fn properties(&self, c: char) -> Properties {
         Properties::get(c)
     }
 
     #[inline(always)]
-    pub(crate) fn grapheme_segmenter(&self) -> GraphemeClusterSegmenterBorrowed<'_> {
+    pub fn grapheme_segmenter(&self) -> GraphemeClusterSegmenterBorrowed<'_> {
         const { GraphemeClusterSegmenter::new() }
     }
 
@@ -78,17 +132,17 @@ impl AnalysisDataSources {
     }
 
     #[inline(always)]
-    fn composing_normalizer(&self) -> CanonicalCompositionBorrowed<'_> {
+    pub fn composing_normalizer(&self) -> CanonicalCompositionBorrowed<'_> {
         const { CanonicalComposition::new() }
     }
 
     #[inline(always)]
-    fn decomposing_normalizer(&self) -> CanonicalDecompositionBorrowed<'_> {
+    pub fn decomposing_normalizer(&self) -> CanonicalDecompositionBorrowed<'_> {
         const { CanonicalDecomposition::new() }
     }
 
     #[inline(always)]
-    pub(crate) fn script_short_name(&self) -> PropertyNamesShortBorrowed<'static, Script> {
+    pub fn script_short_name(&self) -> PropertyNamesShortBorrowed<'static, Script> {
         PropertyNamesShort::new()
     }
 
@@ -110,8 +164,9 @@ fn line_segmenter_impl(opt: LineBreakOptions<'_>) -> LineSegmenterBorrowed<'stat
     LineSegmenter::new_for_non_complex_scripts(opt)
 }
 
+/// Per-character analysis info.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub(crate) struct CharInfo {
+pub struct CharInfo {
     /// The line/word breaking boundary classification of this character.
     pub boundary: Boundary,
     /// The Unicode script this character belongs to.
@@ -177,41 +232,40 @@ impl CharInfo {
         }
     }
 
-    #[allow(
-        dead_code,
-        reason = "To be used in more complete emoji checking, in select_font"
-    )]
+    /// Whether this character is a variation selector.
     #[inline(always)]
-    pub(crate) fn is_variation_selector(self) -> bool {
+    pub fn is_variation_selector(self) -> bool {
         self.flags & Self::VARIATION_SELECTOR_MASK != 0
     }
 
-    #[allow(
-        dead_code,
-        reason = "To be used in more complete emoji checking, in select_font"
-    )]
+    /// Whether this character is a regional indicator symbol.
     #[inline(always)]
-    pub(crate) fn is_region_indicator(self) -> bool {
+    pub fn is_region_indicator(self) -> bool {
         self.flags & Self::REGION_INDICATOR_MASK != 0
     }
 
+    /// Whether this character is a control character.
     #[inline(always)]
-    pub(crate) fn is_control(self) -> bool {
+    pub fn is_control(self) -> bool {
         self.flags & Self::CONTROL_MASK != 0
     }
 
+    /// Whether this character is an emoji or pictograph.
     #[inline(always)]
-    pub(crate) fn is_emoji_or_pictograph(self) -> bool {
+    pub fn is_emoji_or_pictograph(self) -> bool {
         self.flags & Self::EMOJI_OR_PICTOGRAPH_MASK != 0
     }
 
+    /// Whether this character contributes glyphs to shaping (`false` for control characters and
+    /// most format characters).
     #[inline(always)]
-    pub(crate) fn contributes_to_shaping(self) -> bool {
+    pub fn contributes_to_shaping(self) -> bool {
         self.flags & Self::CONTRIBUTES_TO_SHAPING_MASK != 0
     }
 
+    /// Whether this character should be normalized before glyph mapping during shaping.
     #[inline(always)]
-    pub(crate) fn force_normalize(self) -> bool {
+    pub fn force_normalize(self) -> bool {
         self.flags & Self::FORCE_NORMALIZE_MASK != 0
     }
 }
@@ -219,7 +273,7 @@ impl CharInfo {
 /// Boundary type of a character or cluster.
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug)]
 #[repr(u8)]
-pub(crate) enum Boundary {
+pub enum Boundary {
     /// Not a boundary.
     None = 0,
     /// Start of a word.
@@ -230,54 +284,99 @@ pub(crate) enum Boundary {
     Mandatory = 3,
 }
 
-pub(crate) fn analyze_text<B: Brush>(
-    lcx: &mut LayoutContext<B>,
-    mut text: &str,
-    line_break_override: Option<&LineBreakOverrideFn>,
+pub(crate) fn analyze_text(
+    analyzer: &mut Analyzer,
+    text: &str,
+    options: &AnalysisOptions<'_>,
+    analysis: &mut Analysis,
 ) {
-    struct WordBreakSegmentIter<'a, I: Iterator, B: Brush> {
+    /// Turns the sparse, sorted, non-overlapping `options.word_break` into a contiguous sequence of
+    /// `(range, word-break)` segments covering all of `text`.
+    ///
+    /// Any region not covered by an override takes the default `WordBreak::Normal`.
+    struct DenseWordBreaks<'a> {
+        word_break: &'a [(Range<usize>, WordBreak)],
+        /// Index of the next word break to emit.
+        next: usize,
+        /// Start of the next segment to emit.
+        cursor: usize,
+        text_len: usize,
+    }
+
+    impl<'a> DenseWordBreaks<'a> {
+        fn new(word_break: &'a [(Range<usize>, WordBreak)], text_len: usize) -> Self {
+            Self {
+                word_break,
+                next: 0,
+                cursor: 0,
+                text_len,
+            }
+        }
+    }
+
+    impl Iterator for DenseWordBreaks<'_> {
+        type Item = (Range<usize>, WordBreak);
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.cursor >= self.text_len {
+                return None;
+            }
+            match self.word_break.get(self.next) {
+                // A gap before the next override: fill it with the default up to its start.
+                Some((range, _)) if self.cursor < range.start => {
+                    let segment = self.cursor..range.start;
+                    self.cursor = range.start;
+                    Some((segment, WordBreak::Normal))
+                }
+                // At the next override: emit it.
+                Some((range, word_break)) => {
+                    self.cursor = range.end;
+                    self.next += 1;
+                    Some((range.start..range.end, *word_break))
+                }
+                // No overrides remain: fill the default to the end.
+                None => {
+                    let segment = self.cursor..self.text_len;
+                    self.cursor = self.text_len;
+                    Some((segment, WordBreak::Normal))
+                }
+            }
+        }
+    }
+
+    struct WordBreakSegmentIter<'a, I: Iterator> {
         text: &'a str,
-        style_runs: I,
-        lcx: &'a LayoutContext<B>,
+        segments: I,
         char_indices: core::str::CharIndices<'a>,
         current_char: (usize, char),
         building_range_start: usize,
         previous_word_break_style: WordBreak,
         done: bool,
-        _phantom: PhantomData<B>,
     }
 
-    impl<'a, I, B: Brush + 'a> WordBreakSegmentIter<'a, I, B>
+    impl<'a, I> WordBreakSegmentIter<'a, I>
     where
-        I: Iterator<Item = &'a StyleRun>,
+        I: Iterator<Item = (Range<usize>, WordBreak)>,
     {
-        fn new(
-            text: &'a str,
-            style_runs: I,
-            lcx: &'a LayoutContext<B>,
-            first_style_run: &StyleRun,
-        ) -> Self {
+        fn new(text: &'a str, segments: I, first_segment: (Range<usize>, WordBreak)) -> Self {
             let mut char_indices = text.char_indices();
             let current_char_len = char_indices.next().unwrap();
-            let first_style = &lcx.style_table[first_style_run.style_index as usize];
 
             Self {
                 text,
-                style_runs,
-                lcx,
+                segments,
                 char_indices,
                 current_char: current_char_len,
-                building_range_start: first_style_run.range.start,
-                previous_word_break_style: first_style.word_break,
+                building_range_start: first_segment.0.start,
+                previous_word_break_style: first_segment.1,
                 done: false,
-                _phantom: PhantomData,
             }
         }
     }
 
-    impl<'a, I, B: Brush + 'a> Iterator for WordBreakSegmentIter<'a, I, B>
+    impl<'a, I> Iterator for WordBreakSegmentIter<'a, I>
     where
-        I: Iterator<Item = &'a StyleRun>,
+        I: Iterator<Item = (Range<usize>, WordBreak)>,
     {
         type Item = (&'a str, WordBreak, bool);
 
@@ -286,11 +385,10 @@ pub(crate) fn analyze_text<B: Brush>(
                 return None;
             }
 
-            for style_run in self.style_runs.by_ref() {
-                // Empty style ranges are disallowed.
-                assert!(style_run.range.start < style_run.range.end);
+            for (range, word_break) in self.segments.by_ref() {
+                assert!(range.start < range.end, "Segments must not be empty");
 
-                let style_start_index = style_run.range.start;
+                let style_start_index = range.start;
                 let mut prev_char_index = self.current_char;
 
                 // Find the character at the style boundary
@@ -299,8 +397,7 @@ pub(crate) fn analyze_text<B: Brush>(
                     self.current_char = self.char_indices.next().unwrap();
                 }
 
-                let current_word_break_style =
-                    self.lcx.style_table[style_run.style_index as usize].word_break;
+                let current_word_break_style = word_break;
                 if self.previous_word_break_style == current_word_break_style {
                     continue;
                 }
@@ -326,29 +423,29 @@ pub(crate) fn analyze_text<B: Brush>(
     }
 
     if text.is_empty() {
-        text = " ";
+        return;
     }
 
     // Line boundaries (word break naming refers to the line boundary determination config).
     //
     // This breaks text into sequences with similar line boundary config (part of style
     // information). If this config is consistent for all text, we use a fast path through this.
-    let (first_style_run, rest_runs) = lcx
-        .style_runs
-        .split_first()
-        .expect("analyze_text requires at least one style run");
+    let mut segments = DenseWordBreaks::new(options.word_break, text.len());
+    // `text` is non-empty (checked above), so there is always at least one segment.
+    let first_segment = segments.next().unwrap();
+    let contiguous_word_break_substrings = WordBreakSegmentIter::new(text, segments, first_segment);
 
-    let contiguous_word_break_substrings =
-        WordBreakSegmentIter::new(text, rest_runs.iter(), lcx, first_style_run);
     let mut global_offset = 0;
     let mut line_boundary_positions: Vec<usize> = Vec::new();
+
+    let data_sources = AnalysisDataSources::new();
+
     for (substring_index, (substring, word_break_strength, last)) in
         contiguous_word_break_substrings.enumerate()
     {
         // Fast path for text with a single word-break option.
         if substring_index == 0 && last {
-            let mut lb_iter = lcx
-                .analysis_data_sources
+            let mut lb_iter = data_sources
                 .line_segmenter(word_break_strength)
                 .segment_str(substring);
 
@@ -370,8 +467,7 @@ pub(crate) fn analyze_text<B: Brush>(
             break;
         }
 
-        let line_boundaries_iter = lcx
-            .analysis_data_sources
+        let line_boundaries_iter = data_sources
             .line_segmenter(word_break_strength)
             .segment_str(substring);
 
@@ -405,11 +501,7 @@ pub(crate) fn analyze_text<B: Brush>(
     }
 
     // Collect boundary byte positions compactly
-    let mut wb_iter = lcx
-        .analysis_data_sources
-        .word_segmenter()
-        .segment_str(text)
-        .peekable();
+    let mut wb_iter = data_sources.word_segmenter().segment_str(text).peekable();
 
     // Merge boundaries - line takes precedence over word
     let mut lb_iter = line_boundary_positions.iter().peekable();
@@ -449,7 +541,7 @@ pub(crate) fn analyze_text<B: Brush>(
         }
 
         // This leaves word boundaries intact. Consumers can only impact line boundaries.
-        if let (Some(prev), Some(lb_override)) = (prev_char, line_break_override) {
+        if let (Some(prev), Some(lb_override)) = (prev_char, options.line_break_override) {
             let forced = lb_override(LineBreakContext {
                 before_before: prev_prev_char,
                 before: prev,
@@ -473,11 +565,11 @@ pub(crate) fn analyze_text<B: Brush>(
         (boundary, ch)
     });
 
-    let properties = |c| lcx.analysis_data_sources.properties(c);
+    let properties = |c| data_sources.properties(c);
 
     let mut needs_bidi_resolution = false;
 
-    lcx.info.reserve(text.len());
+    analysis.info.reserve(text.len());
     boundary_iter
         // Shift line break data forward one, as line boundaries corresponding with line-breaking
         // characters (like '\n') exist at an index position one higher than the respective
@@ -515,37 +607,39 @@ pub(crate) fn analyze_text<B: Brush>(
 
             needs_bidi_resolution |= bidi::needs_bidi_resolution(bidi_class);
             // TODO: maybe extend Properties to u64 to fit BidiMirroringGlyph
-            let bracket = lcx.analysis_data_sources.brackets().get(ch);
+            let bracket = data_sources.brackets().get(ch);
+            analyzer.bidi_props.push((bidi_class, bracket));
 
-            lcx.info.push((
-                CharInfo::new(
-                    boundary,
-                    script,
-                    grapheme_cluster_break,
-                    bidi_class,
-                    bracket,
-                    is_variation_selector,
-                    is_region_indicator,
-                    general_category == GeneralCategory::Control,
-                    is_emoji_or_pictograph,
-                    contributes_to_shaping(general_category, script),
-                    force_normalize,
-                ),
-                0, // Style index is populated later
+            analysis.info.push(CharInfo::new(
+                boundary,
+                script,
+                grapheme_cluster_break,
+                bidi_class,
+                bracket,
+                is_variation_selector,
+                is_region_indicator,
+                general_category == GeneralCategory::Control,
+                is_emoji_or_pictograph,
+                contributes_to_shaping(general_category, script),
+                force_normalize,
             ));
 
             next_mandatory_linebreak
         });
 
     if needs_bidi_resolution {
-        lcx.bidi.resolve(
+        analyzer.bidi.resolve(
             text.chars().zip(
-                lcx.info
+                analysis
+                    .info
                     .iter()
-                    .map(|info| (info.0.bidi_class, info.0.bracket)),
+                    .map(|info| (info.bidi_class, info.bracket)),
             ),
             None,
         );
+        // TODO: perhaps core::mem::swap?
+        analysis.levels.extend_from_slice(analyzer.bidi.levels());
+        analysis.paragraph_level = analyzer.bidi.base_level();
     }
 }
 

--- a/parley_core/src/analysis.rs
+++ b/parley_core/src/analysis.rs
@@ -640,8 +640,7 @@ pub(crate) fn analyze_text(
             ),
             None,
         );
-        // TODO: perhaps core::mem::swap?
-        analysis.levels.extend_from_slice(analyzer.bidi.levels());
+        core::mem::swap(&mut analysis.levels, &mut analyzer.bidi.levels);
         analysis.paragraph_level = analyzer.bidi.base_level();
     }
 }

--- a/parley_core/src/analysis.rs
+++ b/parley_core/src/analysis.rs
@@ -608,7 +608,6 @@ pub(crate) fn analyze_text(
             needs_bidi_resolution |= bidi::needs_bidi_resolution(bidi_class);
             // TODO: maybe extend Properties to u64 to fit BidiMirroringGlyph
             let bracket = data_sources.brackets().get(ch);
-            analyzer.bidi_props.push((bidi_class, bracket));
 
             analysis.info.push(CharInfo::new(
                 boundary,

--- a/parley_core/src/analyzer.rs
+++ b/parley_core/src/analyzer.rs
@@ -5,8 +5,6 @@
 
 use core::ops::Range;
 
-use alloc::vec::Vec;
-use icu_properties::props::{BidiClass, BidiMirroringGlyph};
 use parlance::WordBreak;
 
 use crate::{bidi::BidiResolver, break_overrides::LineBreakOverrideFn};
@@ -17,7 +15,6 @@ use crate::analysis::{Analysis, analyze_text};
 #[derive(Default)]
 pub struct Analyzer {
     pub(crate) bidi: BidiResolver,
-    pub(crate) bidi_props: Vec<(BidiClass, BidiMirroringGlyph)>,
 }
 
 impl core::fmt::Debug for Analyzer {

--- a/parley_core/src/analyzer.rs
+++ b/parley_core/src/analyzer.rs
@@ -1,0 +1,62 @@
+// Copyright 2026 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! The analyzer API.
+
+use core::ops::Range;
+
+use alloc::vec::Vec;
+use icu_properties::props::{BidiClass, BidiMirroringGlyph};
+use parlance::WordBreak;
+
+use crate::{bidi::BidiResolver, break_overrides::LineBreakOverrideFn};
+
+use crate::analysis::{Analysis, analyze_text};
+
+/// Reusable scratch for [`Analyzer::analyze`].
+#[derive(Default)]
+pub struct Analyzer {
+    pub(crate) bidi: BidiResolver,
+    pub(crate) bidi_props: Vec<(BidiClass, BidiMirroringGlyph)>,
+}
+
+impl core::fmt::Debug for Analyzer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Analyzer").finish_non_exhaustive()
+    }
+}
+
+impl Analyzer {
+    /// Creates a new analyzer.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Analyze `text`, overwriting `analysis`.
+    ///
+    /// This reuses the allocations of `analysis`.
+    pub fn analyze(&mut self, text: &str, options: &AnalysisOptions<'_>, analysis: &mut Analysis) {
+        analysis.clear();
+        analyze_text(self, text, options, analysis);
+    }
+}
+
+/// Options controlling [`Analyzer::analyze`].
+#[derive(Clone, Copy)]
+pub struct AnalysisOptions<'a> {
+    /// Word break configuration for ranges of the source text.
+    ///
+    /// Ranges must be sorted and non-overlapping. Gaps use [`WordBreak::Normal`].
+    pub word_break: &'a [(Range<usize>, WordBreak)],
+
+    /// The callback which will be called as a first provider of line breaking decisions.
+    ///
+    /// See [`LineBreakOverrideFn`] for more details.
+    pub line_break_override: Option<&'a LineBreakOverrideFn>,
+}
+
+impl core::fmt::Debug for AnalysisOptions<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AnalysisOptions").finish_non_exhaustive()
+    }
+}

--- a/parley_core/src/bidi.rs
+++ b/parley_core/src/bidi.rs
@@ -13,7 +13,7 @@ pub type BidiLevel = u8;
 #[derive(Clone, Default)]
 pub struct BidiResolver {
     base_level: BidiLevel,
-    levels: Vec<BidiLevel>,
+    pub(crate) levels: Vec<BidiLevel>,
     initial_types: Vec<BidiClass>,
     types: Vec<BidiClass>,
     brackets: Vec<(usize, char, BidiMirroringGlyph)>,

--- a/parley_core/src/break_overrides.rs
+++ b/parley_core/src/break_overrides.rs
@@ -7,8 +7,7 @@ use core::ops::RangeInclusive;
 
 /// Context for a potential line break opportunity between two adjacent code points.
 #[derive(Clone, Copy, Debug)]
-// #[non_exhaustive]
-// TODO: re-enable the non-exhaustive above
+#[non_exhaustive]
 pub struct LineBreakContext {
     /// The code point before the `before` code point, if any.
     pub before_before: Option<char>,
@@ -110,7 +109,7 @@ static CHROMIUM_LINE_BREAK_TABLE: AsciiLineBreakTable<5> =
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// # use parley_core::break_overrides::CHROMIUM_LINE_BREAK_OVERRIDE;
 /// # use parley_core::{Analysis, AnalysisOptions, Analyzer};
 /// # let mut analyzer = Analyzer::new();

--- a/parley_core/src/lib.rs
+++ b/parley_core/src/lib.rs
@@ -23,5 +23,10 @@ extern crate std;
 
 extern crate alloc;
 
+mod analysis;
+mod analyzer;
 pub mod bidi;
 pub mod break_overrides;
+
+pub use analysis::{Analysis, AnalysisDataSources, Boundary, CharInfo};
+pub use analyzer::{AnalysisOptions, Analyzer};


### PR DESCRIPTION
On top of #648.

This introduces `Analyzer` and `Analysis` as scratch, moves over `analyze_text` from Parley into Parley Core, as well as some types like `CharInfo`, `Boundary`. Parley now calls into Parley Core for analysis.

Analysis is unchanged, except Parley Core is given the word break config spans by Parley, where Parley previously reached into the style runs during analysis.

`CharInfo` has different fields in https://github.com/linebender/parley/pull/634 (the big PR where all of shaping was migrated to `parley_core`), and we may move to something like that later. For now, this is probably fine.

<details>
<summary>Benches neutral as expected</summary>

```
$ cargo export target/benchmarks -- bench --bench=main
$ cargo bench -q --bench=main -- compare ../target/benchmarks/main -t 8.
Default Style - arabic 20 characters               [   8.7 us ...   8.7 us ]      -0.26%
Default Style - latin 20 characters                [   4.1 us ...   4.2 us ]      +1.69%*
Default Style - japanese 20 characters             [   8.1 us ...   8.2 us ]      +0.49%
Default Style - arabic 1 paragraph                 [  47.0 us ...  46.7 us ]      -0.66%
Default Style - latin 1 paragraph                  [  16.0 us ...  16.5 us ]      +2.78%*
Default Style - japanese 1 paragraph               [  69.1 us ...  68.7 us ]      -0.55%
Default Style - arabic 4 paragraph                 [ 203.1 us ... 196.7 us ]      -3.13%*
Default Style - latin 4 paragraph                  [  61.5 us ...  61.7 us ]      +0.39%
Default Style - japanese 4 paragraph               [  98.1 us ...  97.0 us ]      -1.14%*
Styled - arabic 20 characters                      [   9.7 us ...   9.7 us ]      +0.04%
Styled - latin 20 characters                       [   5.3 us ...   5.3 us ]      +1.55%*
Styled - japanese 20 characters                    [   8.6 us ...   8.6 us ]      -0.46%
Styled - arabic 1 paragraph                        [  49.3 us ...  49.0 us ]      -0.76%
Styled - latin 1 paragraph                         [  20.4 us ...  20.6 us ]      +0.93%
Styled - japanese 1 paragraph                      [  75.0 us ...  74.4 us ]      -0.90%
Styled - arabic 4 paragraph                        [ 220.1 us ... 215.6 us ]      -2.02%*
Styled - latin 4 paragraph                         [  79.5 us ...  80.0 us ]      +0.59%
Styled - japanese 4 paragraph                      [ 106.2 us ... 105.3 us ]      -0.85%
```
</details>
