### PR TITLE
Remove `Glyph::style_index`, allow access to indices on `Cluster` and `GlyphRun`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV] of 1.88.
 
+### Changed
+
+#### Parley
+
+- Breaking change: the `Glyph::style_index` field was removed. Use `Clusters::{style, style_index}` or `GlyphRun::{style, style_index}` instead. (#661 by [@tomcur][])
+
 ## [0.11.0] - 2026-06-24
 
 This release has an [MSRV] of 1.88.
@@ -681,6 +687,7 @@ This release has an [MSRV][] of 1.70.
 [#640]: https://github.com/linebender/parley/pull/640
 [#643]: https://github.com/linebender/parley/pull/643
 [#650]: https://github.com/linebender/parley/pull/650
+[#661]: https://github.com/linebender/parley/pull/661
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/linebender/parley/compare/v0.10.0...v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This release has an [MSRV] of 1.88.
 
 #### Parley
 
-- Breaking change: the `Glyph::style_index` field was removed. Use `Clusters::{style, style_index}` or `GlyphRun::{style, style_index}` instead. (#661 by [@tomcur][])
+- Breaking change: the `Glyph::style_index` field was removed. Use `Cluster::{style, style_index}` or `GlyphRun::{style, style_index}` instead. (#661 by [@tomcur][])
 
 ## [0.11.0] - 2026-06-24
 

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -151,8 +151,19 @@ impl<'a, B: Brush> Cluster<'a, B> {
     /// Returns the style of the character this cluster represents.
     ///
     /// All of the cluster's glyphs share this style.
+    ///
+    /// See also [`Self::style_index`].
     pub fn style(&self) -> &Style<B> {
         &self.run.layout.styles()[usize::from(self.data.style_index)]
+    }
+
+    /// Returns the style index of the character this cluster represents.
+    ///
+    /// All of the cluster's glyphs share this style.
+    ///
+    /// See also [`Self::style`].
+    pub fn style_index(&self) -> u16 {
+        self.data.style_index
     }
 
     /// Returns the advance of the cluster.
@@ -209,7 +220,6 @@ impl<'a, B: Brush> Cluster<'a, B> {
         if self.data.glyph_len == 0xFF {
             GlyphIter::Single(Some(Glyph {
                 id: self.data.glyph_offset,
-                style_index: self.data.style_index,
                 x: 0.,
                 y: 0.,
                 advance: self.data.advance,

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -786,7 +786,6 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
 
         let glyph = Glyph {
             id: glyph_info.glyph_id,
-            style_index: char_info.1,
             x: (glyph_pos.x_offset as f32) * scale_factor,
             // Convert from font space (Y-up) to layout space (Y-down)
             y: -(glyph_pos.y_offset as f32) * scale_factor,

--- a/parley/src/layout/glyph.rs
+++ b/parley/src/layout/glyph.rs
@@ -5,15 +5,7 @@
 #[derive(Copy, Clone, Default, Debug, PartialEq)]
 pub struct Glyph {
     pub id: u32,
-    pub style_index: u16,
     pub x: f32,
     pub y: f32,
     pub advance: f32,
-}
-
-impl Glyph {
-    /// Returns the index into the layout style collection.
-    pub fn style_index(&self) -> usize {
-        self.style_index as usize
-    }
 }

--- a/parley/src/layout/line.rs
+++ b/parley/src/layout/line.rs
@@ -188,7 +188,7 @@ pub struct PositionedInlineBox {
 #[derive(Clone)]
 pub struct GlyphRun<'a, B: Brush> {
     run: Run<'a, B>,
-    style: &'a Style<B>,
+    style_index: u16,
     glyph_start: usize,
     glyph_count: usize,
     offset: f32,
@@ -203,8 +203,17 @@ impl<'a, B: Brush> GlyphRun<'a, B> {
     }
 
     /// Returns the associated style.
+    ///
+    /// See also [`Self::style_index`].
     pub fn style(&self) -> &Style<B> {
-        self.style
+        &self.run.layout.styles()[usize::from(self.style_index)]
+    }
+
+    /// Returns the associated style index.
+    ///
+    /// See also [`Self::style`].
+    pub fn style_index(&self) -> u16 {
+        self.style_index
     }
 
     /// Returns the offset to the baseline.
@@ -279,27 +288,27 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                     }));
                 }
                 LineItem::Run(run) => {
-                    let mut iter = run
+                    let mut glyphs = run
                         .visual_clusters()
-                        .flat_map(|c| c.glyphs())
+                        .flat_map(|c| c.glyphs().map(|glyph| (glyph, c.data.style_index)))
                         .skip(self.glyph_start);
 
-                    if let Some(first) = iter.next() {
-                        let mut advance = first.advance;
-                        let style_index = first.style_index();
+                    if let Some((first_glyph, first_style_index)) = glyphs.next() {
+                        let mut advance = first_glyph.advance;
                         let mut glyph_count = 1;
-                        for glyph in iter.take_while(|g| g.style_index() == style_index) {
+                        for (glyph, _) in
+                            glyphs.take_while(|(_, style_index)| *style_index == first_style_index)
+                        {
                             glyph_count += 1;
                             advance += glyph.advance;
                         }
-                        let style = run.layout.data.styles.get(style_index)?;
                         let glyph_start = self.glyph_start;
                         self.glyph_start += glyph_count;
                         let offset = self.offset;
                         self.offset += advance;
                         return Some(PositionedLayoutItem::GlyphRun(GlyphRun {
                             run,
-                            style,
+                            style_index: first_style_index,
                             glyph_start,
                             glyph_count,
                             offset: offset

--- a/parley/src/tests/utils/asserts.rs
+++ b/parley/src/tests/utils/asserts.rs
@@ -28,9 +28,6 @@ fn canonicalize_layout_data<B: Brush>(layout_data: &LayoutData<B>) -> LayoutData
     for cluster in &mut normalized.clusters {
         cluster.style_index = remap[cluster.style_index as usize];
     }
-    for glyph in &mut normalized.glyphs {
-        glyph.style_index = remap[glyph.style_index as usize];
-    }
     normalized.styles = canonical_styles;
     normalized
 }


### PR DESCRIPTION
On top of https://github.com/linebender/parley/pull/660.

A glyph's style index is equal to its owning `Cluster`'s style index, and style indices are constant by construction in `GlyphRun`. As those are the two containers through which a user can get at a `Glyph`, the `Glyph`s themselves don't need to carry the style index.

This is motivated by `parley::layout::Glyph` moving to `parley_core` soon, and so far `parley_core` does not encode style indices at all.

Added a changelog entry, but if `Glyph` is migrated to `parley_core` (without a shim in `parley`) before the next release, this entry will likely get absorbed into a bigger entry.