### PR TITLE
Release Parley v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,29 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV] of 1.88.
 
+## [0.11.0] - 2026-06-24
+
+This release has an [MSRV] of 1.88.
+
 ### Added
 
 #### Parley
 
+- Line break opportunity override (#640 by [@taj-p][]).
+  The builders now have a `set_line_break_override` method which can be used to customise where the parley detects line-breaking opportunities. It can be called with `Some(parley::CHROMIUM_LINE_BREAK_OVERRIDE)` to make line-breaking match Chromium, or with a custom instance of `AsciiLineBreakTable` created with `AsciiLineBreakTableBuilder`. If you do not call the function then you will get the existing standard ICU-defined behavior.
 - `From` conversions into `StyleProperty` for `FontWidth`, `FontStyle`, `FontWeight`, `WordBreak`, `OverflowWrap`, and `TextWrapMode`, matching the existing conversions for font family, variations, features, and line height. (#643 by [@waywardmonkeys][])
+
+### Changed
+
+#### Parley
+
+- Upgrade to `read-fonts` 0.40, `skrifa` 0.43, `harfrust` 0.10 (#650 by [@nicoburns][])
+
+### Fixed
+
+#### Parley
+
+- Fix font selection for emoji followed by a variation selector (#637 by [@kane50613][])
 
 ## [0.10.0] - 2026-06-01
 
@@ -500,6 +518,7 @@ This release has an [MSRV][] of 1.70.
 [@guiguiprim]: https://github.com/guiguiprim
 [@grebmeg]: https://github.com/grebmeg
 [@jordanhalase]: https://github.com/jordanhalase
+[@kane50613]: https://github.com/kane50613
 [@kekelp]: https://github.com/kekelp
 [@lainon1]: https://github.com/lainon1
 [@Linktime]: https://github.com/Linktime
@@ -658,9 +677,13 @@ This release has an [MSRV][] of 1.70.
 [#621]: https://github.com/linebender/parley/pull/621
 [#626]: https://github.com/linebender/parley/pull/626
 [#632]: https://github.com/linebender/parley/pull/632
+[#637]: https://github.com/linebender/parley/pull/637
+[#640]: https://github.com/linebender/parley/pull/640
 [#643]: https://github.com/linebender/parley/pull/643
+[#650]: https://github.com/linebender/parley/pull/650
 
-[Unreleased]: https://github.com/linebender/parley/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/linebender/parley/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/linebender/parley/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/linebender/parley/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/linebender/parley/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/linebender/parley/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This release has an [MSRV] of 1.88.
 #### Parley
 
 - Line break opportunity override (#640 by [@taj-p][]).
-  The builders now have a `set_line_break_override` method which can be used to customise where the parley detects line-breaking opportunities. It can be called with `Some(parley::CHROMIUM_LINE_BREAK_OVERRIDE)` to make line-breaking match Chromium, or with a custom instance of `AsciiLineBreakTable` created with `AsciiLineBreakTableBuilder`. If you do not call the function then you will get the existing standard ICU-defined behavior.
+  The builders now have a `set_line_break_override` method which can be used to customise where Parley detects line-breaking opportunities. It can be called with `Some(parley::CHROMIUM_LINE_BREAK_OVERRIDE)` to make line-breaking match Chromium, or with a custom instance of `AsciiLineBreakTable` created with `AsciiLineBreakTableBuilder`. If you do not call the function then you will get the existing standard ICU-defined behavior.
 - `From` conversions into `StyleProperty` for `FontWidth`, `FontStyle`, `FontWeight`, `WordBreak`, `OverflowWrap`, and `TextWrapMode`, matching the existing conversions for font family, variations, features, and line height. (#643 by [@waywardmonkeys][])
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "parley"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "accesskit",
  "core_maths",
@@ -2928,7 +2928,7 @@ version = "0.0.0"
 
 [[package]]
 name = "parley_data"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "icu_properties",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.10.0"
+version = "0.11.0"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
 # Until MSRV is bumped to 1.96+, use `core::ops::Range*` rather than `core::range::Range*`.
@@ -33,9 +33,18 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/parley"
 
 [workspace.dependencies]
+# Local crates
+parlance = { version = "0.1.0", default-features = false, path = "parlance" }
+fontique = { version = "0.11.0", default-features = false, path = "fontique" }
+parley = { version = "0.11.0", default-features = false, path = "parley" }
+parley_data = { version = "0.11.0", path = "parley_data", default-features = false }
+parley_data_gen = { path = "parley_data_gen" }
+parley_dev = { default-features = false, path = "parley_dev" }
+parley_linebreaking_cases = { path = "parley_tests/linebreaking_cases" }
+
+# External dependencies
 accesskit = "0.24.0"
 bytemuck = { version = "1.25.0", default-features = false }
-fontique = { version = "0.10.0", default-features = false, path = "fontique" }
 harfrust = { version = "0.10.0", default-features = false }
 hashbrown = { version = "0.17.0", default-features = false, features = [
     "default-hasher",
@@ -47,12 +56,6 @@ icu_properties = { version = "2.1.2", default-features = false }
 icu_segmenter = { version = "2.1.2", default-features = false }
 linebender_resource_handle = { version = "0.1.1", default-features = false }
 packtab = { version = "1.8.0" }
-parlance = { version = "0.1.0", default-features = false, path = "parlance" }
-parley = { version = "0.10.0", default-features = false, path = "parley" }
-parley_data = { version = "0.10.0", path = "parley_data", default-features = false }
-parley_data_gen = { path = "parley_data_gen" }
-parley_dev = { default-features = false, path = "parley_dev" }
-parley_linebreaking_cases = { path = "parley_tests/linebreaking_cases" }
 glifo = { git = "https://github.com/linebender/vello", rev = "5796226", default-features = false }
 rand = { version = "0.10.1", default-features = false, features = ["std", "std_rng"] }
 rand_chacha = { version = "0.10.0", default-features = false }


### PR DESCRIPTION
- Update changelog
- Update package version numbers
- Group local crates together in Cargo.toml so it's easier to find them when updating the version numbers