### PR TITLE
Make GenericFamily::parse / parse_css_list detection of generic families case-insensitive

### DIFF
--- a/parlance/src/font_family.rs
+++ b/parlance/src/font_family.rs
@@ -377,6 +377,25 @@ mod tests {
     }
 
     #[test]
+    fn parse_generic_family_is_case_insensitive_when_unquoted() {
+        assert_eq!(
+            FontFamilyName::parse("SERIF"),
+            Some(FontFamilyName::Generic(GenericFamily::Serif))
+        );
+
+        let families: Result<alloc::vec::Vec<_>, _> =
+            FontFamilyName::parse_css_list(r#"Arial, SERIF, "serif""#).collect();
+        assert_eq!(
+            families.unwrap(),
+            alloc::vec![
+                FontFamilyName::Named(Cow::Borrowed("Arial")),
+                FontFamilyName::Generic(GenericFamily::Serif),
+                FontFamilyName::Named(Cow::Borrowed("serif")),
+            ]
+        );
+    }
+
+    #[test]
     fn parse_generic_family_is_named_when_quoted() {
         assert_eq!(
             FontFamilyName::parse("'monospace'"),

--- a/parlance/src/generic_family.rs
+++ b/parlance/src/generic_family.rs
@@ -59,25 +59,39 @@ impl GenericFamily {
     ///     GenericFamily::parse("sans-serif"),
     ///     Some(GenericFamily::SansSerif)
     /// );
+    /// assert_eq!(GenericFamily::parse("SERIF"), Some(GenericFamily::Serif));
     /// assert_eq!(GenericFamily::parse("Arial"), None);
     /// ```
     pub fn parse(s: &str) -> Option<Self> {
         let s = s.trim();
-        Some(match s {
-            "serif" => Self::Serif,
-            "sans-serif" => Self::SansSerif,
-            "monospace" => Self::Monospace,
-            "cursive" => Self::Cursive,
-            "fantasy" => Self::Fantasy,
-            "system-ui" => Self::SystemUi,
-            "ui-serif" => Self::UiSerif,
-            "ui-sans-serif" => Self::UiSansSerif,
-            "ui-monospace" => Self::UiMonospace,
-            "ui-rounded" => Self::UiRounded,
-            "emoji" => Self::Emoji,
-            "math" => Self::Math,
-            "fangsong" => Self::FangSong,
-            _ => return None,
+        Some(if s.eq_ignore_ascii_case("serif") {
+            Self::Serif
+        } else if s.eq_ignore_ascii_case("sans-serif") {
+            Self::SansSerif
+        } else if s.eq_ignore_ascii_case("monospace") {
+            Self::Monospace
+        } else if s.eq_ignore_ascii_case("cursive") {
+            Self::Cursive
+        } else if s.eq_ignore_ascii_case("fantasy") {
+            Self::Fantasy
+        } else if s.eq_ignore_ascii_case("system-ui") {
+            Self::SystemUi
+        } else if s.eq_ignore_ascii_case("ui-serif") {
+            Self::UiSerif
+        } else if s.eq_ignore_ascii_case("ui-sans-serif") {
+            Self::UiSansSerif
+        } else if s.eq_ignore_ascii_case("ui-monospace") {
+            Self::UiMonospace
+        } else if s.eq_ignore_ascii_case("ui-rounded") {
+            Self::UiRounded
+        } else if s.eq_ignore_ascii_case("emoji") {
+            Self::Emoji
+        } else if s.eq_ignore_ascii_case("math") {
+            Self::Math
+        } else if s.eq_ignore_ascii_case("fangsong") {
+            Self::FangSong
+        } else {
+            return None;
         })
     }
 
@@ -119,5 +133,41 @@ impl fmt::Display for GenericFamily {
             Self::FangSong => "fangsong",
         };
         f.write_str(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GenericFamily;
+
+    #[test]
+    fn parse_is_ascii_case_insensitive() {
+        assert_eq!(GenericFamily::parse("SERIF"), Some(GenericFamily::Serif));
+        assert_eq!(
+            GenericFamily::parse("Sans-Serif"),
+            Some(GenericFamily::SansSerif)
+        );
+        assert_eq!(
+            GenericFamily::parse("MONOSPACE"),
+            Some(GenericFamily::Monospace)
+        );
+        assert_eq!(
+            GenericFamily::parse("UI-Rounded"),
+            Some(GenericFamily::UiRounded)
+        );
+        assert_eq!(
+            GenericFamily::parse("FangSong"),
+            Some(GenericFamily::FangSong)
+        );
+    }
+
+    #[test]
+    fn parse_preserves_lowercase_trim_and_named_behavior() {
+        assert_eq!(GenericFamily::parse("serif"), Some(GenericFamily::Serif));
+        assert_eq!(
+            GenericFamily::parse("  SERIF  "),
+            Some(GenericFamily::Serif)
+        );
+        assert_eq!(GenericFamily::parse("Arial"), None);
     }
 }


### PR DESCRIPTION
## Summary

Generic font-family keywords (`serif`, `sans-serif`, `monospace`, `cursive`, `fantasy`, `system-ui`, etc.) are now matched case-insensitively when parsing a font-family list, so `Serif` or `SANS-SERIF` resolve to the same generic family as their lowercase forms.

## Why this matters

The generic-family parser compared the input against lowercase keywords exactly, so any input with different casing fell through and was treated as a named family rather than the intended generic, producing the wrong font selection. CSS treats these keywords case-insensitively, so this matches the expected behavior. Reported in #596.

## Testing

Added targeted tests for mixed-case generic-family inputs; `cargo test --workspace` passes.

Closes #596
