### PR TITLE
Update PackTab to 1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2850,8 +2850,7 @@ dependencies = [
 [[package]]
 name = "packtab"
 version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e24935132067c8b4378bd0140fd77fbe882d1cd8d3cd796a082c2831782c5a"
+source = "git+https://github.com/behdad/packtab.rs.git?rev=558be7e723bbf6e7b22873c79ddbb7c9da498fc0#558be7e723bbf6e7b22873c79ddbb7c9da498fc0"
 
 [[package]]
 name = "parking"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2849,8 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "packtab"
-version = "1.8.0"
-source = "git+https://github.com/behdad/packtab.rs.git?rev=558be7e723bbf6e7b22873c79ddbb7c9da498fc0#558be7e723bbf6e7b22873c79ddbb7c9da498fc0"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5113194bb1e649b5af5940def220bef7a62fbae393d37863e5bb94463212725a"
 
 [[package]]
 name = "parking"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ icu_normalizer = { version = "2.1.1", default-features = false }
 icu_properties = { version = "2.1.2", default-features = false }
 icu_segmenter = { version = "2.1.2", default-features = false }
 linebender_resource_handle = { version = "0.1.1", default-features = false }
-packtab = { git = "https://github.com/behdad/packtab.rs.git", rev = "558be7e723bbf6e7b22873c79ddbb7c9da498fc0" }
+packtab = { version = "1.9.0" }
 glifo = { git = "https://github.com/linebender/vello", rev = "5796226", default-features = false }
 rand = { version = "0.10.1", default-features = false, features = ["std", "std_rng"] }
 rand_chacha = { version = "0.10.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ icu_normalizer = { version = "2.1.1", default-features = false }
 icu_properties = { version = "2.1.2", default-features = false }
 icu_segmenter = { version = "2.1.2", default-features = false }
 linebender_resource_handle = { version = "0.1.1", default-features = false }
-packtab = { version = "1.8.0" }
+packtab = { git = "https://github.com/behdad/packtab.rs.git", rev = "558be7e723bbf6e7b22873c79ddbb7c9da498fc0" }
 glifo = { git = "https://github.com/linebender/vello", rev = "5796226", default-features = false }
 rand = { version = "0.10.1", default-features = false, features = ["std", "std_rng"] }
 rand_chacha = { version = "0.10.0", default-features = false }


### PR DESCRIPTION
## Intent

Upgrade to the new PackTab 1.9.0.

---

I previously tested the PR (https://github.com/behdad/packtab.rs/pull/2) in https://github.com/linebender/parley/pull/674/commits/22bbd1dc2855513d3fe226258a6cad45cdf5140a prior to updating this PR to use the new 1.9.0 version. That investigation is below:

Tested against cases our existing `--compression=5`, but also `--compression=0` and `--compression=10`. Our regressions tests pass for all cases - so, it's correct as far as Parley is concerned. 

At compression=10, I noticed a 7 byte reduction relative to current PackTab - I believe that's expected because the proposed PR drops dead padding bytes