### PR TITLE
Treat CRLF as a single hard line break

### DIFF
--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -584,8 +584,41 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                             if max_height_exceeded {
                                 return self.max_height_break_data(line_height);
                             }
+                            // A CRLF sequence is a single grapheme cluster and must produce
+                            // exactly one hard line break (UAX#14: CR × LF, do not break
+                            // between). When this newline is a CR immediately followed by an
+                            // LF, append the CR to the current line but suppress the break
+                            // here and let the LF emit the single break, so CR and LF share
+                            // one line. The lookahead reads the global cluster list so a CRLF
+                            // that shaping split across two runs (e.g. a style boundary at the
+                            // LF) is still coalesced. The LF must be item-adjacent to the CR:
+                            // if it lands in a later run it only coalesces when the next item
+                            // is that run (not an inline box sitting between the two), so an
+                            // inline box at the LF offset keeps the CR's break. Lone CR, lone
+                            // LF, LS, and PS are unaffected.
+                            let lf_is_item_adjacent = self.state.cluster_idx + 1 < cluster_end
+                                || self
+                                    .layout
+                                    .data
+                                    .items
+                                    .get(self.state.item_idx + 1)
+                                    .is_some_and(|item| item.kind == LayoutItemKind::TextRun);
+                            let is_cr_before_lf = cluster.info().source_char() == '\r'
+                                && lf_is_item_adjacent
+                                && self
+                                    .layout
+                                    .data
+                                    .clusters
+                                    .get(self.state.cluster_idx + 1)
+                                    .is_some_and(|next| {
+                                        next.info.whitespace() == Whitespace::Newline
+                                            && next.info.source_char() == '\n'
+                                    });
                             self.state
                                 .append_cluster_to_line(self.state.line.x, line_height);
+                            if is_cr_before_lf {
+                                continue;
+                            }
                             return self.start_new_line(
                                 BreakReason::Explicit,
                                 max_advance,

--- a/parley/src/tests/test_builders.rs
+++ b/parley/src/tests/test_builders.rs
@@ -544,3 +544,87 @@ fn builders_mixed_styles() {
         false,
     );
 }
+
+#[test]
+fn builders_crlf_counts_as_single_line_break() {
+    let mut fcx = create_font_context();
+    let mut line_count = |text: &str| -> usize {
+        let mut lcx: LayoutContext<ColorBrush> = LayoutContext::new();
+        let ropts = RangedOptions {
+            scale: 1.0,
+            quantize: false,
+            max_advance: None,
+            text,
+        };
+        let layout = build_layout_with_ranged(&mut fcx, &mut lcx, &ropts, |rb| {
+            set_root_style(rb);
+        });
+        layout.lines().len()
+    };
+
+    let crlf = line_count("a\r\nb");
+    let lf = line_count("a\nb");
+    let cr = line_count("a\rb");
+
+    assert_eq!(crlf, 2, "CRLF should produce exactly two lines");
+    assert_eq!(lf, 2, "LF should produce exactly two lines");
+    assert_eq!(crlf, lf, "CRLF should match LF line count");
+    assert_eq!(crlf, cr, "CRLF, LF, and CR should match line count");
+
+    let double_crlf = line_count("a\r\n\r\nb");
+    let double_lf = line_count("a\n\nb");
+
+    assert_eq!(
+        double_crlf, 3,
+        "two CRLF breaks should produce one blank line, not extra blanks"
+    );
+    assert_eq!(
+        double_crlf, double_lf,
+        "two CRLF breaks should match two LF breaks"
+    );
+
+    let trailing_cr = line_count("a\r");
+    let trailing_lf = line_count("a\n");
+
+    assert_eq!(
+        trailing_cr, trailing_lf,
+        "trailing CR should match trailing LF line count"
+    );
+}
+
+/// A CRLF whose `\r` and `\n` land in different shaped runs (because a style
+/// change starts at the `\n`) must still coalesce into a single hard break.
+#[test]
+fn builders_crlf_across_run_boundary_counts_as_single_line_break() {
+    let mut fcx = create_font_context();
+    let styled_line_count =
+        |fcx: &mut FontContext, text: &str, style_range: std::ops::Range<usize>| -> usize {
+            let mut lcx: LayoutContext<ColorBrush> = LayoutContext::new();
+            let ropts = RangedOptions {
+                scale: 1.0,
+                quantize: false,
+                max_advance: None,
+                text,
+            };
+            let layout = build_layout_with_ranged(fcx, &mut lcx, &ropts, |rb| {
+                set_root_style(rb);
+                // A style change starting at the `\n` forces shaping to split the
+                // CRLF pair across two runs.
+                rb.push(StyleProperty::FontSize(40.), style_range.clone());
+            });
+            layout.lines().len()
+        };
+
+    // The `\n` in "a\r\nb" is byte 2.
+    let split_crlf = styled_line_count(&mut fcx, "a\r\nb", 2..3);
+    let split_lf = styled_line_count(&mut fcx, "a\nb", 2..3);
+
+    assert_eq!(
+        split_crlf, 2,
+        "a style boundary at the LF must not turn CRLF into two hard breaks"
+    );
+    assert_eq!(
+        split_crlf, split_lf,
+        "styled CRLF should match styled LF line count"
+    );
+}


### PR DESCRIPTION
## What

A `\r\n` (CRLF) sequence is currently treated as two hard line breaks instead of one, so a document authored with CRLF line endings renders with a spurious empty line between every line compared with the same text using `\n`.

## Why

`to_whitespace` in `layout/data.rs` classifies both `'\r'` and `'\n'` as `Whitespace::Newline`, so a CRLF surfaces as two consecutive newline clusters. In `break_next`, the `is_newline` branch emits `BreakReason::Explicit` for each of them, producing two lines.

Per UAX#14 (CR × LF, do not break between) and the grapheme-cluster framing raised in the issue thread, CR, LF, and CRLF should each be a single hard break (CR+LF is one grapheme cluster).

## How

The fix stays at the line-breaking layer and does not touch `to_whitespace` / `ClusterInfo`, which are used broadly by cursor and selection code.

In `break_next`, when a newline cluster is a `'\r'` immediately followed by a `'\n'` newline, the `'\r'` is appended to the current line but the break is suppressed there, letting the following `'\n'` emit the single hard break so the CR and LF share one line. The lookahead reads the global cluster list, so it also coalesces a CRLF that shaping split across two runs (for example a style or font boundary starting at the `\n`). It requires the LF to be item-adjacent to the CR, so an inline box positioned between the two still keeps the CR's break. Lone `\r`, lone `\n`, LS (U+2028), and PS (U+2029) behaviour is unchanged.

## Scope

This covers the CRLF-as-one-hard-break part of the issue. The separate case mentioned in the thread, where an over-long ligature that forms a single grapheme cluster still needs character-level emergency wrapping, lives in a different code path and is left as follow-up, so this references rather than closes the issue.

## Tests

Added two tests in `tests/test_builders.rs`:

- `builders_crlf_counts_as_single_line_break`: `"a\r\nb"` yields the same line count as `"a\nb"` and `"a\rb"` (2 lines, no blank line between); doubled `"a\r\n\r\nb"` matches `"a\n\nb"` (3 lines, one blank line) rather than producing extra blanks; a trailing `"a\r"` matches `"a\n"`.
- `builders_crlf_across_run_boundary_counts_as_single_line_break`: a style change starting at the `\n` forces shaping to split the CRLF across two runs, and the pair still coalesces into a single break.

Happy to add a `CHANGELOG.md` entry under `[Unreleased]` once this has a PR number, if that is preferred.

Refs #555
