### PR TITLE
Correctly handle "doesn't compose" in `CharCluster`

### DIFF
--- a/parley_core/src/shape/cluster.rs
+++ b/parley_core/src/shape/cluster.rs
@@ -181,21 +181,14 @@ impl CharCluster {
                 }
 
                 let composer = analysis_data_sources.composing_normalizer();
-                let comp = composer.compose(self.chars[0].ch, self.chars[1].ch);
-                match comp {
-                    None => {
-                        // The characters don't compose.
-                        return None;
-                    }
-                    Some(ch) => {
-                        let mut copy = self.chars[0];
-                        copy.ch = ch;
-                        copy.contributes_to_shaping =
-                            Self::contributes_to_shaping(ch, analysis_data_sources);
-                        self.comp.chars[0] = copy;
-                        self.comp.len = 1;
-                    }
-                }
+                let ch = composer.compose(self.chars[0].ch, self.chars[1].ch)?;
+
+                let mut copy = self.chars[0];
+                copy.ch = ch;
+                copy.contributes_to_shaping =
+                    Self::contributes_to_shaping(ch, analysis_data_sources);
+                self.comp.chars[0] = copy;
+                self.comp.len = 1;
 
                 self.comp.state = FormState::Valid;
                 self.comp.setup();

--- a/parley_core/src/shape/cluster.rs
+++ b/parley_core/src/shape/cluster.rs
@@ -183,7 +183,10 @@ impl CharCluster {
                 let composer = analysis_data_sources.composing_normalizer();
                 let comp = composer.compose(self.chars[0].ch, self.chars[1].ch);
                 match comp {
-                    None => {}
+                    None => {
+                        // The characters don't compose.
+                        return None;
+                    }
                     Some(ch) => {
                         let mut copy = self.chars[0];
                         copy.ch = ch;


### PR DESCRIPTION
We are treating "doesn't compose" as a zero-length composition.

This bug has no observable effect outside the module, as we later do a `map_len.max(1)` and end up treating this as a coverage of `0 / 1`, but that feels like accidental correctness (I hit the bug when I was changing some other code in this module).