### PR TITLE
Add `fontique::Collection::family_ids`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This release has an [MSRV] of 1.88.
 
 - `BidiLevel` to encode bidirectional text embedding levels. ([#710][] by [@tomcur][])
 
+#### Fontique
+
+- `Collection::family_ids` to iterate over unique font family identifiers. ([#725][] by [@tomcur][])
+
 ### Changed
 
 #### Parley
@@ -713,6 +717,7 @@ This release has an [MSRV][] of 1.70.
 [#697]: https://github.com/linebender/parley/pull/697
 [#710]: https://github.com/linebender/parley/pull/710
 [#717]: https://github.com/linebender/parley/pull/717
+[#725]: https://github.com/linebender/parley/pull/725
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/linebender/parley/compare/v0.10.0...v0.11.0

--- a/fontique/src/collection/mod.rs
+++ b/fontique/src/collection/mod.rs
@@ -112,6 +112,14 @@ impl Collection {
         self.inner.family_names()
     }
 
+    /// Returns an iterator over all available family identifiers in the collection.
+    ///
+    /// If `fontique` was compiled with the `"system"` feature, then it will
+    /// include system fonts after the registered fonts.
+    pub fn family_ids(&mut self) -> impl Iterator<Item = FamilyId> + '_ + Clone {
+        self.inner.family_ids()
+    }
+
     /// Returns the family identifier for the given family name.
     pub fn family_id(&mut self, name: &str) -> Option<FamilyId> {
         self.inner.family_id(name)
@@ -285,6 +293,20 @@ impl Inner {
             system: self.system.as_ref().map(|sys| sys.family_names.iter()),
         }
         .map(|name| name.name())
+    }
+
+    /// Returns an iterator over all available family identifiers in the collection.
+    ///
+    /// This includes both system and registered fonts.
+    pub fn family_ids(&mut self) -> impl Iterator<Item = FamilyId> + '_ + Clone {
+        self.sync_shared();
+        self.data.family_names.ids().chain(
+            self.system
+                .as_ref()
+                .map(|sys| sys.family_names.ids())
+                .into_iter()
+                .flatten(),
+        )
     }
 
     /// Returns the family identifier for the given family name.

--- a/fontique/src/family_name.rs
+++ b/fontique/src/family_name.rs
@@ -88,9 +88,14 @@ impl FamilyNameMap {
         }
     }
 
-    /// Returns an iterator over all of the font family names.
+    /// Returns an iterator over all of the font family names, including aliases.
     pub fn iter(&self) -> impl Iterator<Item = &FamilyName> + Clone {
         self.name_map.values()
+    }
+
+    /// Returns an iterator over all of the font family identifiers.
+    pub fn ids(&self) -> impl Iterator<Item = FamilyId> + Clone + '_ {
+        self.id_map.keys().copied()
     }
 }
 
@@ -115,5 +120,34 @@ impl NameKey {
 
     pub fn as_bytes(&self) -> &[u8] {
         &self.data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FamilyNameMap;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn iterate_names_and_ids() {
+        let mut map = FamilyNameMap::default();
+        let name = map.get_or_insert("Family");
+        map.add_alias(name.id(), "Alias");
+        let other_name = map.get_or_insert("Other family");
+
+        let mut names: Vec<_> = map.iter().map(|f| f.name()).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            &["Alias", "Family", "Other family"],
+            "family names and aliases should both show up"
+        );
+
+        let mut ids: Vec<_> = map.ids().collect();
+        ids.sort_unstable();
+        let mut expected = vec![name.id(), other_name.id()];
+        expected.sort_unstable();
+        assert_eq!(ids, expected, "family identifiers should only show up once");
     }
 }


### PR DESCRIPTION
This is similar to `fontique::Collection::family_names`, but yields identifiers instead of names, and doesn't include duplicates due to aliases. It's cheaper to iterate over unique families this way.

This is motivated by https://github.com/linebender/parley/pull/722#discussion_r3696623172.

I'm not very familiar with `fontique`, so this is based on investigation with an LLM.