### PR TITLE
Fix docs about emoji variation selector ignoring

### DIFF
--- a/parley_core/src/shape/cluster.rs
+++ b/parley_core/src/shape/cluster.rs
@@ -315,10 +315,13 @@ impl CharCluster {
             // Its presentation depends on the platform and font.
             //
             // e.g.
-            //  - `U+270C + U+FE0F`: `✌`, force basic presentation
+            //  - `U+270C + U+FE0E`: `✌`, force text presentation
             //  - `U+270C + U+FE0F`: `✌️`, force emoji presentation
             //
-            // <https://www.unicode.org/reports/tr37/>
+            // See <https://www.unicode.org/reports/tr51/#Emoji_Variation_Sequences> for emoji
+            // variation sequences and
+            // <https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-23/#G19053> for
+            // variation selectors more generally.
             let is_emoji_with_non_printing_variation_selector =
                 is_emoji_or_pictograph && info.is_variation_selector();
 


### PR DESCRIPTION
This fixes the code point in the docs, links to the Unicode report defining these Emoji sequences, and replaces the link to TR37 (ideographic variation selectors) with a link to the section on variation selectors in the core spec.

(For posterity, these docs were introduced in https://github.com/linebender/parley/pull/617, which fixed font querying for emoji with variation selectors).

It's probably valid for the check to ignore all variation selectors, not only those following emoji, but that's a separate discussion.