### PR TITLE
Pre-allocate some `ShapedText` storage

### DIFF
--- a/parley_core/src/shape/shaped_text.rs
+++ b/parley_core/src/shape/shaped_text.rs
@@ -100,6 +100,15 @@ impl ShapedText {
         Self::default()
     }
 
+    /// Reserve capacity for at least `additional_chars` more characters.
+    ///
+    /// This speculatively reserves capacity for `additional_chars` more glyphs.
+    #[inline]
+    pub(crate) fn reserve(&mut self, additional_chars: usize) {
+        self.clusters.reserve(additional_chars);
+        self.glyphs.reserve(additional_chars);
+    }
+
     /// Clear the result while retaining capacity.
     #[inline]
     pub fn clear(&mut self) {

--- a/parley_core/src/shape/shaper.rs
+++ b/parley_core/src/shape/shaper.rs
@@ -116,6 +116,8 @@ impl Shaper {
         analysis_data_sources: &AnalysisDataSources,
         shaped_text: &mut ShapedText,
     ) -> Range<usize> {
+        shaped_text.reserve(item.range.char_range.len());
+
         let start = shaped_text.runs().len();
         shape_item(
             self,


### PR DESCRIPTION
Implementing https://github.com/linebender/parley/pull/679#discussion_r3606606674 seems to be a nice little speed up.

This pre-allocates at the granularity of items, which means the glyph allocation is speculative. An alternative is to pre-allocate at the smaller granularity of runs, once you know how many glyphs you need to push, but that turns out to be slower as you need to reallocate more often.

We *could* expose `ShapedText::reserve` publicly and let users handle pre-allocation (at, e.g., the paragraph level), which theoretically could be slightly faster still, but that adds API surface for something that mostly stops mattering once you're reusing the `ShapedText` allocation.

```
$ cargo bench --bench main -- compare ../target/benchmarks/main -t 8.
Default Style - arabic 20 characters               [   9.0 us ...   8.8 us ]      -2.09%*
Default Style - latin 20 characters                [   4.3 us ...   4.1 us ]      -3.14%*
Default Style - japanese 20 characters             [   8.3 us ...   8.3 us ]      -0.33%
Default Style - arabic 1 paragraph                 [  48.7 us ...  47.8 us ]      -1.80%*
Default Style - latin 1 paragraph                  [  16.8 us ...  16.5 us ]      -2.07%*
Default Style - japanese 1 paragraph               [  70.6 us ...  70.1 us ]      -0.76%
Default Style - arabic 4 paragraph                 [ 208.1 us ... 201.5 us ]      -3.13%*
Default Style - latin 4 paragraph                  [  64.0 us ...  62.8 us ]      -1.84%*
Default Style - japanese 4 paragraph               [  99.9 us ...  98.8 us ]      -1.03%*
Styled - arabic 20 characters                      [  10.1 us ...   9.8 us ]      -2.32%*
Styled - latin 20 characters                       [   5.4 us ...   5.3 us ]      -1.94%*
Styled - japanese 20 characters                    [   8.9 us ...   9.0 us ]      +1.59%*
Styled - arabic 1 paragraph                        [  51.2 us ...  50.2 us ]      -1.86%*
Styled - latin 1 paragraph                         [  21.4 us ...  21.1 us ]      -1.11%*
Styled - japanese 1 paragraph                      [  77.2 us ...  76.7 us ]      -0.73%
Styled - arabic 4 paragraph                        [ 227.8 us ... 221.3 us ]      -2.88%*
Styled - latin 4 paragraph                         [  83.2 us ...  82.3 us ]      -1.09%*
Styled - japanese 4 paragraph                      [ 109.1 us ... 108.1 us ]      -0.98%
```