### PR TITLE
`parley_engine`: Abort shaping if no font is available, attempt a last resort scan in `parley`

### DIFF
--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -363,10 +363,9 @@ fn build_into_layout<B: Brush>(
     lcx.inline_boxes.sort_by_key(|b| b.index);
 
     {
-        let query = fcx.collection.query(&mut fcx.source_cache);
         super::shape::shape_text(
             &lcx.rcx,
-            query,
+            fcx,
             &lcx.style_table,
             &lcx.inline_boxes,
             &lcx.analysis,

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -4,7 +4,6 @@
 //! Text shaping implementation using `harfrust`for shaping
 //! and `icu` for text analysis.
 
-use alloc::vec::Vec;
 use parley_engine::shape::{CharCluster, Coverage};
 use parley_engine::{Analysis, AnalysisDataSources, FontInstance, ShapeOptions, Shaper};
 
@@ -39,15 +38,7 @@ pub(crate) fn shape_text<'a, B: Brush>(
     }
 
     // Do nothing if there is no text or styles (there should always be a default style)
-    let last_resort_font;
-    if text.is_empty() || styles.is_empty() || {
-        // Get any font (and only at this point, because if we returned due to empty text or styles,
-        // we don't need to build the font).
-        last_resort_font = any_font(fcx);
-
-        // If `true`, there isn't even a single font we could use to shape.
-        last_resort_font.is_none()
-    } {
+    if text.is_empty() || styles.is_empty() {
         // Process any remaining inline boxes whose index is greater than the length of the text
         for box_idx in 0..inline_boxes.len() {
             // Push the box to the list of items
@@ -55,7 +46,6 @@ pub(crate) fn shape_text<'a, B: Brush>(
         }
         return;
     }
-    let last_resort_font = last_resort_font.unwrap();
 
     let mut fq = fcx.collection.query(&mut fcx.source_cache);
 
@@ -114,15 +104,8 @@ pub(crate) fn shape_text<'a, B: Brush>(
 
         let style_index = char_style_indices[item.range.char_range.start];
         let style = &styles[usize::from(style_index)];
-        let mut font_selector = FontSelector::new(
-            &mut fq,
-            rcx,
-            styles,
-            style_index,
-            item.script,
-            style.locale,
-            &last_resort_font,
-        );
+        let mut font_selector =
+            FontSelector::new(&mut fq, rcx, styles, style_index, item.script, style.locale);
 
         let shaped_runs_range = scx.shape_item(
             text,
@@ -136,7 +119,7 @@ pub(crate) fn shape_text<'a, B: Brush>(
                 char_style_indices,
             },
             #[inline(always)]
-            |char_cluster| Some(font_selector.select_font(char_cluster, analysis_data_sources)),
+            |char_cluster| font_selector.select_font(char_cluster, analysis_data_sources),
             &mut layout.data.shaped_text,
         );
         for shaped_run_idx in shaped_runs_range {
@@ -158,6 +141,14 @@ pub(crate) fn shape_text<'a, B: Brush>(
     }
 }
 
+/// The font to use if a font query doesn't return any font candidates at all.
+#[derive(Debug)]
+enum LastResortFont {
+    Unresolved,
+    Resolved(FontInstance),
+    Unavailable,
+}
+
 struct FontSelector<'a, 'b, B: Brush> {
     query: &'b mut Query<'a>,
     fonts_id: Option<usize>,
@@ -169,14 +160,11 @@ struct FontSelector<'a, 'b, B: Brush> {
     features: &'a [FontFeature],
 
     /// The font to use if [`Self::query`] doesn't return any font.
-    last_resort_font: &'b QueryFont,
+    last_resort_font: LastResortFont,
 }
 
 impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
     /// Construct a new `FontSelector`.
-    ///
-    /// If `query` ends up not returning a font for a query, the `last_resort_font` is returned
-    /// instead.
     fn new(
         query: &'b mut Query<'a>,
         rcx: &'a ResolveContext,
@@ -184,7 +172,6 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
         style_index: u16,
         script: Script,
         locale: Option<Language>,
-        last_resort_font: &'b QueryFont,
     ) -> Self {
         let style = &styles[style_index as usize];
         let fonts_id = style.font_family.id();
@@ -210,7 +197,7 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
             attrs,
             variations,
             features,
-            last_resort_font,
+            last_resort_font: LastResortFont::Unresolved,
         }
     }
 
@@ -218,7 +205,7 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
         &mut self,
         cluster: &mut CharCluster,
         analysis_data_sources: &AnalysisDataSources,
-    ) -> FontInstance {
+    ) -> Option<FontInstance> {
         let style_index = cluster.style_index();
         let is_emoji = cluster.is_emoji();
         if style_index != self.style_index || is_emoji || self.fonts_id.is_none() {
@@ -286,76 +273,62 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
             }
         });
 
-        let selected_font = selected_font
+        selected_font
             .map(|selected_font| selected_font.font)
-            .unwrap_or(self.last_resort_font.clone());
+            .map(|font| FontInstance {
+                font: FontData {
+                    data: font.blob,
+                    index: font.index,
+                },
+                synthesis: font.synthesis,
+            })
+            .or_else(|| {
+                if matches!(self.last_resort_font, LastResortFont::Unresolved) {
+                    if let Some(font) = any_font(self.query) {
+                        self.last_resort_font = LastResortFont::Resolved(FontInstance {
+                            font: FontData {
+                                data: font.blob,
+                                index: font.index,
+                            },
+                            synthesis: font.synthesis,
+                        });
+                    } else {
+                        self.last_resort_font = LastResortFont::Unavailable;
+                    }
 
-        FontInstance {
-            font: FontData {
-                data: selected_font.blob,
-                index: selected_font.index,
-            },
-            synthesis: selected_font.synthesis,
-        }
+                    self.fonts_id = None;
+                }
+
+                if let LastResortFont::Resolved(ref font) = self.last_resort_font {
+                    Some(font.clone())
+                } else {
+                    None
+                }
+            })
     }
 }
 
-/// Just select any font from the font collection, preferring text fonts.
+/// Just query for any generic family's font from the font collection.
 ///
-/// If this returns `None`, there are no fonts available at all.
+/// This sets generic families on `query`, so callers need to make sure to set families back again.
+/// This returns `None` if it doesn't find any fonts, but note this only checks generic families.
 ///
 /// This can be used to have a font at hand for shaping, in case more sophisticated font querying
 /// returns no fonts.
-fn any_font(fcx: &mut FontContext) -> Option<QueryFont> {
+fn any_font(query: &mut Query<'_>) -> Option<QueryFont> {
     let mut found = None;
 
-    // First try the system's preferred generic text families.
+    // Try the system's generic text families.
     //
     // At this point, the font itself doesn't really matter: we mostly just need any font to work
-    // with. We take the first from each generic family, as on most systems that should "just work"
-    // and give a sensible font, while allowing us to skip extending our query's candidate font
-    // families with all the generic families registered on the system.
-    let sans = fcx
-        .collection
-        .generic_families(GenericFamily::SansSerif)
-        .next();
-    let serif = fcx.collection.generic_families(GenericFamily::Serif).next();
-    let monospace = fcx
-        .collection
-        .generic_families(GenericFamily::Monospace)
-        .next();
-    // Plus any font covering Latin.
-    let latin = fcx
-        .collection
-        .fallback_families(fontique::FallbackKey::new(
-            Script::from_bytes(*b"Latn"),
-            None,
-        ))
-        .next();
-    let preferred = [sans, serif, monospace, latin];
-
-    {
-        let mut query = fcx.collection.query(&mut fcx.source_cache);
-        query.set_families(preferred.into_iter().flatten());
-        query.matches_with(
-            #[inline]
-            |font: &QueryFont| {
-                found = Some(font.clone());
-                fontique::QueryStatus::Stop
-            },
-        );
-    }
-
-    if found.is_some() {
-        return found;
-    }
-
-    // If that failed, it seems like there aren't any text fonts in the collection, so just take
-    // anything at all. Unfortunately, we must collect IDs before the query, as iterating IDs
-    // borrows the collection mutably.
-    let families: Vec<fontique::FamilyId> = fcx.collection.family_ids().collect();
-    let mut query = fcx.collection.query(&mut fcx.source_cache);
-    query.set_families(families);
+    // with. This has a cost, as it extends our query's candidate font families with all the generic
+    // families registered on the system. A better future may be to allow users to register some
+    // last resort in `fontique`, or pass it directly to `parley`.
+    query.set_families([
+        QueryFamily::Generic(GenericFamily::SansSerif),
+        QueryFamily::Generic(GenericFamily::Serif),
+        QueryFamily::Generic(GenericFamily::Monospace),
+    ]);
     query.matches_with(
         #[inline]
         |font: &QueryFont| {
@@ -363,6 +336,7 @@ fn any_font(fcx: &mut FontContext) -> Option<QueryFont> {
             fontique::QueryStatus::Stop
         },
     );
+
     found
 }
 

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -136,7 +136,7 @@ pub(crate) fn shape_text<'a, B: Brush>(
                 char_style_indices,
             },
             #[inline(always)]
-            |char_cluster| font_selector.select_font(char_cluster, analysis_data_sources),
+            |char_cluster| Some(font_selector.select_font(char_cluster, analysis_data_sources)),
             &mut layout.data.shaped_text,
         );
         for shaped_run_idx in shaped_runs_range {

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -39,14 +39,14 @@ pub(crate) fn shape_text<'a, B: Brush>(
     }
 
     // Do nothing if there is no text or styles (there should always be a default style)
-    let fallback_font;
+    let last_resort_font;
     if text.is_empty() || styles.is_empty() || {
         // Get any font (and only at this point, because if we returned due to empty text or styles,
         // we don't need to build the font).
-        fallback_font = any_font(fcx);
+        last_resort_font = any_font(fcx);
 
         // If `true`, there isn't even a single font we could use to shape.
-        fallback_font.is_none()
+        last_resort_font.is_none()
     } {
         // Process any remaining inline boxes whose index is greater than the length of the text
         for box_idx in 0..inline_boxes.len() {
@@ -55,7 +55,7 @@ pub(crate) fn shape_text<'a, B: Brush>(
         }
         return;
     }
-    let fallback_font = fallback_font.unwrap();
+    let last_resort_font = last_resort_font.unwrap();
 
     let mut fq = fcx.collection.query(&mut fcx.source_cache);
 
@@ -121,7 +121,7 @@ pub(crate) fn shape_text<'a, B: Brush>(
             style_index,
             item.script,
             style.locale,
-            &fallback_font,
+            &last_resort_font,
         );
 
         let shaped_runs_range = scx.shape_item(
@@ -169,13 +169,13 @@ struct FontSelector<'a, 'b, B: Brush> {
     features: &'a [FontFeature],
 
     /// The font to use if [`Self::query`] doesn't return any font.
-    fallback_font: &'b FontInstance,
+    last_resort_font: &'b FontInstance,
 }
 
 impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
     /// Construct a new `FontSelector`.
     ///
-    /// If `query` ends up not returning a font for a query, the `fallback_font` is returned
+    /// If `query` ends up not returning a font for a query, the `last_resort_font` is returned
     /// instead.
     fn new(
         query: &'b mut Query<'a>,
@@ -184,7 +184,7 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
         style_index: u16,
         script: Script,
         locale: Option<Language>,
-        fallback_font: &'b FontInstance,
+        last_resort_font: &'b FontInstance,
     ) -> Self {
         let style = &styles[style_index as usize];
         let fonts_id = style.font_family.id();
@@ -210,7 +210,7 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
             attrs,
             variations,
             features,
-            fallback_font,
+            last_resort_font,
         }
     }
 
@@ -293,7 +293,7 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
                 },
                 synthesis: selected_font.font.synthesis,
             })
-            .unwrap_or(self.fallback_font.clone())
+            .unwrap_or(self.last_resort_font.clone())
     }
 }
 

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -298,10 +298,10 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
     }
 }
 
-/// Just select any font, that we can pass to [`FontSelector::new`] such that font selection becomes
-/// infallible.
+/// Just select any font from the font collection.
 ///
-/// All we need are some `.notdef`s. If this returns `None`, there are no fonts available at all.
+/// If this returns `None`, there are no fonts available at all. This can be used to have a font at
+/// hand for shaping, in case more sophisticated font querying returns no fonts.
 fn any_font(fcx: &mut FontContext) -> Option<FontInstance> {
     let name = fcx.collection.family_names().next()?.to_owned();
     let font = fcx

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -23,7 +23,6 @@ use parlance::Script;
 pub(crate) fn shape_text<'a, B: Brush>(
     rcx: &'a ResolveContext,
     fcx: &'a mut FontContext,
-    // mut fq: Query<'a>,
     styles: &'a [ResolvedStyle<B>],
     inline_boxes: &[InlineBox],
     analysis: &Analysis,

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -4,16 +4,17 @@
 //! Text shaping implementation using `harfrust`for shaping
 //! and `icu` for text analysis.
 
+use alloc::borrow::ToOwned;
 use parley_engine::shape::{CharCluster, Coverage};
 use parley_engine::{Analysis, AnalysisDataSources, FontInstance, ShapeOptions, Shaper};
 
 use super::layout::Layout;
 use super::resolve::{ResolveContext, ResolvedStyle};
 use super::style::{Brush, FontFeature, FontVariation};
-use crate::FontData;
 use crate::inline_box::InlineBox;
 use crate::util::nearly_eq;
-use fontique::Language;
+use crate::{FontContext, FontData};
+use fontique::{Language, Synthesis};
 
 use fontique::{self, Query, QueryFamily, QueryFont};
 use parlance::Script;
@@ -21,7 +22,8 @@ use parlance::Script;
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn shape_text<'a, B: Brush>(
     rcx: &'a ResolveContext,
-    mut fq: Query<'a>,
+    fcx: &'a mut FontContext,
+    // mut fq: Query<'a>,
     styles: &'a [ResolvedStyle<B>],
     inline_boxes: &[InlineBox],
     analysis: &Analysis,
@@ -36,8 +38,17 @@ pub(crate) fn shape_text<'a, B: Brush>(
     if text.is_empty() && inline_boxes.is_empty() {
         text = " ";
     }
+
     // Do nothing if there is no text or styles (there should always be a default style)
-    if text.is_empty() || styles.is_empty() {
+    let fallback_font;
+    if text.is_empty() || styles.is_empty() || {
+        // Get any font (and only at this point, because if we returned due to empty text or styles,
+        // we don't need to build the font).
+        fallback_font = any_font(fcx);
+
+        // If `true`, there isn't even a single font we could use to shape.
+        fallback_font.is_none()
+    } {
         // Process any remaining inline boxes whose index is greater than the length of the text
         for box_idx in 0..inline_boxes.len() {
             // Push the box to the list of items
@@ -45,6 +56,9 @@ pub(crate) fn shape_text<'a, B: Brush>(
         }
         return;
     }
+    let fallback_font = fallback_font.unwrap();
+
+    let mut fq = fcx.collection.query(&mut fcx.source_cache);
 
     let mut inline_box_iter = inline_boxes.iter().peekable();
     let split_after = |item_range: parley_engine::itemize::TextRange| {
@@ -101,8 +115,15 @@ pub(crate) fn shape_text<'a, B: Brush>(
 
         let style_index = char_style_indices[item.range.char_range.start];
         let style = &styles[usize::from(style_index)];
-        let mut font_selector =
-            FontSelector::new(&mut fq, rcx, styles, style_index, item.script, style.locale);
+        let mut font_selector = FontSelector::new(
+            &mut fq,
+            rcx,
+            styles,
+            style_index,
+            item.script,
+            style.locale,
+            &fallback_font,
+        );
 
         let shaped_runs_range = scx.shape_item(
             text,
@@ -116,17 +137,7 @@ pub(crate) fn shape_text<'a, B: Brush>(
                 char_style_indices,
             },
             #[inline(always)]
-            |char_cluster| {
-                font_selector
-                    .select_font(char_cluster, analysis_data_sources)
-                    .map(|selected| FontInstance {
-                        font: FontData {
-                            data: selected.font.blob,
-                            index: selected.font.index,
-                        },
-                        synthesis: selected.font.synthesis,
-                    })
-            },
+            |char_cluster| font_selector.select_font(char_cluster, analysis_data_sources),
             &mut layout.data.shaped_text,
         );
         for shaped_run_idx in shaped_runs_range {
@@ -157,9 +168,16 @@ struct FontSelector<'a, 'b, B: Brush> {
     attrs: fontique::Attributes,
     variations: &'a [FontVariation],
     features: &'a [FontFeature],
+
+    /// The font to use if [`Self::query`] doesn't return any font.
+    fallback_font: &'b FontInstance,
 }
 
 impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
+    /// Construct a new `FontSelector`.
+    ///
+    /// If `query` ends up not returning a font for a query, the `fallback_font` is returned
+    /// instead.
     fn new(
         query: &'b mut Query<'a>,
         rcx: &'a ResolveContext,
@@ -167,6 +185,7 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
         style_index: u16,
         script: Script,
         locale: Option<Language>,
+        fallback_font: &'b FontInstance,
     ) -> Self {
         let style = &styles[style_index as usize];
         let fonts_id = style.font_family.id();
@@ -192,6 +211,7 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
             attrs,
             variations,
             features,
+            fallback_font,
         }
     }
 
@@ -199,7 +219,7 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
         &mut self,
         cluster: &mut CharCluster,
         analysis_data_sources: &AnalysisDataSources,
-    ) -> Option<SelectedFont> {
+    ) -> FontInstance {
         let style_index = cluster.style_index();
         let is_emoji = cluster.is_emoji();
         if style_index != self.style_index || is_emoji || self.fonts_id.is_none() {
@@ -267,7 +287,32 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
             }
         });
         selected_font
+            .map(|selected_font| FontInstance {
+                font: FontData {
+                    data: selected_font.font.blob,
+                    index: selected_font.font.index,
+                },
+                synthesis: selected_font.font.synthesis,
+            })
+            .unwrap_or(self.fallback_font.clone())
     }
+}
+
+/// Just select any font, that we can pass to [`FontSelector::new`] such that font selection becomes
+/// infallible.
+///
+/// All we need are some `.notdef`s. If this returns `None`, there are no fonts available at all.
+fn any_font(fcx: &mut FontContext) -> Option<FontInstance> {
+    let name = fcx.collection.family_names().next()?.to_owned();
+    let font = fcx
+        .collection
+        .family_by_name(&name)?
+        .default_font()?
+        .clone();
+    Some(FontInstance {
+        font: FontData::new(font.load(Some(&mut fcx.source_cache))?, font.index()),
+        synthesis: Synthesis::default(),
+    })
 }
 
 struct SelectedFont {

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -309,22 +309,34 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
 fn any_font(fcx: &mut FontContext) -> Option<QueryFont> {
     let mut found = None;
 
-    // First try generic text families, and set Latin-script fallback fonts. But note that at this
-    // point, the font itself doesn't really matter: we mostly just need any font to work with.
-    {
-        let mut query = fcx.collection.query(&mut fcx.source_cache);
-        query.set_families(
-            [
-                GenericFamily::SansSerif,
-                GenericFamily::Serif,
-                GenericFamily::Monospace,
-            ]
-            .map(GenericFamily::from),
-        );
-        query.set_fallbacks(fontique::FallbackKey::new(
+    // First try the system's preferred generic text families.
+    //
+    // At this point, the font itself doesn't really matter: we mostly just need any font to work
+    // with. We take the first from each generic family, as on most systems that should "just work"
+    // and give a sensible font, while allowing us to skip extending our query's candidate font
+    // families with all the generic families registered on the system.
+    let sans = fcx
+        .collection
+        .generic_families(GenericFamily::SansSerif)
+        .next();
+    let serif = fcx.collection.generic_families(GenericFamily::Serif).next();
+    let monospace = fcx
+        .collection
+        .generic_families(GenericFamily::Monospace)
+        .next();
+    // Plus any font covering Latin.
+    let latin = fcx
+        .collection
+        .fallback_families(fontique::FallbackKey::new(
             Script::from_bytes(*b"Latn"),
             None,
-        ));
+        ))
+        .next();
+    let preferred = [sans, serif, monospace, latin];
+
+    {
+        let mut query = fcx.collection.query(&mut fcx.source_cache);
+        query.set_families(preferred.into_iter().flatten());
         query.matches_with(
             #[inline]
             |font: &QueryFont| {

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -4,7 +4,7 @@
 //! Text shaping implementation using `harfrust`for shaping
 //! and `icu` for text analysis.
 
-use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
 use parley_engine::shape::{CharCluster, Coverage};
 use parley_engine::{Analysis, AnalysisDataSources, FontInstance, ShapeOptions, Shaper};
 
@@ -14,10 +14,10 @@ use super::style::{Brush, FontFeature, FontVariation};
 use crate::inline_box::InlineBox;
 use crate::util::nearly_eq;
 use crate::{FontContext, FontData};
-use fontique::{Language, Synthesis};
+use fontique::Language;
 
 use fontique::{self, Query, QueryFamily, QueryFont};
-use parlance::Script;
+use parlance::{GenericFamily, Script};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn shape_text<'a, B: Brush>(
@@ -169,7 +169,7 @@ struct FontSelector<'a, 'b, B: Brush> {
     features: &'a [FontFeature],
 
     /// The font to use if [`Self::query`] doesn't return any font.
-    last_resort_font: &'b FontInstance,
+    last_resort_font: &'b QueryFont,
 }
 
 impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
@@ -184,7 +184,7 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
         style_index: u16,
         script: Script,
         locale: Option<Language>,
-        last_resort_font: &'b FontInstance,
+        last_resort_font: &'b QueryFont,
     ) -> Self {
         let style = &styles[style_index as usize];
         let fonts_id = style.font_family.id();
@@ -230,7 +230,7 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
             let fonts = fonts.iter().copied().map(QueryFamily::Id);
             if is_emoji {
                 use core::iter::once;
-                let emoji_family = QueryFamily::Generic(fontique::GenericFamily::Emoji);
+                let emoji_family = QueryFamily::Generic(GenericFamily::Emoji);
                 self.query.set_families(fonts.chain(once(emoji_family)));
                 self.fonts_id = None;
             } else if self.fonts_id != Some(fonts_id) {
@@ -285,33 +285,73 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
                 fontique::QueryStatus::Continue
             }
         });
-        selected_font
-            .map(|selected_font| FontInstance {
-                font: FontData {
-                    data: selected_font.font.blob,
-                    index: selected_font.font.index,
-                },
-                synthesis: selected_font.font.synthesis,
-            })
-            .unwrap_or(self.last_resort_font.clone())
+
+        let selected_font = selected_font
+            .map(|selected_font| selected_font.font)
+            .unwrap_or(self.last_resort_font.clone());
+
+        FontInstance {
+            font: FontData {
+                data: selected_font.blob,
+                index: selected_font.index,
+            },
+            synthesis: selected_font.synthesis,
+        }
     }
 }
 
-/// Just select any font from the font collection.
+/// Just select any font from the font collection, preferring text fonts.
 ///
-/// If this returns `None`, there are no fonts available at all. This can be used to have a font at
-/// hand for shaping, in case more sophisticated font querying returns no fonts.
-fn any_font(fcx: &mut FontContext) -> Option<FontInstance> {
-    let name = fcx.collection.family_names().next()?.to_owned();
-    let font = fcx
-        .collection
-        .family_by_name(&name)?
-        .default_font()?
-        .clone();
-    Some(FontInstance {
-        font: FontData::new(font.load(Some(&mut fcx.source_cache))?, font.index()),
-        synthesis: Synthesis::default(),
-    })
+/// If this returns `None`, there are no fonts available at all.
+///
+/// This can be used to have a font at hand for shaping, in case more sophisticated font querying
+/// returns no fonts.
+fn any_font(fcx: &mut FontContext) -> Option<QueryFont> {
+    let mut found = None;
+
+    // First try generic text families, and set Latin-script fallback fonts. But note that at this
+    // point, the font itself doesn't really matter: we mostly just need any font to work with.
+    {
+        let mut query = fcx.collection.query(&mut fcx.source_cache);
+        query.set_families(
+            [
+                GenericFamily::SansSerif,
+                GenericFamily::Serif,
+                GenericFamily::Monospace,
+            ]
+            .map(GenericFamily::from),
+        );
+        query.set_fallbacks(fontique::FallbackKey::new(
+            Script::from_bytes(*b"Latn"),
+            None,
+        ));
+        query.matches_with(
+            #[inline]
+            |font: &QueryFont| {
+                found = Some(font.clone());
+                fontique::QueryStatus::Stop
+            },
+        );
+    }
+
+    if found.is_some() {
+        return found;
+    }
+
+    // If that failed, it seems like there aren't any text fonts in the collection, so just take
+    // anything at all. Unfortunately, we must collect IDs before the query, as iterating IDs
+    // borrows the collection mutably.
+    let families: Vec<fontique::FamilyId> = fcx.collection.family_ids().collect();
+    let mut query = fcx.collection.query(&mut fcx.source_cache);
+    query.set_families(families);
+    query.matches_with(
+        #[inline]
+        |font: &QueryFont| {
+            found = Some(font.clone());
+            fontique::QueryStatus::Stop
+        },
+    );
+    found
 }
 
 struct SelectedFont {

--- a/parley_engine/src/shape/shaped_text.rs
+++ b/parley_engine/src/shape/shaped_text.rs
@@ -715,7 +715,7 @@ mod tests {
                     variations: &[],
                     char_style_indices: &char_style_indices,
                 },
-                |_| font.clone(),
+                |_| Some(font.clone()),
                 &mut shaped,
             );
         }

--- a/parley_engine/src/shape/shaped_text.rs
+++ b/parley_engine/src/shape/shaped_text.rs
@@ -715,7 +715,7 @@ mod tests {
                     variations: &[],
                     char_style_indices: &char_style_indices,
                 },
-                |_| Some(font.clone()),
+                |_| font.clone(),
                 &mut shaped,
             );
         }

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -112,7 +112,7 @@ impl Shaper {
         analysis: &Analysis,
         item: &Item,
         options: &ShapeOptions<'_>,
-        select_font: impl FnMut(&mut CharCluster) -> Option<FontInstance>,
+        select_font: impl FnMut(&mut CharCluster) -> FontInstance,
         shaped_text: &mut ShapedText,
     ) -> Range<usize> {
         shaped_text.reserve(item.range.char_range.len());
@@ -136,7 +136,7 @@ fn shape_item(
     text: &str,
     item: &Item,
     options: &ShapeOptions<'_>,
-    mut select_font: impl FnMut(&mut CharCluster) -> Option<FontInstance>,
+    mut select_font: impl FnMut(&mut CharCluster) -> FontInstance,
     char_info: &[CharInfo],
     shaped_text: &mut ShapedText,
 ) {
@@ -176,7 +176,7 @@ fn shape_item(
         &mut code_unit_offset_in_string,
     );
 
-    let mut current_font = select_font(char_cluster);
+    let mut current_font = Some(select_font(char_cluster));
 
     // Main segmentation loop (based on swash shape_clusters) - only within current item
     while let Some(font) = current_font.take() {
@@ -195,17 +195,13 @@ fn shape_item(
                 &mut code_unit_offset_in_string,
             );
 
-            if let Some(next_font) = select_font(char_cluster) {
-                if next_font != font {
-                    current_font = Some(next_font);
-                    break;
-                } else {
-                    // Same font - add to current segment
-                    segment_end_offset = char_cluster.range().end as usize - text_range.start;
-                }
+            let next_font = select_font(char_cluster);
+            if next_font != font {
+                current_font = Some(next_font);
+                break;
             } else {
-                // No font determined, continue to next cluster
-                continue;
+                // Same font - add to current segment
+                segment_end_offset = char_cluster.range().end as usize - text_range.start;
             }
         }
 

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -89,6 +89,8 @@ impl Shaper {
     ///
     /// The `select_font` callback should return the font to shape `char_cluster` with. If
     /// consecutive character clusters select a different font, they become separately-shaped runs.
+    /// Shaping is aborted if `select_font` returns `None`; [`ShapedText`] then contains a partial
+    /// result.
     ///
     /// Returns the index range of runs appended to `shaped_text`.
     ///
@@ -101,13 +103,13 @@ impl Shaper {
         analysis: &Analysis,
         item: &Item,
         options: &ShapeOptions<'_>,
-        select_font: impl FnMut(&mut CharCluster) -> FontInstance,
+        select_font: impl FnMut(&mut CharCluster) -> Option<FontInstance>,
         shaped_text: &mut ShapedText,
     ) -> Range<usize> {
         shaped_text.reserve(item.range.char_range.len());
 
         let start = shaped_text.runs().len();
-        shape_item(
+        let _ = shape_item(
             self,
             text,
             item,
@@ -120,15 +122,19 @@ impl Shaper {
     }
 }
 
+/// Shape one item.
+///
+/// Returns `Err(())` if shaping should be aborted, which can only happen if `select_font` returned
+/// `None`.
 fn shape_item(
     scx: &mut Shaper,
     text: &str,
     item: &Item,
     options: &ShapeOptions<'_>,
-    mut select_font: impl FnMut(&mut CharCluster) -> FontInstance,
+    mut select_font: impl FnMut(&mut CharCluster) -> Option<FontInstance>,
     char_info: &[CharInfo],
     shaped_text: &mut ShapedText,
-) {
+) -> Result<(), ()> {
     let text_range = &item.range.byte_range;
     let char_range = &item.range.char_range;
 
@@ -139,7 +145,7 @@ fn shape_item(
     let item_char_style_indices = &options.char_style_indices[char_range.start..char_range.end];
 
     if item_text.is_empty() {
-        return; // No clusters
+        return Ok(()); // No clusters
     }
 
     let mut item_infos_iter = item_char_info
@@ -165,7 +171,10 @@ fn shape_item(
         &mut code_unit_offset_in_string,
     );
 
-    let mut current_font = Some(select_font(char_cluster));
+    let Some(next_font) = select_font(char_cluster) else {
+        return Err(());
+    };
+    let mut current_font = Some(next_font);
 
     // Main segmentation loop (based on swash shape_clusters) - only within current item
     while let Some(font) = current_font.take() {
@@ -184,7 +193,9 @@ fn shape_item(
                 &mut code_unit_offset_in_string,
             );
 
-            let next_font = select_font(char_cluster);
+            let Some(next_font) = select_font(char_cluster) else {
+                return Err(());
+            };
             if next_font != font {
                 current_font = Some(next_font);
                 break;
@@ -322,6 +333,8 @@ fn shape_item(
         // Replace buffer to reuse allocation in next iteration.
         scx.unicode_buffer = Some(glyph_buffer.clear());
     }
+
+    Ok(())
 }
 
 #[inline]

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -95,17 +95,6 @@ impl Shaper {
     /// # Panics
     ///
     /// Panics if the font returned by `select_font` isn't a parseable font.
-    ///
-    // TODO: For `select_font`, on `None`, the previous font is taken (and the run is dropped if
-    // `None` is returned on the first call). This is identical to Parley's old behavior, but we
-    // probably want the commented-out documented behavior that follows, as returning a font is
-    // cheap and it probably doesn't make a ton of sense to hardcode some font fallback behavior
-    // here.
-    //
-    // /// Return `None` if there are no fonts available at all. The character cluster's text will be
-    // /// omitted from the shaped result. Instead, you probably want to render a `.notdef` glyph from a
-    // /// font you do have available, in which case you can return the previous font or some
-    // /// last-resort fallback font instead.
     pub fn shape_item(
         &mut self,
         text: &str,

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -124,8 +124,7 @@ impl Shaper {
 
 /// Shape one item.
 ///
-/// Returns `Err(())` if shaping should be aborted, which can only happen if `select_font` returned
-/// `None`.
+/// Returns `Err(())` if shaping should be aborted, which happens iff `select_font` returned `None`.
 fn shape_item(
     scx: &mut Shaper,
     text: &str,


### PR DESCRIPTION
This makes the font selection callback `parley_engine` takes infallible. That's important, because a font is needed to be able to give font metrics to a `ShapedRun`. As my intention is to move to a `ShapedText` model where the entire source text is covered, to simplify the API and reduce some bookkeeping, that means there shouldn't be gaps in `ShapedRun`s.

`parley` is updated to always pass a font. This PR proposes the very simple/naive protocol of just taking any font from the collection as a final "fallback font", which is used if the font query itself doesn't return any font. If there are no fonts in the collection at all, shaping is completely skipped.

#720 and #721 fixed some pre-existing bugs around empty text, which this infallible font selection surfaced (see #721 in particular).