### PR TITLE
Fix Fontique build on 32bit platforms + add CI job to check this

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_STABLE_VER }}
-          targets: x86_64-unknown-none,thumbv8m.main-none-eabihf
+          targets: x86_64-unknown-none,thumbv8m.main-none-eabihf,powerpc-unknown-linux-gnu
           components: clippy
 
       - name: Install fontconfig-dev
@@ -143,6 +143,14 @@ jobs:
 
       - name: cargo clippy (no_std 32-bit)
         run: cargo hack clippy ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} --target thumbv8m.main-none-eabihf -- -D warnings
+
+      # We check the std code paths on a 32-bit target without 64-bit atomics
+      # (powerpc-unknown-linux-gnu) to catch regressions like our atomics-based
+      # version counters assuming a 64-bit-wide integer. We omit --optional-deps
+      # and exclude the system feature because the system font backends pull in
+      # C dependencies (e.g. fontconfig) that can't be cross-compiled here.
+      - name: cargo clippy (32-bit with std)
+        run: cargo hack clippy ${{ env.RUST_MIN_VER_PKGS }} --locked --each-feature --ignore-unknown-features --features std --exclude-features default,system,png,vello_hybrid --target powerpc-unknown-linux-gnu -- -D warnings
 
       - name: cargo clippy
         run: cargo hack clippy --workspace --locked --optional-deps --each-feature --ignore-unknown-features --features std -- -D warnings
@@ -275,7 +283,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_MIN_VER }}
-          targets: x86_64-unknown-none,thumbv8m.main-none-eabihf
+          targets: x86_64-unknown-none,thumbv8m.main-none-eabihf,powerpc-unknown-linux-gnu
 
       - name: Install fontconfig-dev
         if: runner.os == 'Linux'
@@ -298,6 +306,14 @@ jobs:
 
       - name: cargo check (no_std 32-bit)
         run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} --target thumbv8m.main-none-eabihf
+
+      # We check the std code paths on a 32-bit target without 64-bit atomics
+      # (powerpc-unknown-linux-gnu) to catch regressions like our atomics-based
+      # version counters assuming a 64-bit-wide integer. We omit --optional-deps
+      # and exclude the system feature because the system font backends pull in
+      # C dependencies (e.g. fontconfig) that can't be cross-compiled here.
+      - name: cargo check (32-bit with std)
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --each-feature --ignore-unknown-features --features std --exclude-features default,system,png,vello_hybrid --target powerpc-unknown-linux-gnu
 
       - name: cargo check
         run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features std

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ This release has an [MSRV] of 1.88.
 
 - Breaking change: the `Glyph::style_index` field was removed. Use `Cluster::{style, style_index}` or `GlyphRun::{style, style_index}` instead. (#661 by [@tomcur][])
 
+### Fixed
+
+#### Fontique
+
+- Fix compilation on 32-bit platforms without 64-bit atomics (e.g. `mipsel-unknown-linux-gnu`). (#671 by [@nicoburns][])
+
 ## [0.11.0] - 2026-06-24
 
 This release has an [MSRV] of 1.88.

--- a/fontique/src/collection/mod.rs
+++ b/fontique/src/collection/mod.rs
@@ -21,7 +21,7 @@ use super::{
     generic::GenericFamilyMap,
     source::{SourceId, SourceInfo, SourceKind},
 };
-use crate::AtomicCounter;
+use crate::{AtomicCounter, CounterInt};
 use alloc::{string::String, sync::Arc, vec::Vec};
 use hashbrown::HashMap;
 use read_fonts::types::NameId;
@@ -242,7 +242,7 @@ struct Inner {
     #[allow(unused)]
     shared: Option<Arc<Shared>>,
     #[allow(unused)]
-    shared_version: u64,
+    shared_version: CounterInt,
     fallback_cache: FallbackCache,
 }
 

--- a/fontique/src/lib.rs
+++ b/fontique/src/lib.rs
@@ -75,3 +75,13 @@ pub use source_cache::{SourceCache, SourceCacheOptions};
 use core::sync::atomic::AtomicU32 as AtomicCounter;
 #[cfg(target_has_atomic = "64")]
 use core::sync::atomic::AtomicU64 as AtomicCounter;
+
+/// The integer type underlying [`AtomicCounter`].
+///
+/// This is `u32` on platforms without 64-bit atomics (e.g. many 32-bit
+/// targets) and `u64` elsewhere.
+#[cfg(not(target_has_atomic = "64"))]
+type CounterInt = u32;
+/// The integer type underlying [`AtomicCounter`].
+#[cfg(target_has_atomic = "64")]
+type CounterInt = u64;


### PR DESCRIPTION
Fixes https://github.com/linebender/parley/issues/671

Changes:

- Adds a 64/32 bit conditional compile for non-atomic integers, as these are converted into atomic ones in some places.
- Uses this for the `shared_version` field of the collection's `Inner` type.
- Add CI jobs for `powerpc-unknown-linux-gnu`

Generated by Opus 4.8