### PR TITLE
Lookup + Store Grapheme Boundaries during Text Analysis

### DIFF
--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -127,7 +127,6 @@ pub(crate) fn shape_text<'a, B: Brush>(
                         synthesis: selected.font.synthesis,
                     })
             },
-            analysis_data_sources,
             &mut layout.data.shaped_text,
         );
         for shaped_run_idx in shaped_runs_range {

--- a/parley/src/tests/test_analysis.rs
+++ b/parley/src/tests/test_analysis.rs
@@ -56,6 +56,18 @@ impl TestContext {
         self
     }
 
+    fn expect_grapheme_start_list(self, expected: Vec<bool>) -> Self {
+        let actual: Vec<_> = self
+            .layout_context
+            .analysis
+            .char_info()
+            .iter()
+            .map(|info| info.is_grapheme_start())
+            .collect();
+        assert_eq!(actual, expected, "Grapheme start list mismatch");
+        self
+    }
+
     fn expect_is_control_list(self, expected: Vec<bool>) -> Self {
         let actual: Vec<_> = self
             .layout_context
@@ -430,7 +442,31 @@ fn test_multi_char_grapheme() {
         ])
         .expect_is_control_list(vec![false, false, false, false, false, false])
         .expect_contributes_to_shaping_list(vec![true, true, true, true, true, true])
-        .expect_force_normalize_list(vec![false, false, false, true, false, false]);
+        .expect_force_normalize_list(vec![false, false, false, true, false, false])
+        .expect_grapheme_start_list(vec![true, true, true, false, true, true]);
+}
+
+#[test]
+fn test_grapheme_start_multi_char_graphemes() {
+    // CRLF (GB3), emoji ZWJ sequence 👨‍👩‍👧 (GB9/GB11), and regional indicator
+    // pair 🇦🇺 (GB12) are each a single extended grapheme cluster.
+    verify_analysis(
+        "a\r\n\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{1F1E6}\u{1F1FA}b",
+        |_| {},
+    )
+    .expect_grapheme_start_list(vec![
+        true,  // 'a'
+        true,  // '\r'
+        false, // '\n' (CR x LF)
+        true,  // 👨
+        false, // ZWJ
+        false, // 👩
+        false, // ZWJ
+        false, // 👧
+        true,  // 🇦 (regional indicator A)
+        false, // 🇺 (regional indicator U)
+        true,  // 'b'
+    ]);
 }
 
 #[test]

--- a/parley_core/src/analysis.rs
+++ b/parley_core/src/analysis.rs
@@ -277,7 +277,9 @@ impl CharInfo {
         self.flags & Self::FORCE_NORMALIZE_MASK != 0
     }
 
-    /// Whether this character begins a grapheme cluster (UAX #29).
+    /// Whether this character begins a grapheme cluster ([UAX #29 § 3][graphemes]).
+    ///
+    /// [graphemes]: https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries
     #[inline(always)]
     pub fn is_grapheme_start(self) -> bool {
         self.flags & Self::GRAPHEME_START_MASK != 0

--- a/parley_core/src/analysis.rs
+++ b/parley_core/src/analysis.rs
@@ -277,7 +277,7 @@ impl CharInfo {
         self.flags & Self::FORCE_NORMALIZE_MASK != 0
     }
 
-    /// Whether this character begins an extended grapheme cluster (UAX #29).
+    /// Whether this character begins a grapheme cluster (UAX #29).
     #[inline(always)]
     pub fn is_grapheme_start(self) -> bool {
         self.flags & Self::GRAPHEME_START_MASK != 0

--- a/parley_core/src/analysis.rs
+++ b/parley_core/src/analysis.rs
@@ -192,6 +192,7 @@ impl CharInfo {
     const EMOJI_OR_PICTOGRAPH_SHIFT: u8 = 3;
     const CONTRIBUTES_TO_SHAPING_SHIFT: u8 = 4;
     const FORCE_NORMALIZE_SHIFT: u8 = 5;
+    const GRAPHEME_START_SHIFT: u8 = 6;
 
     #[allow(
         dead_code,
@@ -207,6 +208,7 @@ impl CharInfo {
     const EMOJI_OR_PICTOGRAPH_MASK: u8 = 1 << Self::EMOJI_OR_PICTOGRAPH_SHIFT;
     const CONTRIBUTES_TO_SHAPING_MASK: u8 = 1 << Self::CONTRIBUTES_TO_SHAPING_SHIFT;
     const FORCE_NORMALIZE_MASK: u8 = 1 << Self::FORCE_NORMALIZE_SHIFT;
+    const GRAPHEME_START_MASK: u8 = 1 << Self::GRAPHEME_START_SHIFT;
 
     fn new(
         boundary: Boundary,
@@ -220,6 +222,7 @@ impl CharInfo {
         is_emoji_or_pictograph: bool,
         contributes_to_shaping: bool,
         force_normalize: bool,
+        is_grapheme_start: bool,
     ) -> Self {
         Self {
             boundary,
@@ -232,7 +235,8 @@ impl CharInfo {
                 | (is_control as u8) << Self::CONTROL_SHIFT
                 | (is_emoji_or_pictograph as u8) << Self::EMOJI_OR_PICTOGRAPH_SHIFT
                 | (contributes_to_shaping as u8) << Self::CONTRIBUTES_TO_SHAPING_SHIFT
-                | (force_normalize as u8) << Self::FORCE_NORMALIZE_SHIFT,
+                | (force_normalize as u8) << Self::FORCE_NORMALIZE_SHIFT
+                | (is_grapheme_start as u8) << Self::GRAPHEME_START_SHIFT,
         }
     }
 
@@ -271,6 +275,12 @@ impl CharInfo {
     #[inline(always)]
     pub fn force_normalize(self) -> bool {
         self.flags & Self::FORCE_NORMALIZE_MASK != 0
+    }
+
+    /// Whether this character begins an extended grapheme cluster (UAX #29).
+    #[inline(always)]
+    pub fn is_grapheme_start(self) -> bool {
+        self.flags & Self::GRAPHEME_START_MASK != 0
     }
 }
 
@@ -506,6 +516,10 @@ pub(crate) fn analyze_text(
 
     // Collect boundary byte positions compactly
     let mut wb_iter = data_sources.word_segmenter().segment_str(text).peekable();
+    let mut gb_iter = data_sources
+        .grapheme_segmenter()
+        .segment_str(text)
+        .peekable();
 
     // Merge boundaries - line takes precedence over word
     let mut lb_iter = line_boundary_positions.iter().peekable();
@@ -516,6 +530,14 @@ pub(crate) fn analyze_text(
         while let Some(&w) = wb_iter.peek() {
             if w < byte_pos {
                 _ = wb_iter.next();
+            } else {
+                break;
+            }
+        }
+        // advance any stale grapheme boundary positions
+        while let Some(&g) = gb_iter.peek() {
+            if g < byte_pos {
+                _ = gb_iter.next();
             } else {
                 break;
             }
@@ -535,6 +557,13 @@ pub(crate) fn analyze_text(
         {
             is_word = true;
             _ = wb_iter.next();
+        }
+        let mut is_grapheme_start = false;
+        if let Some(&g) = gb_iter.peek()
+            && g == byte_pos
+        {
+            is_grapheme_start = true;
+            _ = gb_iter.next();
         }
         let mut is_line = false;
         if let Some(&l) = lb_iter.peek()
@@ -566,7 +595,7 @@ pub(crate) fn analyze_text(
             Boundary::None
         };
 
-        (boundary, ch)
+        (boundary, is_grapheme_start, ch)
     });
 
     let properties = |c| data_sources.properties(c);
@@ -579,56 +608,60 @@ pub(crate) fn analyze_text(
         // characters (like '\n') exist at an index position one higher than the respective
         // character's index, but we need our iterators to align, and the rest are simply
         // character-indexed.
-        .fold(false, |is_mandatory_linebreak, (boundary, ch)| {
-            let properties = properties(ch);
-            let script = properties.script();
-            let grapheme_cluster_break = properties.grapheme_cluster_break();
-            let bidi_class = properties.bidi_class();
-            let general_category = properties.general_category();
-            let is_emoji_or_pictograph = properties.is_emoji_or_pictograph();
-            let is_variation_selector = properties.is_variation_selector();
-            let is_region_indicator = properties.is_region_indicator();
-            let next_mandatory_linebreak = properties.is_mandatory_linebreak();
+        .fold(
+            false,
+            |is_mandatory_linebreak, (boundary, is_grapheme_start, ch)| {
+                let properties = properties(ch);
+                let script = properties.script();
+                let grapheme_cluster_break = properties.grapheme_cluster_break();
+                let bidi_class = properties.bidi_class();
+                let general_category = properties.general_category();
+                let is_emoji_or_pictograph = properties.is_emoji_or_pictograph();
+                let is_variation_selector = properties.is_variation_selector();
+                let is_region_indicator = properties.is_region_indicator();
+                let next_mandatory_linebreak = properties.is_mandatory_linebreak();
 
-            let boundary = if is_mandatory_linebreak {
-                Boundary::Mandatory
-            } else {
-                boundary
-            };
+                let boundary = if is_mandatory_linebreak {
+                    Boundary::Mandatory
+                } else {
+                    boundary
+                };
 
-            let force_normalize = {
-                // "Extend" break chars should be normalized first, with two exceptions
-                if matches!(grapheme_cluster_break, GraphemeClusterBreak::Extend) &&
+                let force_normalize = {
+                    // "Extend" break chars should be normalized first, with two exceptions
+                    if matches!(grapheme_cluster_break, GraphemeClusterBreak::Extend) &&
                     ch as u32 != 0x200C && // Is not a Zero Width Non-Joiner &&
                     !is_variation_selector
-                {
-                    true
-                } else {
-                    // All spacing mark break chars should be normalized first.
-                    matches!(grapheme_cluster_break, GraphemeClusterBreak::SpacingMark)
-                }
-            };
+                    {
+                        true
+                    } else {
+                        // All spacing mark break chars should be normalized first.
+                        matches!(grapheme_cluster_break, GraphemeClusterBreak::SpacingMark)
+                    }
+                };
 
-            needs_bidi_resolution |= bidi::needs_bidi_resolution(bidi_class);
-            // TODO: maybe extend Properties to u64 to fit BidiMirroringGlyph
-            let bracket = data_sources.brackets().get(ch);
+                needs_bidi_resolution |= bidi::needs_bidi_resolution(bidi_class);
+                // TODO: maybe extend Properties to u64 to fit BidiMirroringGlyph
+                let bracket = data_sources.brackets().get(ch);
 
-            analysis.info.push(CharInfo::new(
-                boundary,
-                script,
-                grapheme_cluster_break,
-                bidi_class,
-                bracket,
-                is_variation_selector,
-                is_region_indicator,
-                general_category == GeneralCategory::Control,
-                is_emoji_or_pictograph,
-                contributes_to_shaping(general_category, script),
-                force_normalize,
-            ));
+                analysis.info.push(CharInfo::new(
+                    boundary,
+                    script,
+                    grapheme_cluster_break,
+                    bidi_class,
+                    bracket,
+                    is_variation_selector,
+                    is_region_indicator,
+                    general_category == GeneralCategory::Control,
+                    is_emoji_or_pictograph,
+                    contributes_to_shaping(general_category, script),
+                    force_normalize,
+                    is_grapheme_start,
+                ));
 
-            next_mandatory_linebreak
-        });
+                next_mandatory_linebreak
+            },
+        );
 
     if needs_bidi_resolution {
         analyzer.bidi.resolve(

--- a/parley_core/src/shape/shaper.rs
+++ b/parley_core/src/shape/shaper.rs
@@ -160,10 +160,7 @@ fn shape_item(
     let mut code_unit_offset_in_string = text_range.start;
     let char_cluster = &mut scx.char_cluster;
 
-    // Build an iterator of grapheme-cluster end boundaries (byte offsets into `item_text`) from
-    // the per-character grapheme-start flags computed during analysis. The item start is treated
-    // as a grapheme start regardless of its flag (an item boundary never extends a preceding
-    // grapheme for shaping purposes), hence `skip(1)`.
+    // Build an iterator of boundaries and consume the first segment to seed the loop
     let mut boundaries_iter = item_text
         .char_indices()
         .zip(item_char_info.iter())
@@ -171,8 +168,6 @@ fn shape_item(
         .filter_map(|((byte_pos, _), info)| info.is_grapheme_start().then_some(byte_pos))
         .chain(core::iter::once(item_text.len()));
     let mut last_boundary = 0_usize;
-    // Consume the first segment to seed the loop. `boundaries_iter` always yields at least
-    // `item_text.len()` for non-empty text.
     let mut current_boundary = boundaries_iter.next().unwrap();
 
     char_cluster.fill(

--- a/parley_core/src/shape/shaper.rs
+++ b/parley_core/src/shape/shaper.rs
@@ -10,7 +10,7 @@ use linebender_resource_handle::FontData;
 use parlance::{FontFeature, FontVariation, Language};
 
 use crate::{
-    Analysis, AnalysisDataSources, CharInfo, ShapedText,
+    Analysis, CharInfo, ShapedText,
     itemize::{Item, TextRange},
     lru_cache::LruCache,
     shape::{CharCluster, cache},
@@ -113,7 +113,6 @@ impl Shaper {
         item: &Item,
         options: &ShapeOptions<'_>,
         select_font: impl FnMut(&mut CharCluster) -> Option<FontInstance>,
-        analysis_data_sources: &AnalysisDataSources,
         shaped_text: &mut ShapedText,
     ) -> Range<usize> {
         shaped_text.reserve(item.range.char_range.len());
@@ -126,7 +125,6 @@ impl Shaper {
             options,
             select_font,
             analysis.char_info(),
-            analysis_data_sources,
             shaped_text,
         );
         start..shaped_text.runs().len()
@@ -140,7 +138,6 @@ fn shape_item(
     options: &ShapeOptions<'_>,
     mut select_font: impl FnMut(&mut CharCluster) -> Option<FontInstance>,
     char_info: &[CharInfo],
-    analysis_data_sources: &AnalysisDataSources,
     shaped_text: &mut ShapedText,
 ) {
     let text_range = &item.range.byte_range;
@@ -152,9 +149,10 @@ fn shape_item(
     let item_char_info = &char_info[char_range.start..char_range.end];
     let item_char_style_indices = &options.char_style_indices[char_range.start..char_range.end];
 
-    let grapheme_cluster_boundaries = analysis_data_sources
-        .grapheme_segmenter()
-        .segment_str(item_text);
+    if item_text.is_empty() {
+        return; // No clusters
+    }
+
     let mut item_infos_iter = item_char_info
         .iter()
         .copied()
@@ -162,12 +160,20 @@ fn shape_item(
     let mut code_unit_offset_in_string = text_range.start;
     let char_cluster = &mut scx.char_cluster;
 
-    // Build an iterator of boundaries and consume the first segment to seed the loop
-    let mut boundaries_iter = grapheme_cluster_boundaries.skip(1);
+    // Build an iterator of grapheme-cluster end boundaries (byte offsets into `item_text`) from
+    // the per-character grapheme-start flags computed during analysis. The item start is treated
+    // as a grapheme start regardless of its flag (an item boundary never extends a preceding
+    // grapheme for shaping purposes), hence `skip(1)`.
+    let mut boundaries_iter = item_text
+        .char_indices()
+        .zip(item_char_info.iter())
+        .skip(1)
+        .filter_map(|((byte_pos, _), info)| info.is_grapheme_start().then_some(byte_pos))
+        .chain(core::iter::once(item_text.len()));
     let mut last_boundary = 0_usize;
-    let Some(mut current_boundary) = boundaries_iter.next() else {
-        return; // No clusters
-    };
+    // Consume the first segment to seed the loop. `boundaries_iter` always yields at least
+    // `item_text.len()` for non-empty text.
+    let mut current_boundary = boundaries_iter.next().unwrap();
 
     char_cluster.fill(
         &item_text[last_boundary..current_boundary],


### PR DESCRIPTION
## Context

A small tidy up identified while pondering [#parley > use grapheme clusters over shaping clusters](https://xi.zulipchat.com/#narrow/channel/205635-parley/topic/use.20grapheme.20clusters.20over.20shaping.20clusters/with/611800211).

## Intent

Whether we create APIs for grapheme boundaries that are materialized on demand or stored persistently within our model, we probably want to perform this analysis during text analysis and not during shaping (just like word and line boundaries). Then, we can carry that information forwards from analysis to shaping.

I also imagine a consumer of parley core would expect grapheme boundaries computed during analysis and exposed in the model this way.

## Performance

Looks neutral

```txt
Default Style - arabic 20 characters               [  15.9 us ...  15.8 us ]      -0.55%
Default Style - latin 20 characters                [   7.5 us ...   7.5 us ]      -0.22%
Default Style - japanese 20 characters             [  14.8 us ...  14.5 us ]      -1.61%*
Default Style - arabic 1 paragraph                 [  87.4 us ...  87.0 us ]      -0.54%
Default Style - latin 1 paragraph                  [  29.9 us ...  30.9 us ]      +3.21%
Default Style - japanese 1 paragraph               [ 126.5 us ... 127.4 us ]      +0.73%
Default Style - arabic 4 paragraph                 [ 366.1 us ... 369.5 us ]      +0.93%
Default Style - latin 4 paragraph                  [ 114.5 us ... 116.3 us ]      +1.59%
Default Style - japanese 4 paragraph               [ 180.4 us ... 178.5 us ]      -1.04%
Styled - arabic 20 characters                      [  18.0 us ...  17.9 us ]      -0.36%
Styled - latin 20 characters                       [  10.3 us ...  10.1 us ]      -1.74%
Styled - japanese 20 characters                    [  16.5 us ...  15.9 us ]      -3.81%*
Styled - arabic 1 paragraph                        [  93.9 us ...  91.8 us ]      -2.25%
Styled - latin 1 paragraph                         [  38.3 us ...  38.6 us ]      +0.75%
Styled - japanese 1 paragraph                      [ 142.2 us ... 138.2 us ]      -2.84%*
Styled - arabic 4 paragraph                        [ 409.8 us ... 402.4 us ]      -1.80%
Styled - latin 4 paragraph                         [ 150.0 us ... 151.2 us ]      +0.77%
Styled - japanese 4 paragraph                      [ 198.6 us ... 195.4 us ]      -1.59%

```

## Extra

Incidentally, this means that we don't need to pass analysis data sources to the shaper. Does that impact your plans for the `Shaper` @tomcur ?