### PR TITLE
Upgrade to read-fonts 0.41, skrifa 0.44, harfrust 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts 0.40.2",
+ "read-fonts 0.41.0",
  "roxmltree",
  "smallvec",
  "windows 0.62.2",
@@ -1513,14 +1513,14 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0589ddd0d2935dd2845827ac606b4081c266225d613b268ed2910f832889cab"
+checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
- "read-fonts 0.40.2",
+ "read-fonts 0.41.0",
  "smallvec",
 ]
 
@@ -2905,7 +2905,7 @@ dependencies = [
  "parley_dev",
  "parley_engine",
  "peniko",
- "skrifa 0.43.2",
+ "skrifa 0.44.0",
 ]
 
 [[package]]
@@ -2950,7 +2950,7 @@ dependencies = [
  "linebender_resource_handle",
  "parlance",
  "parley_data",
- "skrifa 0.43.2",
+ "skrifa 0.44.0",
 ]
 
 [[package]]
@@ -3406,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.40.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487889119a5f19ff7c0a20637196bdc76b9f54ebec17e3588b5d75e4999f8773"
+checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -3722,13 +3722,13 @@ dependencies = [
 
 [[package]]
 name = "skrifa"
-version = "0.43.2"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbe997d0f2480442d727488fbe2150779114cbe480ecdbadef58b33e0318ffb"
+checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
 dependencies = [
  "bytemuck",
  "core_maths",
- "read-fonts 0.40.2",
+ "read-fonts 0.41.0",
 ]
 
 [[package]]
@@ -3861,7 +3861,7 @@ version = "0.1.0"
 dependencies = [
  "image",
  "parley",
- "skrifa 0.43.2",
+ "skrifa 0.44.0",
  "swash",
 ]
 
@@ -4039,7 +4039,7 @@ name = "tiny_skia_render"
 version = "0.1.0"
 dependencies = [
  "parley",
- "skrifa 0.43.2",
+ "skrifa 0.44.0",
  "tiny-skia",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ parley_linebreaking_cases = { path = "parley_tests/linebreaking_cases" }
 # External dependencies
 accesskit = "0.24.0"
 bytemuck = { version = "1.25.0", default-features = false }
-harfrust = { version = "0.10.0", default-features = false }
+harfrust = { version = "0.12.0", default-features = false }
 hashbrown = { version = "0.17.0", default-features = false, features = [
     "default-hasher",
     "raw-entry",
@@ -60,8 +60,8 @@ glifo = { git = "https://github.com/linebender/vello", rev = "5796226", default-
 rand = { version = "0.10.1", default-features = false, features = ["std", "std_rng"] }
 rand_chacha = { version = "0.10.0", default-features = false }
 peniko = { version = "0.6.0", default-features = false }
-read-fonts = { version = "0.40.0", default-features = false }
-skrifa = { version = "0.43.2", default-features = false }
+read-fonts = { version = "0.41.0", default-features = false }
+skrifa = { version = "0.44.0", default-features = false }
 smallvec = "1.15.1"
 swash = { version = "0.2.6", default-features = false }
 vello_common = { version = "0.0.7", default-features = false }


### PR DESCRIPTION
These versions match the Vello Sparse Strips 0.1 release and resvg `main`