### PR TITLE
Don't panic when fontconfig exposes no fonts

### DIFF
--- a/fontique/src/backend/fontconfig.rs
+++ b/fontique/src/backend/fontconfig.rs
@@ -682,8 +682,13 @@ impl SystemFonts {
             config.substitute(&mut pattern, FcMatchPattern);
 
             // We enable the "trim" option here which ignores later fonts if
-            // they provide no new Unicode coverage.
-            let font_set = config.font_sort(&pattern, true).unwrap();
+            // they provide no new Unicode coverage. On error this generic
+            // family simply has no members; in particular `font_sort` errors
+            // with `NoMatch` when there are no fonts to sort at all (e.g. a
+            // fontconfig configuration exposing an empty system font set).
+            let Ok(font_set) = config.font_sort(&pattern, true) else {
+                continue;
+            };
 
             // There are a lot of duplicate font families in the substituted
             // pattern. Keep track of which ones have already been added to the


### PR DESCRIPTION
While populating the generic family map, `SystemFonts::new` unwrapped the result of `font_sort`. On a host whose fontconfig configuration exposes an empty font set (common in minimal containers and embedded Linux images that ship fontconfig but no font files) `font_sort` returns `NoMatch` for the first generic family, so the unwrap panicked inside `Collection::new`, before any fallback font could be registered.

Treat an error from `font_sort` as "this generic family has no members" and skip it. A collection built on a font-less system then exposes no system fonts, which is the correct result and lets the caller register its own fonts afterwards.