### PR TITLE
Ignore empty word break ranges, clarify ranges must fall on character boundaries

### DIFF
--- a/parley_engine/src/analysis.rs
+++ b/parley_engine/src/analysis.rs
@@ -337,6 +337,16 @@ pub(crate) fn analyze_text(
             if self.cursor >= self.text_len {
                 return None;
             }
+
+            // Ignore empty ranges.
+            while self
+                .word_break
+                .get(self.next)
+                .is_some_and(|(range, _)| range.is_empty())
+            {
+                self.next += 1;
+            }
+
             match self.word_break.get(self.next) {
                 // A gap before the next override: fill it with the default up to its start.
                 Some((range, _)) if self.cursor < range.start => {
@@ -407,7 +417,7 @@ pub(crate) fn analyze_text(
                 let style_start_index = range.start;
                 let mut prev_char_index = self.current_char;
 
-                // Find the character at the style boundary
+                // Find the character at the style boundary.
                 while self.current_char.0 < style_start_index {
                     prev_char_index = self.current_char;
                     self.current_char = self.char_indices.next().unwrap();

--- a/parley_engine/src/analyzer.rs
+++ b/parley_engine/src/analyzer.rs
@@ -48,7 +48,8 @@ pub struct AnalysisOptions<'a> {
 
     /// Word break configuration for ranges of the source text.
     ///
-    /// Ranges must be sorted and non-overlapping. Gaps use [`WordBreak::Normal`].
+    /// Ranges must be sorted and non-overlapping, and must start and end on character boundaries of
+    /// the text. Empty ranges are ignored. Gaps use [`WordBreak::Normal`].
     pub word_break: &'a [(Range<usize>, WordBreak)],
 
     /// The callback which will be called as a first provider of line breaking decisions.


### PR DESCRIPTION
Empty ranges must be ignored, as otherwise the range the iterator is pointing can get out of sync with the character.