### PR TITLE
Include all coverage variants for a family in a query

### DIFF
--- a/fontique/src/collection/query.rs
+++ b/fontique/src/collection/query.rs
@@ -5,10 +5,11 @@
 
 use crate::{Charmap, CharmapIndex};
 
-use super::super::{Collection, SourceCache};
+use super::super::{Collection, SourceCache, matching::match_fonts};
 
 use alloc::vec::Vec;
 use parlance::Script;
+use smallvec::SmallVec;
 
 use super::{
     super::{Attributes, Blob, FallbackKey, FamilyId, FamilyInfo, GenericFamily, Synthesis},
@@ -140,22 +141,22 @@ impl<'a> Query<'a> {
             let Entry::Ok(family_info) = &family.family else {
                 continue;
             };
-            let mut best_index = None;
-            if let Some(font) = load_font(
+            let bucket = load_bucket(
                 family_info,
                 self.attributes,
                 &mut family.best,
-                false,
                 self.source_cache,
-            ) {
-                best_index = Some(font.family.1);
+            );
+            let mut yielded_default = false;
+            for font in bucket {
+                if font.family.1 == family_info.default_font_index() {
+                    yielded_default = true;
+                }
                 if f(font) == QueryStatus::Stop {
                     return;
                 }
             }
-            // Don't invoke for the default font if it's the same as the
-            // best match.
-            if best_index == Some(family_info.default_font_index()) {
+            if yielded_default {
                 continue;
             }
             if let Some(font) = load_font(
@@ -244,6 +245,58 @@ impl QueryFont {
     }
 }
 
+/// Loads every font in `family` matching `attributes` (all coverage variants of the best match).
+fn load_bucket<'a>(
+    family: &FamilyInfo,
+    attributes: Attributes,
+    bucket: &'a mut Entry<SmallVec<[QueryFont; 1]>>,
+    source_cache: &mut SourceCache,
+) -> &'a [QueryFont] {
+    match bucket {
+        Entry::Error => &[],
+        Entry::Ok(fonts) => fonts,
+        status @ Entry::Vacant => {
+            *status = Entry::Error;
+            let indices = match_fonts(
+                family.fonts(),
+                attributes.width,
+                attributes.style,
+                attributes.weight,
+                true,
+            );
+            let mut fonts: SmallVec<[QueryFont; 1]> = SmallVec::new();
+            for index in indices {
+                let Some(font_info) = family.fonts().get(index) else {
+                    continue;
+                };
+                let Some(blob) = font_info.load(Some(source_cache)) else {
+                    continue;
+                };
+                fonts.push(QueryFont {
+                    family: (family.id(), index),
+                    blob: blob.clone(),
+                    index: font_info.index(),
+                    synthesis: font_info.synthesis(
+                        attributes.width,
+                        attributes.style,
+                        attributes.weight,
+                    ),
+                    charmap_index: font_info.charmap_index(),
+                });
+            }
+            if fonts.is_empty() {
+                return &[];
+            }
+            *status = Entry::Ok(fonts);
+            if let Entry::Ok(fonts) = status {
+                fonts
+            } else {
+                &[]
+            }
+        }
+    }
+}
+
 fn load_font<'a>(
     family: &FamilyInfo,
     attributes: Attributes,
@@ -288,7 +341,7 @@ fn load_font<'a>(
 struct CachedFamily {
     id: FamilyId,
     family: Entry<FamilyInfo>,
-    best: Entry<QueryFont>,
+    best: Entry<SmallVec<[QueryFont; 1]>>,
     default: Entry<QueryFont>,
 }
 

--- a/fontique/src/collection/query.rs
+++ b/fontique/src/collection/query.rs
@@ -163,7 +163,6 @@ impl<'a> Query<'a> {
                 family_info,
                 self.attributes,
                 &mut family.default,
-                true,
                 self.source_cache,
             ) {
                 if f(font) == QueryStatus::Stop {
@@ -288,11 +287,10 @@ fn load_bucket<'a>(
                 return &[];
             }
             *status = Entry::Ok(fonts);
-            if let Entry::Ok(fonts) = status {
-                fonts
-            } else {
-                &[]
-            }
+            let Entry::Ok(fonts) = status else {
+                unreachable!()
+            };
+            fonts
         }
     }
 }
@@ -301,7 +299,6 @@ fn load_font<'a>(
     family: &FamilyInfo,
     attributes: Attributes,
     font: &'a mut Entry<QueryFont>,
-    is_default: bool,
     source_cache: &mut SourceCache,
 ) -> Option<&'a QueryFont> {
     match font {
@@ -311,11 +308,7 @@ fn load_font<'a>(
             // Set to error in case we fail. This simplifies
             // the following code.
             *status = Entry::Error;
-            let family_index = if is_default {
-                family.default_font_index()
-            } else {
-                family.match_index(attributes.width, attributes.style, attributes.weight, true)?
-            };
+            let family_index = family.default_font_index();
             let font_info = family.fonts().get(family_index)?;
             let blob = font_info.load(Some(source_cache))?;
             let blob_index = font_info.index();

--- a/fontique/src/matching.rs
+++ b/fontique/src/matching.rs
@@ -9,6 +9,27 @@ use smallvec::SmallVec;
 
 const DEFAULT_OBLIQUE_ANGLE: f32 = 14.0;
 
+pub fn match_fonts(
+    set: &[FontInfo],
+    width: FontWidth,
+    style: FontStyle,
+    weight: FontWeight,
+    synthesize_style: bool,
+) -> SmallVec<[usize; 4]> {
+    let Some(best) = match_font(set, width, style, weight, synthesize_style) else {
+        return SmallVec::new();
+    };
+    let win = &set[best];
+    let (win_width, win_style, win_weight) = (win.width(), win.style(), win.weight());
+    set.iter()
+        .enumerate()
+        .filter(|(_, font)| {
+            font.width() == win_width && font.style() == win_style && font.weight() == win_weight
+        })
+        .map(|(index, _)| index)
+        .collect()
+}
+
 pub fn match_font(
     set: &[FontInfo],
     width: FontWidth,

--- a/fontique/src/matching.rs
+++ b/fontique/src/matching.rs
@@ -15,19 +15,16 @@ pub fn match_fonts(
     style: FontStyle,
     weight: FontWeight,
     synthesize_style: bool,
-) -> SmallVec<[usize; 4]> {
-    let Some(best) = match_font(set, width, style, weight, synthesize_style) else {
-        return SmallVec::new();
-    };
-    let win = &set[best];
-    let (win_width, win_style, win_weight) = (win.width(), win.style(), win.weight());
-    set.iter()
-        .enumerate()
-        .filter(|(_, font)| {
-            font.width() == win_width && font.style() == win_style && font.weight() == win_weight
-        })
-        .map(|(index, _)| index)
-        .collect()
+) -> impl Iterator<Item = usize> + '_ {
+    let best = match_font(set, width, style, weight, synthesize_style).map(|index| {
+        let font = &set[index];
+        (font.width(), font.style(), font.weight())
+    });
+    set.iter().enumerate().filter_map(move |(index, font)| {
+        let (best_width, best_style, best_weight) = best?;
+        (font.width() == best_width && font.style() == best_style && font.weight() == best_weight)
+            .then_some(index)
+    })
 }
 
 pub fn match_font(

--- a/fontique/src/matching.rs
+++ b/fontique/src/matching.rs
@@ -9,7 +9,7 @@ use smallvec::SmallVec;
 
 const DEFAULT_OBLIQUE_ANGLE: f32 = 14.0;
 
-pub fn match_fonts(
+pub(crate) fn match_fonts(
     set: &[FontInfo],
     width: FontWidth,
     style: FontStyle,
@@ -22,6 +22,7 @@ pub fn match_fonts(
     });
     set.iter().enumerate().filter_map(move |(index, font)| {
         let (best_width, best_style, best_weight) = best?;
+        // We need to return each font with the best attributes, as there might be multiple subsets.
         (font.width() == best_width && font.style() == best_style && font.weight() == best_weight)
             .then_some(index)
     })


### PR DESCRIPTION
Fixes #322

_Generated with Claude and reviewed by me_

Add `matching::match_fonts` to collect every font sharing the best match's attributes, and have the query include the whole set. The caller already walks candidates per cluster against each font's charmap, so it now lands on the slice that covers the cluster.