### PR TITLE
Keep justification out of `ShapedText`

### DIFF
--- a/parley/src/layout/alignment.rs
+++ b/parley/src/layout/alignment.rs
@@ -5,8 +5,6 @@ use super::{BreakReason, data::LineItemData};
 use crate::data::LayoutData;
 use crate::style::Brush;
 
-use parley_engine::shape::ClusterData;
-
 /// Alignment of a layout.
 #[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
 #[repr(u8)]
@@ -54,53 +52,31 @@ impl Default for AlignmentOptions {
 }
 
 /// Align the layout.
-///
-/// If [`Alignment::Justify`] is requested, clusters' [`ClusterData::advance`] will be adjusted.
-/// Prior to re-line-breaking or re-aligning, [`unjustify`] has to be called.
 pub(crate) fn align<B: Brush>(
     layout: &mut LayoutData<B>,
     alignment: Alignment,
     options: AlignmentOptions,
 ) {
+    layout.clear_justification();
     #[cfg(feature = "accesskit")]
     {
         layout.alignment = Some(alignment);
     }
-    layout.is_aligned_justified = alignment == Alignment::Justify;
 
-    align_impl::<_, false>(layout, alignment, options);
-}
-
-/// Removes previous justification applied to clusters.
-///
-/// This is part of resetting state in preparation for re-line-breaking or re-aligning the same
-/// layout.
-pub(crate) fn unjustify<B: Brush>(layout: &mut LayoutData<B>) {
-    if layout.is_aligned_justified {
-        align_impl::<_, true>(layout, Alignment::Justify, AlignmentOptions::default());
-        layout.is_aligned_justified = false;
-    }
-}
-
-/// The actual alignment implementation.
-///
-/// This is const-generic over `UNDO_JUSTIFICATION`: justified alignment adjusts clusters'
-/// [`ClusterData::advance`], and this mutation has to be undone for re-line-breaking or
-/// re-aligning. `UNDO_JUSTIFICATION` indicates whether the adjustment has to be applied, or
-/// undone.
-///
-/// Writing a separate function for undoing justification would be faster, but not by much, and
-/// doing it this way we are sure the calculations performed are equivalent.
-fn align_impl<B: Brush, const UNDO_JUSTIFICATION: bool>(
-    layout: &mut LayoutData<B>,
-    alignment: Alignment,
-    options: AlignmentOptions,
-) {
     // Whether the text base direction is right-to-left.
     let is_rtl = layout.base_level & 1 == 1;
+    let cluster_count = layout.shaped_text.clusters().len();
+    let LayoutData {
+        lines,
+        line_items,
+        shaped_text,
+        justification_adjustments,
+        ..
+    } = layout;
+    let clusters = shaped_text.clusters();
 
     // Apply alignment to line items
-    for line in &mut layout.lines {
+    for line in lines {
         let indent = line.indent;
 
         if is_rtl {
@@ -154,39 +130,136 @@ fn align_impl<B: Brush, const UNDO_JUSTIFICATION: bool>(
                     continue;
                 }
 
-                let adjustment =
-                    free_space / line.num_spaces as f32 * if UNDO_JUSTIFICATION { -1. } else { 1. };
+                let adjustment = free_space / line.num_spaces as f32;
                 let mut applied = 0;
                 // Iterate over text runs in the line and clusters in the text run
                 //   - Iterate forwards for even bidi levels (which represent LTR runs)
                 //   - Iterate backwards for odd bidi levels (which represent RTL runs)
-                let line_items: &mut dyn Iterator<Item = &LineItemData> = if is_rtl {
-                    &mut layout.line_items[line.item_range.clone()].iter().rev()
+                let line_items: &mut dyn Iterator<Item = &mut LineItemData> = if is_rtl {
+                    &mut line_items[line.item_range.clone()].iter_mut().rev()
                 } else {
-                    &mut layout.line_items[line.item_range.clone()].iter()
+                    &mut line_items[line.item_range.clone()].iter_mut()
                 };
-                line_items
-                    .filter(|item| item.is_text_run())
-                    .for_each(|line_item| {
-                        let clusters =
-                            &mut layout.shaped_text.clusters_mut()[line_item.cluster_range.clone()];
-                        let line_item_is_rtl = line_item.bidi_level & 1 != 0;
-                        let clusters: &mut dyn Iterator<Item = &mut ClusterData> =
-                            if line_item_is_rtl {
-                                &mut clusters.iter_mut().rev()
-                            } else {
-                                &mut clusters.iter_mut()
-                            };
-                        clusters.for_each(|cluster| {
-                            if applied == line.num_spaces {
-                                return;
+                for line_item in line_items.filter(|item| item.is_text_run()) {
+                    let cluster_range = line_item.cluster_range.clone();
+                    let line_item_is_rtl = line_item.bidi_level & 1 != 0;
+                    let cluster_indices: &mut dyn Iterator<Item = usize> = if line_item_is_rtl {
+                        &mut cluster_range.rev()
+                    } else {
+                        &mut cluster_range.into_iter()
+                    };
+                    for cluster_index in cluster_indices {
+                        if applied == line.num_spaces {
+                            break;
+                        }
+                        if clusters[cluster_index].info.whitespace().is_space_or_nbsp() {
+                            if justification_adjustments.is_empty() {
+                                justification_adjustments.resize(cluster_count, 0.0);
                             }
-                            if cluster.info.whitespace().is_space_or_nbsp() {
-                                cluster.advance += adjustment;
-                                applied += 1;
-                            }
-                        });
-                    });
+                            justification_adjustments[cluster_index] = adjustment;
+                            line_item.advance += adjustment;
+                            applied += 1;
+                        }
+                    }
+                    if applied == line.num_spaces {
+                        break;
+                    }
+                }
+                debug_assert_eq!(applied, line.num_spaces);
+                line.metrics.advance += adjustment * applied as f32;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use super::{Alignment, AlignmentOptions};
+    use crate::tests::test_builders::{FONT_FAMILY_LIST, create_font_context};
+    use crate::{FontFamily, Layout, LayoutContext, PositionedLayoutItem};
+
+    fn build_layout(text: &str) -> Layout<()> {
+        let mut fcx = create_font_context();
+        let mut lcx = LayoutContext::new();
+        let mut builder = lcx.ranged_builder(&mut fcx, text, 1.0, true);
+        builder.push_default(FontFamily::from(FONT_FAMILY_LIST));
+        let mut layout = builder.build(text);
+        layout.break_all_lines(Some(150.0));
+        layout
+    }
+
+    #[test]
+    fn justification_does_not_mutate_shaped_text() {
+        let mut layout = build_layout("Lorem ipsum dolor sit amet, consectetur adipiscing elit.");
+        let shaped_text = layout.data.shaped_text.clone();
+
+        layout.align(Alignment::Justify, AlignmentOptions::default());
+        assert_eq!(layout.data.shaped_text, shaped_text);
+
+        layout.align(Alignment::Justify, AlignmentOptions::default());
+        assert_eq!(layout.data.shaped_text, shaped_text);
+
+        layout.break_all_lines(Some(150.0));
+        assert_eq!(layout.data.shaped_text, shaped_text);
+    }
+
+    #[test]
+    fn realignment_restores_empty_final_line_advance() {
+        let mut layout = build_layout("Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n");
+        let natural_advances = layout
+            .lines()
+            .map(|line| line.metrics().advance)
+            .collect::<Vec<_>>();
+
+        layout.align(Alignment::Justify, AlignmentOptions::default());
+        layout.align(Alignment::Start, AlignmentOptions::default());
+
+        assert_eq!(
+            layout
+                .lines()
+                .map(|line| line.metrics().advance)
+                .collect::<Vec<_>>(),
+            natural_advances
+        );
+    }
+
+    #[test]
+    fn justified_advances_are_consistent() {
+        for text in [
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+            "عند برمجة أجهزة الكمبيوتر، قد تجد نفسك فجأة في مواقف غريبة.",
+        ] {
+            let mut layout = build_layout(text);
+            layout.align(Alignment::Justify, AlignmentOptions::default());
+
+            for line in layout.lines() {
+                let mut run_advance = 0.0;
+                let mut cluster_advance = 0.0;
+                for run in line.runs() {
+                    run_advance += run.advance();
+                    cluster_advance += run.clusters().map(|cluster| cluster.advance()).sum::<f32>();
+                }
+                let glyph_advance = line
+                    .items()
+                    .filter_map(|item| match item {
+                        PositionedLayoutItem::GlyphRun(run) => Some(run.advance()),
+                        PositionedLayoutItem::InlineBox(_) => None,
+                    })
+                    .sum::<f32>();
+
+                for (name, advance) in [
+                    ("runs", run_advance),
+                    ("clusters", cluster_advance),
+                    ("glyphs", glyph_advance),
+                ] {
+                    assert!(
+                        (advance - line.metrics().advance).abs() < 0.001,
+                        "{name} advance {advance} did not match line advance {}",
+                        line.metrics().advance
+                    );
+                }
             }
         }
     }

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -170,6 +170,11 @@ impl<'a, B: Brush> Cluster<'a, B> {
     /// Returns the advance of the cluster.
     pub fn advance(&self) -> f32 {
         self.data.advance
+            + self
+                .run
+                .layout
+                .data
+                .justification_adjustment(self.data_index())
     }
 
     /// Returns `true` if this is a right-to-left cluster.
@@ -218,20 +223,26 @@ impl<'a, B: Brush> Cluster<'a, B> {
 
     /// Returns an iterator over the glyphs in the cluster.
     pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + 'a + Clone + use<'a, B> {
+        let advance_adjustment = self
+            .run
+            .layout
+            .data
+            .justification_adjustment(self.data_index());
         if self.data.glyph_len == 0xFF {
             GlyphIter::Single(Some(Glyph {
                 id: self.data.glyph_offset,
                 x: 0.,
                 y: 0.,
-                advance: self.data.advance,
+                advance: self.data.advance + advance_adjustment,
             }))
         } else {
             let start = self.run.shaped.glyphs_range.start + self.data.glyph_offset as usize;
-            GlyphIter::Slice(
-                self.run.layout.data.shaped_text.glyphs()
+            GlyphIter::Slice {
+                iter: self.run.layout.data.shaped_text.glyphs()
                     [start..start + self.data.glyph_len as usize]
                     .iter(),
-            )
+                advance_adjustment,
+            }
         }
     }
 
@@ -446,6 +457,17 @@ impl<'a, B: Brush> Cluster<'a, B> {
         &self.data.info
     }
 
+    #[inline]
+    fn data_index(&self) -> usize {
+        let range_start = self
+            .run
+            .line_data
+            .map_or(self.run.shaped.clusters_range.start, |line_data| {
+                line_data.cluster_range.start
+            });
+        range_start + self.path.logical_index()
+    }
+
     /// Returns the text length of the cluster in bytes.
     ///
     /// This is only used for tests, and is *not* part of the public API.
@@ -537,7 +559,10 @@ impl ClusterPath {
 #[derive(Clone)]
 enum GlyphIter<'a> {
     Single(Option<Glyph>),
-    Slice(core::slice::Iter<'a, Glyph>),
+    Slice {
+        iter: core::slice::Iter<'a, Glyph>,
+        advance_adjustment: f32,
+    },
 }
 
 impl Iterator for GlyphIter<'_> {
@@ -546,8 +571,14 @@ impl Iterator for GlyphIter<'_> {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::Single(glyph) => glyph.take(),
-            Self::Slice(iter) => {
-                let glyph = *iter.next()?;
+            Self::Slice {
+                iter,
+                advance_adjustment,
+            } => {
+                let mut glyph = *iter.next()?;
+                if iter.len() == 0 {
+                    glyph.advance += *advance_adjustment;
+                }
                 Some(glyph)
             }
         }

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -45,6 +45,8 @@ pub(crate) struct LineData {
     pub(crate) item_range: Range<usize>,
     /// Metrics for the line.
     pub(crate) metrics: LineMetrics,
+    /// Full inline advance before alignment.
+    pub(crate) natural_advance: f32,
     /// The cause of the line break.
     pub(crate) break_reason: BreakReason,
     /// Maximum advance for the line.
@@ -186,8 +188,10 @@ pub(crate) struct LayoutData<B: Brush> {
     /// Directly store the alignment if accessibility is enabled so we can
     /// set the corresponding AccessKit property.
     pub(crate) alignment: Option<super::Alignment>,
-    /// Whether the layout is aligned with [`crate::Alignment::Justify`].
-    pub(crate) is_aligned_justified: bool,
+    /// Per-cluster advance adjustments produced by justification.
+    ///
+    /// An empty vector means that justification has not adjusted any clusters.
+    pub(crate) justification_adjustments: Vec<f32>,
     /// The text-indent amount in layout units.
     pub(crate) indent_amount: f32,
     /// Options controlling text-indent behavior (each-line, hanging).
@@ -213,7 +217,7 @@ impl<B: Brush> Default for LayoutData<B> {
             line_items: Vec::new(),
             #[cfg(feature = "accesskit")]
             alignment: None,
-            is_aligned_justified: false,
+            justification_adjustments: Vec::new(),
             layout_max_advance: 0.0,
             indent_amount: 0.0,
             indent_options: IndentOptions::default(),
@@ -237,6 +241,42 @@ impl<B: Brush> LayoutData<B> {
         self.items.clear();
         self.lines.clear();
         self.line_items.clear();
+        self.justification_adjustments.clear();
+    }
+
+    /// Returns the layout-time adjustment for a shaped cluster.
+    #[inline]
+    pub(crate) fn justification_adjustment(&self, cluster_index: usize) -> f32 {
+        if self.justification_adjustments.is_empty() {
+            0.0
+        } else {
+            debug_assert_eq!(
+                self.justification_adjustments.len(),
+                self.shaped_text.clusters().len()
+            );
+            self.justification_adjustments[cluster_index]
+        }
+    }
+
+    /// Discards justification and restores cached natural advances.
+    pub(crate) fn clear_justification(&mut self) {
+        if self.justification_adjustments.is_empty() {
+            return;
+        }
+        self.justification_adjustments.clear();
+
+        let clusters = self.shaped_text.clusters();
+        for item in &mut self.line_items {
+            if item.is_text_run() {
+                item.advance = clusters[item.cluster_range.clone()]
+                    .iter()
+                    .map(|cluster| cluster.advance)
+                    .sum();
+            }
+        }
+        for line in &mut self.lines {
+            line.metrics.advance = line.natural_advance;
+        }
     }
 
     /// Push an inline box to the list of items

--- a/parley/src/layout/layout.rs
+++ b/parley/src/layout/layout.rs
@@ -3,7 +3,6 @@
 
 use crate::InlineBox;
 use crate::layout::alignment::align;
-use crate::layout::alignment::unjustify;
 use crate::layout::data::LayoutData;
 use crate::style::Brush;
 use core::cmp::Ordering;
@@ -165,7 +164,7 @@ impl<B: Brush> Layout<B> {
 
     /// Returns line breaker to compute lines for the layout.
     pub fn break_lines(&mut self) -> BreakLines<'_, B> {
-        unjustify(&mut self.data);
+        self.data.clear_justification();
         BreakLines::new(self)
     }
 
@@ -187,7 +186,6 @@ impl<B: Brush> Layout<B> {
     /// If line-specific `offset` and `max_advance` are set using the advanced methods on the `BreakLines`
     /// struct then each line will be aligned individually within its line box.
     pub fn align(&mut self, alignment: Alignment, options: AlignmentOptions) {
-        unjustify(&mut self.data);
         align(&mut self.data, alignment, options);
     }
 

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -792,13 +792,13 @@ impl<'a, B: Brush> BreakLines<'a, B> {
 
                         // If current cluster is the start of a ligature, then advance state to include
                         // the remaining clusters that make up the ligature
-                        let mut advance = cluster.advance();
+                        let mut advance = cluster.data.advance;
                         if cluster.is_ligature_start() {
                             while let Some(cluster) = run.get(self.state.cluster_idx + 1) {
                                 if !cluster.is_ligature_continuation() {
                                     break;
                                 } else {
-                                    advance += cluster.advance();
+                                    advance += cluster.data.advance;
                                     self.state.cluster_idx += 1;
                                 }
                             }
@@ -1004,7 +1004,7 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                         let whitespace = cluster.info().whitespace();
                         let is_newline = whitespace == Whitespace::Newline;
                         let is_space = whitespace.is_space_or_nbsp();
-                        let advance = cluster.advance();
+                        let advance = cluster.data.advance;
 
                         // Compute the x position.
                         // Newlines don't contribute to line width (matching break_next behavior).
@@ -1294,6 +1294,7 @@ impl<'a, B: Brush> BreakLines<'a, B> {
 
         line.metrics.inline_min_coord = self.state.line_x;
         line.metrics.inline_max_coord = self.state.line_x + self.state.line_max_advance;
+        line.natural_advance = line.metrics.advance;
     }
 }
 

--- a/parley/src/tests/mod.rs
+++ b/parley/src/tests/mod.rs
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 mod test_analysis;
-mod test_builders;
+pub(crate) mod test_builders;
 mod utils;

--- a/parley/src/tests/test_builders.rs
+++ b/parley/src/tests/test_builders.rs
@@ -20,7 +20,7 @@ use crate::{
 // duplicated between this crate and `parley_test`. We can't move the builder
 // tests into `parley_test` because they use private APIs, but should eventually
 // figure out some way to reduce the duplication.
-const FONT_FAMILY_LIST: &[FontFamilyName<'_>] = &[
+pub(crate) const FONT_FAMILY_LIST: &[FontFamilyName<'_>] = &[
     FontFamilyName::Named(Cow::Borrowed("Roboto")),
     FontFamilyName::Named(Cow::Borrowed("Noto Kufi Arabic")),
 ];
@@ -51,7 +51,7 @@ pub(crate) fn load_fonts(
     Ok(())
 }
 
-fn create_font_context() -> FontContext {
+pub(crate) fn create_font_context() -> FontContext {
     let mut collection = Collection::new(CollectionOptions {
         shared: false,
         system_fonts: false,

--- a/parley/src/tests/utils/asserts.rs
+++ b/parley/src/tests/utils/asserts.rs
@@ -82,8 +82,8 @@ pub(crate) fn assert_eq_layout_data<B: Brush>(a: &LayoutData<B>, b: &LayoutData<
 
     // Output of alignment
     assert_eq!(
-        a.is_aligned_justified, b.is_aligned_justified,
-        "{case} is_aligned_justified mismatch"
+        a.justification_adjustments, b.justification_adjustments,
+        "{case} justification_adjustments mismatch"
     );
     assert_eq!(
         a.layout_max_advance, b.layout_max_advance,

--- a/parley_bench/benches/main.rs
+++ b/parley_bench/benches/main.rs
@@ -5,7 +5,13 @@
 
 use tango_bench::tango_benchmarks;
 
-use parley_bench::benches::{defaults, styled};
+use parley_bench::benches::{defaults, justified, realign, styled};
 use parley_bench::fontique_benches::system_fonts_init;
 
-tango_benchmarks!(defaults(), styled(), system_fonts_init());
+tango_benchmarks!(
+    defaults(),
+    styled(),
+    justified(),
+    realign(),
+    system_fonts_init()
+);

--- a/parley_bench/src/benches.rs
+++ b/parley_bench/src/benches.rs
@@ -47,6 +47,68 @@ pub fn defaults() -> Vec<Benchmark> {
         .collect()
 }
 
+/// Benchmark default-styled text with justified alignment.
+pub fn justified() -> Vec<Benchmark> {
+    const DISPLAY_SCALE: f32 = 1.0;
+    const QUANTIZE: bool = true;
+    const MAX_ADVANCE: f32 = 200.0 * DISPLAY_SCALE;
+
+    get_samples()
+        .iter()
+        .map(|sample| {
+            benchmark_fn(
+                format!("Justified - {} {}", sample.name, sample.modification),
+                |b| {
+                    b.iter(|| {
+                        let text = &sample.text;
+                        with_contexts(|font_cx, layout_cx| {
+                            let mut builder =
+                                layout_cx.ranged_builder(font_cx, text, DISPLAY_SCALE, QUANTIZE);
+                            builder.push_default(FontFamily::from(FONT_FAMILY_LIST));
+
+                            let mut layout: Layout<ColorBrush> = builder.build(text);
+                            layout.break_all_lines(Some(MAX_ADVANCE));
+                            layout.align(Alignment::Justify, AlignmentOptions::default());
+
+                            black_box(layout);
+                        });
+                    })
+                },
+            )
+        })
+        .collect()
+}
+
+/// Benchmark realigning an already line-broken paragraph.
+pub fn realign() -> Vec<Benchmark> {
+    const DISPLAY_SCALE: f32 = 1.0;
+    const QUANTIZE: bool = true;
+    const MAX_ADVANCE: f32 = 200.0 * DISPLAY_SCALE;
+
+    get_samples()
+        .iter()
+        .filter(|sample| sample.modification == "1 paragraph" && sample.name != "japanese")
+        .map(|sample| {
+            benchmark_fn(format!("Realign - {}", sample.name), |b| {
+                let mut layout = with_contexts(|font_cx, layout_cx| {
+                    let mut builder =
+                        layout_cx.ranged_builder(font_cx, &sample.text, DISPLAY_SCALE, QUANTIZE);
+                    builder.push_default(FontFamily::from(FONT_FAMILY_LIST));
+                    let mut layout: Layout<ColorBrush> = builder.build(&sample.text);
+                    layout.break_all_lines(Some(MAX_ADVANCE));
+                    layout
+                });
+
+                b.iter(move || {
+                    layout.align(Alignment::Justify, AlignmentOptions::default());
+                    layout.align(Alignment::Start, AlignmentOptions::default());
+                    black_box(&layout);
+                })
+            })
+        })
+        .collect()
+}
+
 /// Benchmark for styled text.
 pub fn styled() -> Vec<Benchmark> {
     const DISPLAY_SCALE: f32 = 1.0;


### PR DESCRIPTION
## Summary

Keep justification state in `parley` rather than mutating the font-derived data in `parley_engine::ShapedText`.

Justification now stores per-cluster advance adjustments in `LayoutData`. Re-line-breaking or re-aligning discards that derived state directly instead of running the justification algorithm again with negative adjustments.

This removes:

- `unjustify`
- `is_aligned_justified`
- The `UNDO_JUSTIFICATION` const-generic path
- Justification’s use of `ShapedText::clusters_mut()`

## Motivation

`ShapedText` is the output of shaping, but justification previously modified `ClusterData::advance` in place. To reuse a layout, Parley had to remember that this happened and later “unjustify” it by repeating the alignment calculation in reverse.

Besides crossing the shaping/layout ownership boundary, that left multiple answers to how wide justified text was:

- `Cluster::advance()` included justification.
- Cached run and line advances did not.
- Rendering depended on whether a glyph was stored inline.

With this change, shaping output remains unchanged throughout justification, repeated alignment, and re-line-breaking.

## Implementation

`LayoutData` now owns a lazily allocated vector of per-cluster justification adjustments. It is empty for layouts where no spaces have been expanded.

The final adjusted advance is used consistently by:

- `Cluster::advance()`
- Emitted glyph advances
- Cached line-item/run advances
- `LineMetrics::advance`
- Hit testing, cursor placement, and accessibility through their existing cluster/run accessors

Line breaking continues to read natural shaped advances directly. Each line retains its natural advance so clearing justification restores cached geometry without performing an inverse calculation.

For non-inline clusters, the adjustment is added to the copied final glyph in the cluster. This keeps positioned glyphs consistent with the cluster, run, and line geometry without modifying `ShapedText`.

## Tests

Added regressions covering:

- `ShapedText` remaining unchanged after justification
- Repeated justification
- Re-line-breaking a justified layout
- Agreement between line, run, cluster, and emitted glyph advances
- Latin and Arabic text
- Restoring the copied metrics of an empty final line after a trailing newline

Existing realignment, bidi, text-indent, word-spacing, hit-testing, and rendering tests continue to pass.

## Performance

Added permanent Tango benchmarks for full justified layout and repeated realignment of an already line-broken paragraph.

Paired comparison:

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| Realign — Arabic | 408.4 ns | 214.1 ns | −47.58% |
| Realign — Latin | 320.2 ns | 184.8 ns | −42.30% |
| Justified — Arabic, 1 paragraph | 44.3 µs | 44.3 µs | +0.06% |
| Justified — Latin, 1 paragraph | 15.1 µs | 15.1 µs | +0.23% |
| Justified — Arabic, 4 paragraphs | 178.9 µs | 179.2 µs | +0.16% |
| Justified — Latin, 4 paragraphs | 58.6 µs | 58.6 µs | −0.06% |

Repeated runs consistently showed a roughly 42–48% improvement for realignment. Full-layout results remained effectively neutral; small shifts among the shortest default and styled cases moved between runs and did not indicate a path-specific regression.

## Next steps

This does not yet make `ShapedText` immutable from Parley’s perspective. Letter and word spacing still mutate clusters and glyphs through `clusters_and_glyphs_mut()`.

A follow-up should:

1. Resolve the existing letter-spacing/ligature semantics, including whether letter spacing disables ligatures.
2. Move letter and word spacing into layout-owned per-cluster state.
3. Refactor the test canonicalizer so it no longer needs `clusters_mut()`.
4. Remove the hidden `clusters_mut()`, `glyphs_mut()`, and `clusters_and_glyphs_mut()` escape hatches from `parley_engine::ShapedText`.

That would complete the ownership boundary established here: `parley_engine` owns immutable shaping output, while `parley` owns all layout-time advance adjustments.
