### PR TITLE
Rename `parley::layout::Cluster::first_style` => `style`, improve docstring

### DIFF
--- a/parley/src/layout/accessibility.rs
+++ b/parley/src/layout/accessibility.rs
@@ -253,7 +253,7 @@ impl LayoutAccessibility {
 
                     if prev_style_index.is_none() {
                         prev_style_index = Some(style_index);
-                        let style = cluster.first_style();
+                        let style = cluster.style();
                         set_brush_properties(&mut node, style);
                         if let Some(locale) = &style.locale {
                             node.set_language(locale.as_str());

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -148,8 +148,9 @@ impl<'a, B: Brush> Cluster<'a, B> {
         self.data.text_range(self.run.data)
     }
 
-    /// Returns the first style that applies to the cluster. If the cluster contains multiple glyphs
-    /// then this style may not apply to all glyphs in the cluster (see the `DIVERGENT_STYLES` flag)
+    /// Returns the style of the character this cluster represents.
+    ///
+    /// All of the cluster's glyphs share this style.
     pub fn first_style(&self) -> &Style<B> {
         &self.run.layout.styles()[usize::from(self.data.style_index)]
     }

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -151,7 +151,7 @@ impl<'a, B: Brush> Cluster<'a, B> {
     /// Returns the style of the character this cluster represents.
     ///
     /// All of the cluster's glyphs share this style.
-    pub fn first_style(&self) -> &Style<B> {
+    pub fn style(&self) -> &Style<B> {
         &self.run.layout.styles()[usize::from(self.data.style_index)]
     }
 


### PR DESCRIPTION
`DIVERGENT_STYLES` was removed in https://github.com/linebender/parley/pull/449.

The method on this single-character cluster being called `first_style` is perhaps a bit misleading. My understanding is this `Cluster` (as opposed to `CharCluster`!) specifically represents a single character and always has a single, well-defined style index (at least, in a world without `DIVERGENT_STYLES` - I don't know exactly what that was intended for). This proposes renaming the method to `Cluster::style`. Note that `GlyphRun` flatmaps glyphs in subsequent `Cluster`s and already exposes just a single `GlyphRun::style`.

Also note that if styles differ between characters in a *character cluster* (which is a different cluster than this PR touches, and can contain multiple characters), what's supposed to happen is a bit ambiguous. In the web, rendering the text "ffi" in a font that makes it a ligature (e.g. Noto Serif), and coloring one of the characters differently, Firefox seems to color a part of the ligature, whereas Chrome seems to take the first character's style.

See https://developer.mozilla.org/en-US/play?id=4v27MYBCmNq9Ykm21hxn3WOqTwpOHN5tF72iZC9E6jdyurWr8A5AQOZb5DqMyG3xnRwGHBzfcvc%2FY2ax.

On my machine, that example renders as follows.
 
| Firefox | Chromium |
| --- | --- |
| <img width="34" height="25" alt="Screenshot 2026-06-30 at 16-02-23 Playground MDN" src="https://github.com/user-attachments/assets/bfce5a37-e983-4411-92c6-7df781ad5771" /> | <img width="34" height="25" alt="developer mozilla org_en-US_play_id=4v27MYBCmNq9Ykm21hxn3WOqTwpOHN5tF72iZC9E6jdyurWr8A5AQOZb5DqMyG3xnRwGHBzfcvc%2FY2ax" src="https://github.com/user-attachments/assets/89618d7a-0ab1-4dd7-abd8-3902e00f11b4" /> |
