### PR TITLE
Update to the Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,8 +72,6 @@ vello_hybrid = { version = "0.0.7", default-features = false }
 [workspace.lints]
 rust.unsafe_code = "deny"
 
-clippy.collapsible_if = "allow"
-
 # LINEBENDER LINT SET - Cargo.toml - v7
 # See https://linebender.org/wiki/canonical-lints/
 rust.keyword_idents_2024 = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,8 @@ vello_hybrid = { version = "0.0.7", default-features = false }
 [workspace.lints]
 rust.unsafe_code = "deny"
 
+clippy.collapsible_if = "allow"
+
 # LINEBENDER LINT SET - Cargo.toml - v7
 # See https://linebender.org/wiki/canonical-lints/
 rust.keyword_idents_2024 = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 version = "0.11.0"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.

--- a/examples/vello_editor/src/text.rs
+++ b/examples/vello_editor/src/text.rs
@@ -64,21 +64,21 @@ fn set_accesskit_brush_properties(node: &mut Node, style: &Style<Brush>) {
     if let Some(color) = to_accesskit_color(&style.brush) {
         node.set_foreground_color(color);
     }
-    if let Some(deco) = &style.underline {
-        if let Some(color) = to_accesskit_color(&deco.brush) {
-            node.set_underline(TextDecoration {
-                style: TextDecorationStyle::Solid,
-                color,
-            });
-        }
+    if let Some(deco) = &style.underline
+        && let Some(color) = to_accesskit_color(&deco.brush)
+    {
+        node.set_underline(TextDecoration {
+            style: TextDecorationStyle::Solid,
+            color,
+        });
     }
-    if let Some(deco) = &style.strikethrough {
-        if let Some(color) = to_accesskit_color(&deco.brush) {
-            node.set_strikethrough(TextDecoration {
-                style: TextDecorationStyle::Solid,
-                color,
-            });
-        }
+    if let Some(deco) = &style.strikethrough
+        && let Some(color) = to_accesskit_color(&deco.brush)
+    {
+        node.set_strikethrough(TextDecoration {
+            style: TextDecorationStyle::Solid,
+            color,
+        });
     }
 }
 
@@ -358,10 +358,10 @@ impl Editor {
     }
 
     pub fn handle_accesskit_action_request(&mut self, req: &accesskit::ActionRequest) {
-        if req.action == accesskit::Action::SetTextSelection {
-            if let Some(accesskit::ActionData::SetTextSelection(selection)) = &req.data {
-                self.driver().select_from_accesskit(selection);
-            }
+        if req.action == accesskit::Action::SetTextSelection
+            && let Some(accesskit::ActionData::SetTextSelection(selection)) = &req.data
+        {
+            self.driver().select_from_accesskit(selection);
         }
     }
 
@@ -384,16 +384,16 @@ impl Editor {
                 &convert_rect(&rect),
             );
         });
-        if self.cursor_visible {
-            if let Some(cursor) = self.editor.cursor_geometry(1.5) {
-                scene.fill(
-                    Fill::NonZero,
-                    transform,
-                    palette::css::WHITE,
-                    None,
-                    &convert_rect(&cursor),
-                );
-            }
+        if self.cursor_visible
+            && let Some(cursor) = self.editor.cursor_geometry(1.5)
+        {
+            scene.fill(
+                Fill::NonZero,
+                transform,
+                palette::css::WHITE,
+                None,
+                &convert_rect(&cursor),
+            );
         }
         let layout = self.editor.layout(&mut self.font_cx, &mut self.layout_cx);
         for line in layout.lines() {

--- a/fontique/src/backend/android.rs
+++ b/fontique/src/backend/android.rs
@@ -71,111 +71,108 @@ impl SystemFonts {
         let mut script_fallback = vec![];
 
         // Try to get generic info from fonts.xml
-        if let Ok(s) = std::fs::read_to_string(Path::new(&android_root).join("etc/fonts.xml")) {
-            if let Ok(doc) = Document::parse(s.clone().as_str()) {
-                let root = doc.root_element();
-                if root.tag_name().name() == "familyset"
-                    || root
-                        .attribute("version")
-                        .is_some_and(|v| usize::from_str(v).is_ok_and(|x| x >= 21))
-                {
-                    for child in root.children() {
-                        match child.tag_name().name() {
-                            "alias" => {
-                                if let Some((name, to)) =
-                                    child.attribute("name").zip(child.attribute("to"))
-                                {
-                                    if child.attribute("weight").is_some() {
-                                        // weight aliases are an Android quirk and are not in­
-                                        // teresting for use cases other than Android legacy.
-                                        continue;
-                                    }
-                                    let to_n = name_map.get_or_insert(to);
-                                    name_map.add_alias(to_n.id(), name);
+        if let Ok(s) = std::fs::read_to_string(Path::new(&android_root).join("etc/fonts.xml"))
+            && let Ok(doc) = Document::parse(s.clone().as_str())
+        {
+            let root = doc.root_element();
+            if root.tag_name().name() == "familyset"
+                || root
+                    .attribute("version")
+                    .is_some_and(|v| usize::from_str(v).is_ok_and(|x| x >= 21))
+            {
+                for child in root.children() {
+                    match child.tag_name().name() {
+                        "alias" => {
+                            if let Some((name, to)) =
+                                child.attribute("name").zip(child.attribute("to"))
+                            {
+                                if child.attribute("weight").is_some() {
+                                    // weight aliases are an Android quirk and are not in­
+                                    // teresting for use cases other than Android legacy.
+                                    continue;
                                 }
+                                let to_n = name_map.get_or_insert(to);
+                                name_map.add_alias(to_n.id(), name);
                             }
-                            "family" => {
-                                if let Some(name) = child.attribute("name") {
-                                    let f = name_map.get_or_insert(name);
-                                    let _id = f.id();
-                                    for _child in child.children() {
-                                        // TODO: map using postScriptName when available other­
-                                        //       wise use the file name, and perhaps if necess­
-                                        //       ary (e.g. if it's a collection), do something
-                                        //       smarter, or something dumb that meets expecta­
-                                        //       tions on Android.
-                                    }
-                                } else if let Some(langs) = child
-                                    .attribute("lang")
-                                    .map(|s| s.split(',').collect::<Vec<&str>>())
-                                {
-                                    let (_has_for, hasnt_for): (
-                                        Vec<Node<'_, '_>>,
-                                        Vec<Node<'_, '_>>,
-                                    ) = child
+                        }
+                        "family" => {
+                            if let Some(name) = child.attribute("name") {
+                                let f = name_map.get_or_insert(name);
+                                let _id = f.id();
+                                for _child in child.children() {
+                                    // TODO: map using postScriptName when available other­
+                                    //       wise use the file name, and perhaps if necess­
+                                    //       ary (e.g. if it's a collection), do something
+                                    //       smarter, or something dumb that meets expecta­
+                                    //       tions on Android.
+                                }
+                            } else if let Some(langs) = child
+                                .attribute("lang")
+                                .map(|s| s.split(',').collect::<Vec<&str>>())
+                            {
+                                let (_has_for, hasnt_for): (Vec<Node<'_, '_>>, Vec<Node<'_, '_>>) =
+                                    child
                                         .children()
                                         .partition(|c| c.attribute("fallbackFor").is_some());
-                                    {
-                                        // general fallback families
-                                        let (ps_named, _ps_unnamed): (
-                                            Vec<Node<'_, '_>>,
-                                            Vec<Node<'_, '_>>,
-                                        ) = hasnt_for
-                                            .iter()
-                                            .partition(|c| c.attribute("postScriptName").is_some());
+                                {
+                                    // general fallback families
+                                    let (ps_named, _ps_unnamed): (
+                                        Vec<Node<'_, '_>>,
+                                        Vec<Node<'_, '_>>,
+                                    ) = hasnt_for
+                                        .iter()
+                                        .partition(|c| c.attribute("postScriptName").is_some());
 
-                                        if let Some(family) = ps_named.iter().find_map(|x| {
-                                            postscript_names
-                                                .get(x.attribute("postScriptName").unwrap())
-                                        }) {
-                                            for lang in langs {
-                                                if let Some(scr) = lang.strip_prefix("und-") {
-                                                    // Undefined lang for script-only fallbacks
-                                                    script_fallback.push((
-                                                        scr.parse().unwrap_or(Script::UNKNOWN),
-                                                        *family,
-                                                    ));
-                                                } else if let Ok(locale) = Language::parse(lang) {
-                                                    if let Some(scr) = locale
-                                                        .script()
-                                                        .and_then(|s| s.parse::<Script>().ok())
-                                                    {
-                                                        // Also fallback for the script on its own
-                                                        script_fallback.push((scr, *family));
-                                                        if Script::from_bytes(*b"Hant") == scr {
-                                                            // This works around ambiguous han char­
-                                                            // acters going unmapped with current
-                                                            // fallback code. This should be done in
-                                                            // a locale-dependent manner, since that
-                                                            // is the norm.
-                                                            script_fallback.push((
-                                                                Script::from_bytes(*b"Hani"),
-                                                                *family,
-                                                            ));
-                                                        }
+                                    if let Some(family) = ps_named.iter().find_map(|x| {
+                                        postscript_names.get(x.attribute("postScriptName").unwrap())
+                                    }) {
+                                        for lang in langs {
+                                            if let Some(scr) = lang.strip_prefix("und-") {
+                                                // Undefined lang for script-only fallbacks
+                                                script_fallback.push((
+                                                    scr.parse().unwrap_or(Script::UNKNOWN),
+                                                    *family,
+                                                ));
+                                            } else if let Ok(locale) = Language::parse(lang) {
+                                                if let Some(scr) = locale
+                                                    .script()
+                                                    .and_then(|s| s.parse::<Script>().ok())
+                                                {
+                                                    // Also fallback for the script on its own
+                                                    script_fallback.push((scr, *family));
+                                                    if Script::from_bytes(*b"Hant") == scr {
+                                                        // This works around ambiguous han char­
+                                                        // acters going unmapped with current
+                                                        // fallback code. This should be done in
+                                                        // a locale-dependent manner, since that
+                                                        // is the norm.
+                                                        script_fallback.push((
+                                                            Script::from_bytes(*b"Hani"),
+                                                            *family,
+                                                        ));
                                                     }
-                                                    locale_fallback.push((locale, *family));
                                                 }
+                                                locale_fallback.push((locale, *family));
                                             }
                                         }
-
-                                        // TODO: handle mapping to family names from file names
-                                        //       when postScriptName is unavailable.
                                     }
 
-                                    // family-specific fallback families, currently unimplemented
-                                    // because it requires a GenericFamily to be plumbed through
-                                    // the `RangedStyle` `font_stack` from `resolve` where it is
-                                    // currently thrown away.
-                                    {}
+                                    // TODO: handle mapping to family names from file names
+                                    //       when postScriptName is unavailable.
                                 }
-                                // TODO: interpret variant="compact" without fallbackFor as a
-                                //       fallback for system-ui, as falling back to a
-                                //       variant="elegant" for system-ui can mess up a layout
-                                //       in some scripts.
+
+                                // family-specific fallback families, currently unimplemented
+                                // because it requires a GenericFamily to be plumbed through
+                                // the `RangedStyle` `font_stack` from `resolve` where it is
+                                // currently thrown away.
+                                {}
                             }
-                            _ => {}
+                            // TODO: interpret variant="compact" without fallbackFor as a
+                            //       fallback for system-ui, as falling back to a
+                            //       variant="elegant" for system-ui can mess up a layout
+                            //       in some scripts.
                         }
+                        _ => {}
                     }
                 }
             }

--- a/fontique/src/backend/coretext.rs
+++ b/fontique/src/backend/coretext.rs
@@ -170,12 +170,11 @@ fn collect_files(dir: &Path, max_depth: u32, depth: u32, out: &mut Vec<PathBuf>)
 }
 
 fn create_base_font(prefer_ui_font: bool) -> CFRetained<CTFont> {
-    if prefer_ui_font {
-        if let Some(font) =
+    if prefer_ui_font
+        && let Some(font) =
             unsafe { CTFont::new_ui_font_for_language(CTFontUIFontType::System, 0.0, None) }
-        {
-            return font;
-        }
+    {
+        return font;
     }
     unsafe {
         let attrs = CFDictionary::new(None, null_mut(), null_mut(), 0, null(), null());

--- a/fontique/src/backend/dwrite.rs
+++ b/fontique/src/backend/dwrite.rs
@@ -93,13 +93,12 @@ impl SystemFonts {
         let mut fonts = smallvec::SmallVec::<[FontInfo; 4]>::default();
         if let Some(family) = self.dwrite_fonts.family_by_name(name.name()) {
             for font in family.fonts() {
-                if let Some(font) = FontInfo::from_dwrite(&font, &mut self.source_cache) {
-                    if !fonts
+                if let Some(font) = FontInfo::from_dwrite(&font, &mut self.source_cache)
+                    && !fonts
                         .iter()
                         .any(|f| f.source().id() == font.source().id() && f.index() == font.index())
-                    {
-                        fonts.push(font);
-                    }
+                {
+                    fonts.push(font);
                 }
             }
             if !fonts.is_empty() {
@@ -212,8 +211,8 @@ impl DWriteSystemFonts {
             while cur_offset < text_len {
                 let mut mapped_len = 0;
                 let mut mapped_font = None;
-                if let Some(fallback) = self.fallback.as_ref() {
-                    if fallback
+                if let Some(fallback) = self.fallback.as_ref()
+                    && fallback
                         .MapCharacters(
                             &source,
                             cur_offset as u32,
@@ -228,17 +227,16 @@ impl DWriteSystemFonts {
                             &mut 1.0,
                         )
                         .is_ok()
-                    {
-                        if let Some(font) = mapped_font {
-                            let family = font.GetFontFamily().ok()?;
-                            let names = family.GetFamilyNames().ok()?;
-                            let name_len = names.GetStringLength(0).ok()? as usize;
-                            let mut name_buf = smallvec::SmallVec::<[u16; 128]>::default();
-                            name_buf.resize(name_len + 1, 0);
-                            names.GetString(0, &mut name_buf).ok()?;
-                            name_buf.pop();
-                            return Some(String::from_utf16_lossy(&name_buf));
-                        }
+                {
+                    if let Some(font) = mapped_font {
+                        let family = font.GetFontFamily().ok()?;
+                        let names = family.GetFamilyNames().ok()?;
+                        let name_len = names.GetStringLength(0).ok()? as usize;
+                        let mut name_buf = smallvec::SmallVec::<[u16; 128]>::default();
+                        name_buf.resize(name_len + 1, 0);
+                        names.GetString(0, &mut name_buf).ok()?;
+                        name_buf.pop();
+                        return Some(String::from_utf16_lossy(&name_buf));
                     }
                 }
                 cur_offset += 1;

--- a/fontique/src/backend/dwrite.rs
+++ b/fontique/src/backend/dwrite.rs
@@ -209,10 +209,10 @@ impl DWriteSystemFonts {
         unsafe {
             let mut cur_offset = 0;
             while cur_offset < text_len {
-                let mut mapped_len = 0;
-                let mut mapped_font = None;
-                if let Some(fallback) = self.fallback.as_ref()
-                    && fallback
+                if let Some(fallback) = self.fallback.as_ref() {
+                    let mut mapped_len = 0;
+                    let mut mapped_font = None;
+                    if fallback
                         .MapCharacters(
                             &source,
                             cur_offset as u32,
@@ -227,8 +227,8 @@ impl DWriteSystemFonts {
                             &mut 1.0,
                         )
                         .is_ok()
-                {
-                    if let Some(font) = mapped_font {
+                        && let Some(font) = mapped_font
+                    {
                         let family = font.GetFontFamily().ok()?;
                         let names = family.GetFamilyNames().ok()?;
                         let name_len = names.GetStringLength(0).ok()? as usize;

--- a/fontique/src/backend/fontconfig.rs
+++ b/fontique/src/backend/fontconfig.rs
@@ -232,9 +232,10 @@ impl std::fmt::Debug for Pattern {
             )
         }) {
             Some(unparsed) => {
-                let res = f.write_str(unsafe {
+                let printable = unsafe {
                     &CStr::from_ptr(unparsed.as_ptr() as *const c_char).to_string_lossy()
-                });
+                };
+                let res = f.write_str(printable);
                 unsafe {
                     ffi_dispatch!(
                         feature = "fontconfig-dlopen",

--- a/fontique/src/collection/query.rs
+++ b/fontique/src/collection/query.rs
@@ -164,10 +164,9 @@ impl<'a> Query<'a> {
                 &mut family.default,
                 true,
                 self.source_cache,
-            ) {
-                if f(font) == QueryStatus::Stop {
-                    return;
-                }
+            ) && f(font) == QueryStatus::Stop
+            {
+                return;
             }
         }
     }

--- a/parley/src/editing/cursor.rs
+++ b/parley/src/editing/cursor.rs
@@ -118,23 +118,23 @@ impl Cursor {
     #[must_use]
     pub fn previous_visual<B: Brush>(&self, layout: &Layout<B>) -> Self {
         let [left, right] = self.visual_clusters(layout);
-        if let (Some(left), Some(right)) = (&left, &right) {
-            if left.is_soft_line_break() {
-                if left.is_rtl() && self.affinity == Affinity::Upstream {
-                    let index = if right.is_rtl() {
-                        left.text_range().start
-                    } else {
-                        left.text_range().end
-                    };
-                    return Self::from_byte_index(layout, index, Affinity::Downstream);
-                } else if !left.is_rtl() && self.affinity == Affinity::Downstream {
-                    let index = if right.is_rtl() {
-                        right.text_range().end
-                    } else {
-                        right.text_range().start
-                    };
-                    return Self::from_byte_index(layout, index, Affinity::Upstream);
-                }
+        if let (Some(left), Some(right)) = (&left, &right)
+            && left.is_soft_line_break()
+        {
+            if left.is_rtl() && self.affinity == Affinity::Upstream {
+                let index = if right.is_rtl() {
+                    left.text_range().start
+                } else {
+                    left.text_range().end
+                };
+                return Self::from_byte_index(layout, index, Affinity::Downstream);
+            } else if !left.is_rtl() && self.affinity == Affinity::Downstream {
+                let index = if right.is_rtl() {
+                    right.text_range().end
+                } else {
+                    right.text_range().start
+                };
+                return Self::from_byte_index(layout, index, Affinity::Upstream);
             }
         }
         if let Some(left) = left {

--- a/parley/src/editing/selection.rs
+++ b/parley/src/editing/selection.rs
@@ -53,10 +53,10 @@ impl Selection {
     /// Creates a new selection bounding the word at the given coordinates.
     pub fn word_from_point<B: Brush>(layout: &Layout<B>, x: f32, y: f32) -> Self {
         if let Some((mut cluster, _)) = Cluster::from_point(layout, x, y) {
-            if !cluster.is_word_boundary() {
-                if let Some(prev) = cluster.previous_logical_word() {
-                    cluster = prev;
-                }
+            if !cluster.is_word_boundary()
+                && let Some(prev) = cluster.previous_logical_word()
+            {
+                cluster = prev;
             }
             let anchor = Cursor::from_cluster(layout, cluster.clone(), !cluster.is_rtl());
             let focus = anchor.next_logical_word(layout);

--- a/parley/src/layout/accessibility.rs
+++ b/parley/src/layout/accessibility.rs
@@ -104,15 +104,15 @@ impl LayoutAccessibility {
         });
 
         let font = run.font();
-        if let Ok(font_ref) = FontRef::from_index(font.data.as_ref(), font.index) {
-            if let Ok(name) = font_ref.name() {
-                for n in name.name_record().iter() {
-                    if n.name_id.get() == NameId::FAMILY_NAME {
-                        if let Ok(string) = n.string(name.string_data()) {
-                            node.set_font_family(string.to_string());
-                        }
-                        break;
+        if let Ok(font_ref) = FontRef::from_index(font.data.as_ref(), font.index)
+            && let Ok(name) = font_ref.name()
+        {
+            for n in name.name_record().iter() {
+                if n.name_id.get() == NameId::FAMILY_NAME {
+                    if let Ok(string) = n.string(name.string_data()) {
+                        node.set_font_family(string.to_string());
                     }
+                    break;
                 }
             }
         }

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -205,7 +205,7 @@ impl<'a, B: Brush> Cluster<'a, B> {
     }
 
     /// Returns an iterator over the glyphs in the cluster.
-    pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + 'a + Clone {
+    pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + 'a + Clone + use<'a, B> {
         if self.data.glyph_len == 0xFF {
             GlyphIter::Single(Some(Glyph {
                 id: self.data.glyph_offset,

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -294,15 +294,15 @@ impl<'a, B: Brush> Cluster<'a, B> {
             for line_index in self.path.line_index()..layout.len() {
                 let line = layout.get(line_index)?;
                 for run_index in run_index..line.len() {
-                    if let Some(run) = line.item(run_index).and_then(|item| item.run()) {
-                        if !run.cluster_range().is_empty() {
-                            return ClusterPath {
-                                line_index: line_index as u32,
-                                run_index: run_index as u32,
-                                logical_index: run.visual_to_logical(0)? as u32,
-                            }
-                            .cluster(layout);
+                    if let Some(run) = line.item(run_index).and_then(|item| item.run())
+                        && !run.cluster_range().is_empty()
+                    {
+                        return ClusterPath {
+                            line_index: line_index as u32,
+                            run_index: run_index as u32,
+                            logical_index: run.visual_to_logical(0)? as u32,
                         }
+                        .cluster(layout);
                     }
                 }
                 // Restart at first run on next line

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -867,10 +867,10 @@ fn process_clusters<I: Iterator<Item = (usize, char)>>(
             let mut inline_glyph_id = None;
             match cluster_type {
                 ClusterType::Regular => {
-                    if total_glyphs == cluster_glyph_offset {
-                        if let Some(pending) = pending_inline_glyph.take() {
-                            inline_glyph_id = Some(pending.id);
-                        }
+                    if total_glyphs == cluster_glyph_offset
+                        && let Some(pending) = pending_inline_glyph.take()
+                    {
+                        inline_glyph_id = Some(pending.id);
                     }
                 }
                 _ => {

--- a/parley/src/layout/line.rs
+++ b/parley/src/layout/line.rs
@@ -73,7 +73,9 @@ impl<'a, B: Brush> Line<'a, B> {
     }
 
     /// Returns an iterator over the non-glyph runs and inline boxes for the line.
-    pub(crate) fn items_nonpositioned(&self) -> impl Iterator<Item = LineItem<'a, B>> + Clone + use<'a, B> {
+    pub(crate) fn items_nonpositioned(
+        &self,
+    ) -> impl Iterator<Item = LineItem<'a, B>> + Clone + use<'a, B> {
         let copy = self.clone();
         let line_items = &copy.layout.data.line_items[self.data.item_range.clone()];
         line_items
@@ -94,7 +96,9 @@ impl<'a, B: Brush> Line<'a, B> {
     }
 
     /// Returns an iterator over the glyph runs for the line.
-    pub fn items(&self) -> impl Iterator<Item = PositionedLayoutItem<'a, B>> + 'a + Clone + use<'a, B> {
+    pub fn items(
+        &self,
+    ) -> impl Iterator<Item = PositionedLayoutItem<'a, B>> + 'a + Clone + use<'a, B> {
         GlyphRunIter {
             line: self.clone(),
             item_index: 0,

--- a/parley/src/layout/line.rs
+++ b/parley/src/layout/line.rs
@@ -68,12 +68,12 @@ impl<'a, B: Brush> Line<'a, B> {
     }
 
     /// Returns an iterator over the runs for the line.
-    pub fn runs(&self) -> impl Iterator<Item = Run<'a, B>> + 'a + Clone {
+    pub fn runs(&self) -> impl Iterator<Item = Run<'a, B>> + 'a + Clone + use<'a, B> {
         self.items_nonpositioned().filter_map(|item| item.run())
     }
 
     /// Returns an iterator over the non-glyph runs and inline boxes for the line.
-    pub(crate) fn items_nonpositioned(&self) -> impl Iterator<Item = LineItem<'a, B>> + Clone {
+    pub(crate) fn items_nonpositioned(&self) -> impl Iterator<Item = LineItem<'a, B>> + Clone + use<'a, B> {
         let copy = self.clone();
         let line_items = &copy.layout.data.line_items[self.data.item_range.clone()];
         line_items
@@ -94,7 +94,7 @@ impl<'a, B: Brush> Line<'a, B> {
     }
 
     /// Returns an iterator over the glyph runs for the line.
-    pub fn items(&self) -> impl Iterator<Item = PositionedLayoutItem<'a, B>> + 'a + Clone {
+    pub fn items(&self) -> impl Iterator<Item = PositionedLayoutItem<'a, B>> + 'a + Clone + use<'a, B> {
         GlyphRunIter {
             line: self.clone(),
             item_index: 0,

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -867,11 +867,11 @@ impl<'a, B: Brush> BreakLines<'a, B> {
 
     /// Consumes the line breaker and finalizes all line computations.
     pub fn finish(mut self) {
-        if self.layout.data.text_len == 0 {
-            if let Some(line) = self.lines.line_items.first_mut() {
-                line.text_range = 0..0;
-                line.cluster_range = 0..0;
-            }
+        if self.layout.data.text_len == 0
+            && let Some(line) = self.lines.line_items.first_mut()
+        {
+            line.text_range = 0..0;
+            line.cluster_range = 0..0;
         }
     }
 
@@ -1126,10 +1126,10 @@ impl<B: Brush> Drop for BreakLines<'_, B> {
         }
 
         // Don't include the last line's line_height in the layout's height if the last line is empty
-        if let Some(last_line) = self.lines.lines.last() {
-            if last_line.item_range.is_empty() {
-                height -= last_line.metrics.line_height as f64;
-            }
+        if let Some(last_line) = self.lines.lines.last()
+            && last_line.item_range.is_empty()
+        {
+            height -= last_line.metrics.line_height as f64;
         }
 
         // Save the computed widths/height to the layout

--- a/parley/src/resolve/mod.rs
+++ b/parley/src/resolve/mod.rs
@@ -95,13 +95,13 @@ impl<T: Clone + PartialEq> Cache<T> {
             if range.len() != items.len() {
                 continue;
             }
-            if let Some(existing) = self.items.get(range) {
-                if existing == items {
-                    return Resolved {
-                        index: i,
-                        _phantom: core::marker::PhantomData,
-                    };
-                }
+            if let Some(existing) = self.items.get(range)
+                && existing == items
+            {
+                return Resolved {
+                    index: i,
+                    _phantom: core::marker::PhantomData,
+                };
             }
         }
         let index = self.entries.len();

--- a/parley_bench/src/draw.rs
+++ b/parley_bench/src/draw.rs
@@ -91,25 +91,22 @@ fn render_layout(
                     );
                     run_renderer.fill_glyphs(renderer);
 
-                    if with_underline {
-                        if let Some(decoration) = &glyph_run.style().underline {
-                            let offset =
-                                decoration.offset.unwrap_or(run.metrics().underline_offset);
-                            let size = decoration.size.unwrap_or(run.metrics().underline_size);
+                    if with_underline && let Some(decoration) = &glyph_run.style().underline {
+                        let offset = decoration.offset.unwrap_or(run.metrics().underline_offset);
+                        let size = decoration.size.unwrap_or(run.metrics().underline_size);
 
-                            let x = glyph_run.offset();
-                            let x1 = x + glyph_run.advance();
-                            let baseline = glyph_run.baseline();
+                        let x = glyph_run.offset();
+                        let x1 = x + glyph_run.advance();
+                        let baseline = glyph_run.baseline();
 
-                            run_renderer.render_decoration(
-                                x..=x1,
-                                baseline,
-                                offset,
-                                size,
-                                1.0, // buffer around exclusions
-                                renderer,
-                            );
-                        }
+                        run_renderer.render_decoration(
+                            x..=x1,
+                            baseline,
+                            offset,
+                            size,
+                            1.0, // buffer around exclusions
+                            renderer,
+                        );
                     }
                 }
                 PositionedLayoutItem::InlineBox(_) => {}

--- a/parley_core/src/analysis.rs
+++ b/parley_core/src/analysis.rs
@@ -530,18 +530,18 @@ pub(crate) fn analyze_text(
         }
 
         let mut is_word = false;
-        if let Some(&w) = wb_iter.peek() {
-            if w == byte_pos {
-                is_word = true;
-                _ = wb_iter.next();
-            }
+        if let Some(&w) = wb_iter.peek()
+            && w == byte_pos
+        {
+            is_word = true;
+            _ = wb_iter.next();
         }
         let mut is_line = false;
-        if let Some(&l) = lb_iter.peek() {
-            if *l == byte_pos {
-                is_line = true;
-                _ = lb_iter.next();
-            }
+        if let Some(&l) = lb_iter.peek()
+            && *l == byte_pos
+        {
+            is_line = true;
+            _ = lb_iter.next();
         }
 
         // This leaves word boundaries intact. Consumers can only impact line boundaries.

--- a/parley_tests/tests/util/env.rs
+++ b/parley_tests/tests/util/env.rs
@@ -349,12 +349,12 @@ impl TestEnv {
             // but it's simpler to cover all cases.
             std::fs::write(path, data).unwrap();
 
-            if let Some(max_size) = max_size {
-                if saved_len > max_size {
-                    panic!(
-                        "New screenshot file size ({saved_len}b) was larger than the supported file size ({max_size}b). See TestEnv::max_screenshot_size to change the maximum.",
-                    );
-                }
+            if let Some(max_size) = max_size
+                && saved_len > max_size
+            {
+                panic!(
+                    "New screenshot file size ({saved_len}b) was larger than the supported file size ({max_size}b). See TestEnv::max_screenshot_size to change the maximum.",
+                );
             }
         }
 
@@ -377,12 +377,12 @@ impl TestEnv {
             save_image(img, &comparison_path, max_size);
         } else {
             let reference_size = snapshot_path.metadata().unwrap().len() as usize;
-            if let Some(max_size) = max_size {
-                if reference_size > max_size {
-                    panic!(
-                        "Existing file size ({reference_size}b) was larger than the supported file size ({max_size}b). See TestEnv::max_screenshot_size to change the maximum."
-                    );
-                }
+            if let Some(max_size) = max_size
+                && reference_size > max_size
+            {
+                panic!(
+                    "Existing file size ({reference_size}b) was larger than the supported file size ({max_size}b). See TestEnv::max_screenshot_size to change the maximum."
+                );
             }
         }
     }


### PR DESCRIPTION
Brings in some niceties like let chains.

The easiest way to review this is probably to disable whitespace.

Alternatively, you can run the same sequence of commands:

```sh
cargo fix --edition
cargo fmt
# Bump edition in Cargo.toml
cargo clippy --fix
cargo fmt
```