### PR TITLE
`parley_engine`: Always shape full text, ensuring `ShapedText` covers the full text

### DIFF
--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -264,16 +264,7 @@ impl<B: Brush> LayoutData<B> {
     }
 
     /// Push an inline box to the list of items
-    pub(crate) fn push_inline_box(&mut self, index: usize) {
-        // Give the box the same bidi level as the preceding text run
-        // (or else default to 0 if there is not yet a text run)
-        let bidi_level = self
-            .shaped_text
-            .runs()
-            .last()
-            .map(|r| r.bidi_level)
-            .unwrap_or(BidiLevel::new(0));
-
+    pub(crate) fn push_inline_box(&mut self, index: usize, bidi_level: BidiLevel) {
         self.items.push(LayoutItem {
             kind: LayoutItemKind::InlineBox,
             index,

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -73,106 +73,80 @@ pub(crate) fn shape_text<'a, B: Brush>(
     let mut fq = fcx.collection.query(&mut fcx.source_cache);
 
     let mut inline_box_iter = inline_boxes.iter().peekable();
-    let split_after = |item_range: parley_engine::itemize::TextRange| {
-        // Split at inlines boxes, so each box falls on a shaping boundary.
-        {
-            let mut split = false;
-            // We loop because there may be multiple boxes at this index.
-            while let Some(inline_box) = inline_box_iter.peek() {
-                if inline_box.index < item_range.byte_range.end {
-                    // Inline boxes *before* this index are popped (this occurs if the itemizer
-                    // split a run and we were not called, such as at a bidi boundary).
-                    inline_box_iter.next();
-                } else if inline_box.index == item_range.byte_range.end {
-                    inline_box_iter.next();
-                    split = true;
+
+    let items = {
+        core::iter::from_fn(|| {
+            let mut item_start_char: u32 = 0;
+            let mut cur_char: u32 = 0;
+            loop {
+                let mut split = false;
+
+                // We loop because there may be multiple boxes at this index.
+                while let Some(inline_box) = inline_box_iter.peek() {
+                    if inline_box.index < cur_char as usize {
+                        // Inline boxes *before* this index are popped (this occurs if the itemizer
+                        // split a run and we were not called, such as at a bidi boundary).
+                        inline_box_iter.next();
+                    } else if inline_box.index == cur_char as usize {
+                        inline_box_iter.next();
+                        split = true;
+                    } else {
+                        break;
+                    }
+                }
+
+                let item_style_index = char_style_indices[item_start_char as usize];
+                let style_index = char_style_indices[cur_char as usize];
+
+                if style_index != item_style_index {
+                    let item_style = &styles[usize::from(item_style_index)];
+                    let style = &styles[usize::from(style_index)];
+                    split = !nearly_eq(style.font_size, item_style.font_size)
+                        || style.locale != item_style.locale
+                        || style.font_variations != item_style.font_variations
+                        || style.font_features != item_style.font_features
+                        || !nearly_eq(style.letter_spacing, item_style.letter_spacing)
+                        || !nearly_eq(style.word_spacing, item_style.word_spacing)
+                }
+
+                if split {
+                    item_start_char = cur_char;
+                    cur_char += 1;
+
+                    let item_style = &styles[usize::from(item_style_index)];
+                    break Some(parley_engine::itemize::Item_ {
+                        char_end: item_start_char,
+                        options: ShapeOptions {
+                            language: item_style.locale,
+                            font_size: item_style.font_size,
+                            features: rcx.features(item_style.font_features).unwrap_or(&[]),
+                            variations: rcx.variations(item_style.font_variations).unwrap_or(&[]),
+                            char_style_indices,
+                        },
+                    });
                 } else {
-                    break;
+                    cur_char += 1;
                 }
             }
-
-            if split {
-                return true;
-            }
-        }
-
-        let item_style_index = char_style_indices[item_range.char_range.start];
-        let style_index = char_style_indices[item_range.char_range.end];
-
-        if style_index != item_style_index {
-            let item_style = &styles[usize::from(item_style_index)];
-            let style = &styles[usize::from(style_index)];
-            !nearly_eq(style.font_size, item_style.font_size)
-                || style.locale != item_style.locale
-                || style.font_variations != item_style.font_variations
-                || style.font_features != item_style.font_features
-                || !nearly_eq(style.letter_spacing, item_style.letter_spacing)
-                || !nearly_eq(style.word_spacing, item_style.word_spacing)
-        } else {
-            false
-        }
+        })
     };
 
-    let mut features_scratch = SmallVec::<[FontFeature; 8]>::new();
+    let mut font_selector = FontSelector::new(
+        &mut fq,
+        rcx,
+        styles,
+        char_style_indices,
+        analysis_data_sources,
+    );
+
     let mut inline_box_iter = inline_boxes.iter().enumerate().peekable();
-    for item in analysis.itemize(text, split_after) {
-        // Push inline boxes positioned before the start of this item.
-        while let Some((box_idx, inline_box)) = inline_box_iter.peek() {
-            if inline_box.index <= item.range.byte_range.start {
-                layout.data.push_inline_box(*box_idx);
-                inline_box_iter.next();
-            } else {
-                break;
-            }
-        }
-
-        let style_index = char_style_indices[item.range.char_range.start];
-        let style = &styles[usize::from(style_index)];
-        let mut font_selector =
-            FontSelector::new(&mut fq, rcx, styles, style_index, item.script, style.locale);
-
-        let style_features = rcx.features(style.font_features).unwrap_or(&[]);
-        let features = if !nearly_zero(style.letter_spacing) {
-            if style_features.is_empty() {
-                OPTIONAL_LIGATURES_OFF.as_slice()
-            } else {
-                features_scratch.clear();
-                // Later values override earlier values.
-                features_scratch
-                    .extend(OPTIONAL_LIGATURES_OFF.iter().chain(style_features).copied());
-                features_scratch.as_slice()
-            }
-        } else {
-            style_features
-        };
-
-        let shaped_runs_range = scx.shape_item(
-            text,
-            analysis,
-            &item,
-            &ShapeOptions {
-                language: style.locale,
-                font_size: style.font_size,
-                features,
-                variations: rcx.variations(style.font_variations).unwrap_or(&[]),
-                char_style_indices,
-            },
-            #[inline(always)]
-            |char_cluster| font_selector.select_font(char_cluster, analysis_data_sources),
-            &mut layout.data.shaped_text,
-        );
-        for shaped_run_idx in shaped_runs_range {
-            let shaped_run = &layout.data.shaped_text.runs()[shaped_run_idx];
-            let run_style_index = char_style_indices[shaped_run.range.char_range.start];
-            let run_style = &styles[usize::from(run_style_index)];
-            layout.data.process_shaped_run(
-                shaped_run_idx,
-                run_style,
-                style.word_spacing,
-                style.letter_spacing,
-            );
-        }
-    }
+    scx.shape_text(
+        text,
+        analysis,
+        items,
+        font_selector,
+        &mut layout.data.shaped_text,
+    );
 
     // Process any remaining inline boxes whose index is greater than the length of the text
     for (box_idx, _inline_box) in inline_box_iter {
@@ -189,93 +163,62 @@ enum LastResortFont {
 }
 
 struct FontSelector<'a, 'b, B: Brush> {
+    char_style_indices: &'a [u16],
+
     query: &'b mut Query<'a>,
     fonts_id: Option<usize>,
     rcx: &'a ResolveContext,
     styles: &'a [ResolvedStyle<B>],
-    style_index: u16,
+    // style_index: u16,
     attrs: fontique::Attributes,
     variations: &'a [FontVariation],
     features: &'a [FontFeature],
 
     /// The font to use if [`Self::query`] doesn't return any font.
     last_resort_font: LastResortFont,
+
+    analysis_data_sources: &'a AnalysisDataSources,
 }
 
-impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
-    /// Construct a new `FontSelector`.
-    fn new(
-        query: &'b mut Query<'a>,
-        rcx: &'a ResolveContext,
-        styles: &'a [ResolvedStyle<B>],
-        style_index: u16,
-        script: Script,
-        locale: Option<Language>,
-    ) -> Self {
-        let style = &styles[style_index as usize];
+impl<'a, 'b, B: Brush> parley_engine::FontSelector for FontSelector<'a, 'b, B> {
+    fn begin_item(&mut self, item: &parley_engine::itemize::Item, options: &ShapeOptions<'_>) {
+        let style_index = self.char_style_indices[item.range.char_range.start];
+
+        // self.style_index = style_index;
+        let style = &self.styles[style_index as usize];
+
         let fonts_id = style.font_family.id();
-        let fonts = rcx.stack(style.font_family).unwrap_or(&[]);
+        let fonts = self.rcx.stack(style.font_family).unwrap_or(&[]);
+        let fonts = fonts.iter().copied().map(QueryFamily::Id);
+        // if is_emoji {
+        //     use core::iter::once;
+        //     let emoji_family = QueryFamily::Generic(GenericFamily::Emoji);
+        //     self.query.set_families(fonts.chain(once(emoji_family)));
+        //     self.fonts_id = None;
+        // } else if self.fonts_id != Some(fonts_id) {
+        self.query.set_families(fonts);
+        self.fonts_id = Some(fonts_id);
+        // }
+
         let attrs = fontique::Attributes {
             width: style.font_width,
             weight: style.font_weight,
             style: style.font_style,
         };
-        let variations = rcx.variations(style.font_variations).unwrap_or(&[]);
-        let features = rcx.features(style.font_features).unwrap_or(&[]);
-        query.set_families(fonts.iter().copied());
-
-        query.set_fallbacks(fontique::FallbackKey::new(script, locale.as_ref()));
-        query.set_attributes(attrs);
-
-        Self {
-            query,
-            fonts_id: Some(fonts_id),
-            rcx,
-            styles,
-            style_index,
-            attrs,
-            variations,
-            features,
-            last_resort_font: LastResortFont::Unresolved,
+        if self.attrs != attrs {
+            self.query.set_attributes(attrs);
+            self.attrs = attrs;
         }
+        self.variations = self.rcx.variations(style.font_variations).unwrap_or(&[]);
+        self.features = self.rcx.features(style.font_features).unwrap_or(&[]);
     }
 
     fn select_font(
         &mut self,
+        item: &parley_engine::itemize::Item,
+        options: &ShapeOptions<'_>,
         cluster: &mut CharCluster,
-        analysis_data_sources: &AnalysisDataSources,
     ) -> Option<FontInstance> {
-        let style_index = cluster.style_index();
-        let is_emoji = cluster.is_emoji();
-        if style_index != self.style_index || is_emoji || self.fonts_id.is_none() {
-            self.style_index = style_index;
-            let style = &self.styles[style_index as usize];
-
-            let fonts_id = style.font_family.id();
-            let fonts = self.rcx.stack(style.font_family).unwrap_or(&[]);
-            let fonts = fonts.iter().copied().map(QueryFamily::Id);
-            if is_emoji {
-                use core::iter::once;
-                let emoji_family = QueryFamily::Generic(GenericFamily::Emoji);
-                self.query.set_families(fonts.chain(once(emoji_family)));
-                self.fonts_id = None;
-            } else if self.fonts_id != Some(fonts_id) {
-                self.query.set_families(fonts);
-                self.fonts_id = Some(fonts_id);
-            }
-
-            let attrs = fontique::Attributes {
-                width: style.font_width,
-                weight: style.font_weight,
-                style: style.font_style,
-            };
-            if self.attrs != attrs {
-                self.query.set_attributes(attrs);
-                self.attrs = attrs;
-            }
-            self.variations = self.rcx.variations(style.font_variations).unwrap_or(&[]);
-            self.features = self.rcx.features(style.font_features).unwrap_or(&[]);
-        }
         let mut selected_font = None;
         let mut best_coverage = Coverage::NONE;
         self.query.matches_with(|font| {
@@ -293,7 +236,7 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
                         })
                         .unwrap_or_default()
                 },
-                analysis_data_sources,
+                self.analysis_data_sources,
             );
             if coverage > best_coverage {
                 selected_font = Some(SelectedFont { font: font.clone() });
@@ -344,6 +287,54 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
                     None
                 }
             })
+    }
+}
+
+impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
+    /// Construct a new `FontSelector`.
+    ///
+    /// If `query` ends up not returning a font for a query, the `last_resort_font` is returned
+    /// instead.
+    fn new(
+        query: &'b mut Query<'a>,
+        rcx: &'a ResolveContext,
+        styles: &'a [ResolvedStyle<B>],
+        char_style_indices: &'a [u16],
+        // style_index: u16,
+        // script: Script,
+        // locale: Option<Language>,
+        analysis_data_sources: &'a AnalysisDataSources,
+    ) -> Self {
+        // let style = &styles[style_index as usize];
+        // let fonts_id = style.font_family.id();
+        // let fonts = rcx.stack(style.font_family).unwrap_or(&[]);
+        let attrs = fontique::Attributes::default();
+        // {
+        //     width: style.font_width,
+        //     weight: style.font_weight,
+        //     style: style.font_style,
+        // };
+        // let variations = rcx.variations(style.font_variations).unwrap_or(&[]);
+        // let features = rcx.features(style.font_features).unwrap_or(&[]);
+        // query.set_families(fonts.iter().copied());
+
+        // query.set_fallbacks(fontique::FallbackKey::new(script, locale.as_ref()));
+        // query.set_attributes(attrs);
+
+        Self {
+            query,
+            fonts_id: None,
+            rcx,
+            styles,
+            // style_index,
+            attrs,
+            variations: &[],
+            features: &[],
+            last_resort_font: LastResortFont::Unresolved,
+
+            char_style_indices,
+            analysis_data_sources,
+        }
     }
 }
 

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -274,7 +274,11 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
 }
 
 impl<'a, 'b, B: Brush> parley_engine::FontSelector for FontSelector<'a, 'b, B> {
-    fn begin_item(&mut self, item: &parley_engine::itemize::Segment, options: &ShapeOptions<'_>) {
+    fn begin_segment(
+        &mut self,
+        item: &parley_engine::itemize::Segment,
+        options: &ShapeOptions<'_>,
+    ) {
         self.query.set_fallbacks(fontique::FallbackKey::new(
             item.script,
             options.language.as_ref(),

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -4,6 +4,7 @@
 //! Text shaping implementation using `harfrust`for shaping
 //! and `icu` for text analysis.
 
+use alloc::vec::Vec;
 use parley_engine::shape::{CharCluster, Coverage};
 use parley_engine::{Analysis, AnalysisDataSources, FontInstance, ShapeOptions, Shaper};
 use smallvec::SmallVec;
@@ -72,6 +73,29 @@ pub(crate) fn shape_text<'a, B: Brush>(
     let mut fq = fcx.collection.query(&mut fcx.source_cache);
 
     let mut inline_box_iter = inline_boxes.iter().peekable();
+
+    // Merge font features with letter-spacing ligature suppression.
+    //
+    // TODO: This allocation is slightly unfortunate (though solvable). It's required currently,
+    // because the iterator providing `ShapeOptions` has to provide a borrowed `&'a [FontFeature]`,
+    // which cannot be tied to the lifetime of the call to `Iterator::next`. What we'd need is a
+    // lending iterator (i.e., we probably just need to let `parley_engine` take some trait
+    // providing the items).
+    let style_features: &'_ Vec<SmallVec<[FontFeature; 8]>> = &styles
+        .iter()
+        .map(|style| {
+            let style_features = rcx.features(style.font_features).unwrap_or(&[]);
+            if !nearly_zero(style.letter_spacing) {
+                // Later values override earlier values.
+                OPTIONAL_LIGATURES_OFF
+                    .into_iter()
+                    .chain(style_features.iter().copied())
+                    .collect()
+            } else {
+                style_features.iter().copied().collect()
+            }
+        })
+        .collect();
 
     // Split when shaping-relevant style properties change and at inline boxes.
     let items = {
@@ -147,7 +171,7 @@ pub(crate) fn shape_text<'a, B: Brush>(
                 options: ShapeOptions {
                     language: item_style.locale,
                     font_size: item_style.font_size,
-                    features: rcx.features(item_style.font_features).unwrap_or(&[]),
+                    features: &style_features[item_style_index as usize],
                     variations: rcx.variations(item_style.font_variations).unwrap_or(&[]),
                     char_style_indices,
                 },

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -244,6 +244,35 @@ struct FontSelector<'a, 'b, B: Brush> {
     analysis_data_sources: &'a AnalysisDataSources,
 }
 
+impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
+    /// Construct a new `FontSelector`.
+    ///
+    /// If `query` ends up not returning a font for a query, the `last_resort_font` is returned
+    /// instead.
+    fn new(
+        query: &'b mut Query<'a>,
+        rcx: &'a ResolveContext,
+        styles: &'a [ResolvedStyle<B>],
+        analysis_data_sources: &'a AnalysisDataSources,
+    ) -> Self {
+        let attrs = fontique::Attributes::default();
+
+        Self {
+            query,
+            fonts_id: None,
+            rcx,
+            styles,
+            style_index: 0,
+            attrs,
+            variations: &[],
+            features: &[],
+            last_resort_font: LastResortFont::Unresolved,
+
+            analysis_data_sources,
+        }
+    }
+}
+
 impl<'a, 'b, B: Brush> parley_engine::FontSelector for FontSelector<'a, 'b, B> {
     fn begin_item(&mut self, item: &parley_engine::itemize::Segment, options: &ShapeOptions<'_>) {
         self.query.set_fallbacks(fontique::FallbackKey::new(
@@ -360,35 +389,6 @@ impl<'a, 'b, B: Brush> parley_engine::FontSelector for FontSelector<'a, 'b, B> {
                     None
                 }
             })
-    }
-}
-
-impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
-    /// Construct a new `FontSelector`.
-    ///
-    /// If `query` ends up not returning a font for a query, the `last_resort_font` is returned
-    /// instead.
-    fn new(
-        query: &'b mut Query<'a>,
-        rcx: &'a ResolveContext,
-        styles: &'a [ResolvedStyle<B>],
-        analysis_data_sources: &'a AnalysisDataSources,
-    ) -> Self {
-        let attrs = fontique::Attributes::default();
-
-        Self {
-            query,
-            fonts_id: None,
-            rcx,
-            styles,
-            style_index: 0,
-            attrs,
-            variations: &[],
-            features: &[],
-            last_resort_font: LastResortFont::Unresolved,
-
-            analysis_data_sources,
-        }
     }
 }
 

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -17,7 +17,7 @@ use crate::{FontContext, FontData};
 use fontique::Language;
 
 use fontique::{self, Query, QueryFamily, QueryFont};
-use parlance::{GenericFamily, Script, Tag};
+use parlance::{BidiLevel, GenericFamily, Tag};
 
 /// If these font features are passed to the shaper, optional ligatures are not applied.
 ///
@@ -65,7 +65,7 @@ pub(crate) fn shape_text<'a, B: Brush>(
         // Process any remaining inline boxes whose index is greater than the length of the text
         for box_idx in 0..inline_boxes.len() {
             // Push the box to the list of items
-            layout.data.push_inline_box(box_idx);
+            layout.data.push_inline_box(box_idx, BidiLevel::new(0));
         }
         return;
     }
@@ -178,9 +178,18 @@ pub(crate) fn shape_text<'a, B: Brush>(
         let run_style = &styles[usize::from(run_style_index)];
 
         // Push inline boxes positioned before the start of this item.
+        //
+        // TODO: this lets the inline box take the bidi level of the previous run, but in principle
+        // inline boxes should be included in bidi analysis as an object replacement character
+        // (U+FFFC). The box should then take the bidi level of that character.
+        let prev_bidi_level = if shaped_run_idx > 0 {
+            layout.data.shaped_text.runs()[&shaped_run_idx - 1].bidi_level
+        } else {
+            BidiLevel::new(0)
+        };
         while let Some((box_idx, inline_box)) = inline_box_iter.peek() {
             if inline_box.index <= run_text_byte_start {
-                layout.data.push_inline_box(*box_idx);
+                layout.data.push_inline_box(*box_idx, prev_bidi_level);
                 inline_box_iter.next();
             } else {
                 break;
@@ -201,8 +210,18 @@ pub(crate) fn shape_text<'a, B: Brush>(
     }
 
     // Process any remaining inline boxes whose index is greater than the length of the text
+    //
+    // Give the box the same bidi level as the last text run (or else default to 0 if there is no
+    // text run).
+    let bidi_level = layout
+        .data
+        .shaped_text
+        .runs()
+        .last()
+        .map(|r| r.bidi_level)
+        .unwrap_or(BidiLevel::new(0));
     for (box_idx, _inline_box) in inline_box_iter {
-        layout.data.push_inline_box(box_idx);
+        layout.data.push_inline_box(box_idx, bidi_level);
     }
 }
 
@@ -233,7 +252,6 @@ struct FontSelector<'a, 'b, B: Brush> {
 }
 
 impl<'a, 'b, B: Brush> parley_engine::FontSelector for FontSelector<'a, 'b, B> {
-    #[inline(always)]
     fn begin_item(&mut self, item: &parley_engine::itemize::Item, options: &ShapeOptions<'_>) {
         self.query.set_fallbacks(fontique::FallbackKey::new(
             item.script,
@@ -241,7 +259,6 @@ impl<'a, 'b, B: Brush> parley_engine::FontSelector for FontSelector<'a, 'b, B> {
         ));
     }
 
-    #[inline(always)]
     fn select_font(
         &mut self,
         _item: &parley_engine::itemize::Item,

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -139,7 +139,6 @@ pub(crate) fn shape_text<'a, B: Brush>(
         analysis_data_sources,
     );
 
-    let mut inline_box_iter = inline_boxes.iter().enumerate().peekable();
     scx.shape_text(
         text,
         analysis,
@@ -147,6 +146,34 @@ pub(crate) fn shape_text<'a, B: Brush>(
         font_selector,
         &mut layout.data.shaped_text,
     );
+
+    let mut inline_box_iter = inline_boxes.iter().enumerate().peekable();
+    for shaped_run_idx in 0..layout.data.shaped_text.runs().len() {
+        let shaped_run = &layout.data.shaped_text.runs()[shaped_run_idx];
+        let run_text_byte_start = shaped_run.range.byte_range.start;
+        let run_style_index = char_style_indices[shaped_run.range.char_range.start];
+        let run_style = &styles[usize::from(run_style_index)];
+
+        // Push inline boxes positioned before the start of this item.
+        while let Some((box_idx, inline_box)) = inline_box_iter.peek() {
+            if inline_box.index <= run_text_byte_start {
+                layout.data.push_inline_box(*box_idx);
+                inline_box_iter.next();
+            } else {
+                break;
+            }
+        }
+
+        let shaped_run = &layout.data.shaped_text.runs()[shaped_run_idx];
+        let run_style_index = char_style_indices[shaped_run.range.char_range.start];
+        let run_style = &styles[usize::from(run_style_index)];
+        layout.data.process_shaped_run(
+            shaped_run_idx,
+            run_style,
+            style.word_spacing,
+            style.letter_spacing,
+        );
+    }
 
     // Process any remaining inline boxes whose index is greater than the length of the text
     for (box_idx, _inline_box) in inline_box_iter {

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -74,20 +74,43 @@ pub(crate) fn shape_text<'a, B: Brush>(
 
     let mut inline_box_iter = inline_boxes.iter().peekable();
 
+    // Split when shaping-relevant style properties change and at inline boxes.
     let items = {
-        core::iter::from_fn(|| {
-            let mut item_start_char: u32 = 0;
-            let mut cur_char: u32 = 0;
-            loop {
-                let mut split = false;
+        let char_count = char_style_indices.len();
 
+        // The first character of the item currently being built.
+        let mut item_start_char = 0_usize;
+
+        // Positioned at `item_start_char`, i.e., the first character not yet covered by an item.
+        let mut chars = text.char_indices().enumerate().peekable();
+        core::iter::from_fn(move || {
+            if item_start_char == char_count {
+                return None;
+            }
+
+            let item_style_index = char_style_indices[item_start_char];
+            let item_style = &styles[usize::from(item_style_index)];
+
+            // Items are at least one character long, therefore the item's own first character is
+            // never a split point.
+            chars.next();
+
+            let char_end = loop {
+                let Some(&(char_index, (byte_index, _))) = chars.peek() else {
+                    // End of text.
+                    break char_count;
+                };
+
+                // Split at inlines boxes, so each box falls on a shaping boundary.
+                //
                 // We loop because there may be multiple boxes at this index.
+                let mut split = false;
                 while let Some(inline_box) = inline_box_iter.peek() {
-                    if inline_box.index < cur_char as usize {
+                    if inline_box.index < byte_index {
                         // Inline boxes *before* this index are popped (this occurs if the itemizer
                         // split a run and we were not called, such as at a bidi boundary).
                         inline_box_iter.next();
-                    } else if inline_box.index == cur_char as usize {
+                    } else if inline_box.index == byte_index {
                         inline_box_iter.next();
                         split = true;
                     } else {
@@ -95,43 +118,43 @@ pub(crate) fn shape_text<'a, B: Brush>(
                     }
                 }
 
-                let item_style_index = char_style_indices[item_start_char as usize];
-                let style_index = char_style_indices[cur_char as usize];
+                if split {
+                    break char_index;
+                }
 
+                let style_index = char_style_indices[char_index];
                 if style_index != item_style_index {
-                    let item_style = &styles[usize::from(item_style_index)];
                     let style = &styles[usize::from(style_index)];
                     split = !nearly_eq(style.font_size, item_style.font_size)
                         || style.locale != item_style.locale
                         || style.font_variations != item_style.font_variations
                         || style.font_features != item_style.font_features
                         || !nearly_eq(style.letter_spacing, item_style.letter_spacing)
-                        || !nearly_eq(style.word_spacing, item_style.word_spacing)
+                        || !nearly_eq(style.word_spacing, item_style.word_spacing);
                 }
 
                 if split {
-                    item_start_char = cur_char;
-                    cur_char += 1;
-
-                    let item_style = &styles[usize::from(item_style_index)];
-                    break Some(parley_engine::itemize::Item_ {
-                        char_end: item_start_char,
-                        options: ShapeOptions {
-                            language: item_style.locale,
-                            font_size: item_style.font_size,
-                            features: rcx.features(item_style.font_features).unwrap_or(&[]),
-                            variations: rcx.variations(item_style.font_variations).unwrap_or(&[]),
-                            char_style_indices,
-                        },
-                    });
-                } else {
-                    cur_char += 1;
+                    break char_index;
                 }
-            }
+
+                chars.next();
+            };
+
+            item_start_char = char_end;
+            Some(parley_engine::itemize::Item_ {
+                char_end: char_end as u32,
+                options: ShapeOptions {
+                    language: item_style.locale,
+                    font_size: item_style.font_size,
+                    features: rcx.features(item_style.font_features).unwrap_or(&[]),
+                    variations: rcx.variations(item_style.font_variations).unwrap_or(&[]),
+                    char_style_indices,
+                },
+            })
         })
     };
 
-    let mut font_selector = FontSelector::new(
+    let font_selector = FontSelector::new(
         &mut fq,
         rcx,
         styles,
@@ -164,14 +187,16 @@ pub(crate) fn shape_text<'a, B: Brush>(
             }
         }
 
-        let shaped_run = &layout.data.shaped_text.runs()[shaped_run_idx];
-        let run_style_index = char_style_indices[shaped_run.range.char_range.start];
-        let run_style = &styles[usize::from(run_style_index)];
         layout.data.process_shaped_run(
             shaped_run_idx,
+            // TODO: should we get the *item's* style here?
+            //
+            // Using the run's style for word and letter spacing is probably correct (and in fact,
+            // we probably shouldn't itemize on them; we should just ensure we don't ligate if
+            // they're non-zero).
             run_style,
-            style.word_spacing,
-            style.letter_spacing,
+            run_style.word_spacing,
+            run_style.letter_spacing,
         );
     }
 
@@ -196,7 +221,7 @@ struct FontSelector<'a, 'b, B: Brush> {
     fonts_id: Option<usize>,
     rcx: &'a ResolveContext,
     styles: &'a [ResolvedStyle<B>],
-    // style_index: u16,
+    style_index: u16,
     attrs: fontique::Attributes,
     variations: &'a [FontVariation],
     features: &'a [FontFeature],
@@ -208,46 +233,57 @@ struct FontSelector<'a, 'b, B: Brush> {
 }
 
 impl<'a, 'b, B: Brush> parley_engine::FontSelector for FontSelector<'a, 'b, B> {
+    #[inline(always)]
     fn begin_item(&mut self, item: &parley_engine::itemize::Item, options: &ShapeOptions<'_>) {
-        let style_index = self.char_style_indices[item.range.char_range.start];
-
-        // self.style_index = style_index;
-        let style = &self.styles[style_index as usize];
-
-        let fonts_id = style.font_family.id();
-        let fonts = self.rcx.stack(style.font_family).unwrap_or(&[]);
-        let fonts = fonts.iter().copied().map(QueryFamily::Id);
-        // if is_emoji {
-        //     use core::iter::once;
-        //     let emoji_family = QueryFamily::Generic(GenericFamily::Emoji);
-        //     self.query.set_families(fonts.chain(once(emoji_family)));
-        //     self.fonts_id = None;
-        // } else if self.fonts_id != Some(fonts_id) {
-        self.query.set_families(fonts);
-        self.fonts_id = Some(fonts_id);
-        // }
-
-        let attrs = fontique::Attributes {
-            width: style.font_width,
-            weight: style.font_weight,
-            style: style.font_style,
-        };
-        if self.attrs != attrs {
-            self.query.set_attributes(attrs);
-            self.attrs = attrs;
-        }
-        self.variations = self.rcx.variations(style.font_variations).unwrap_or(&[]);
-        self.features = self.rcx.features(style.font_features).unwrap_or(&[]);
+        self.query.set_fallbacks(fontique::FallbackKey::new(
+            item.script,
+            options.language.as_ref(),
+        ));
     }
 
+    #[inline(always)]
     fn select_font(
         &mut self,
-        item: &parley_engine::itemize::Item,
-        options: &ShapeOptions<'_>,
+        _item: &parley_engine::itemize::Item,
+        _options: &ShapeOptions<'_>,
         cluster: &mut CharCluster,
     ) -> Option<FontInstance> {
+        let style_index = cluster.style_index();
+        let is_emoji = cluster.is_emoji();
+
+        if style_index != self.style_index || is_emoji || self.fonts_id.is_none() {
+            self.style_index = style_index;
+            let style = &self.styles[style_index as usize];
+
+            let fonts_id = style.font_family.id();
+            let fonts = self.rcx.stack(style.font_family).unwrap_or(&[]);
+            let fonts = fonts.iter().copied().map(QueryFamily::Id);
+            if is_emoji {
+                use core::iter::once;
+                let emoji_family = QueryFamily::Generic(GenericFamily::Emoji);
+                self.query.set_families(fonts.chain(once(emoji_family)));
+                self.fonts_id = None;
+            } else if self.fonts_id != Some(fonts_id) {
+                self.query.set_families(fonts);
+                self.fonts_id = Some(fonts_id);
+            }
+
+            let attrs = fontique::Attributes {
+                width: style.font_width,
+                weight: style.font_weight,
+                style: style.font_style,
+            };
+            if self.attrs != attrs {
+                self.query.set_attributes(attrs);
+                self.attrs = attrs;
+            }
+            self.variations = self.rcx.variations(style.font_variations).unwrap_or(&[]);
+            self.features = self.rcx.features(style.font_features).unwrap_or(&[]);
+        }
+
         let mut selected_font = None;
         let mut best_coverage = Coverage::NONE;
+
         self.query.matches_with(|font| {
             let Some(charmap) = font.charmap() else {
                 return fontique::QueryStatus::Continue;
@@ -327,33 +363,16 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
         rcx: &'a ResolveContext,
         styles: &'a [ResolvedStyle<B>],
         char_style_indices: &'a [u16],
-        // style_index: u16,
-        // script: Script,
-        // locale: Option<Language>,
         analysis_data_sources: &'a AnalysisDataSources,
     ) -> Self {
-        // let style = &styles[style_index as usize];
-        // let fonts_id = style.font_family.id();
-        // let fonts = rcx.stack(style.font_family).unwrap_or(&[]);
         let attrs = fontique::Attributes::default();
-        // {
-        //     width: style.font_width,
-        //     weight: style.font_weight,
-        //     style: style.font_style,
-        // };
-        // let variations = rcx.variations(style.font_variations).unwrap_or(&[]);
-        // let features = rcx.features(style.font_features).unwrap_or(&[]);
-        // query.set_families(fonts.iter().copied());
-
-        // query.set_fallbacks(fontique::FallbackKey::new(script, locale.as_ref()));
-        // query.set_attributes(attrs);
 
         Self {
             query,
             fonts_id: None,
             rcx,
             styles,
-            // style_index,
+            style_index: 0,
             attrs,
             variations: &[],
             features: &[],

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -75,6 +75,8 @@ pub(crate) fn shape_text<'a, B: Brush>(
 
     // Split when shaping-relevant style properties change and at inline boxes.
     let items = {
+        // TODO: we currently walk characters here, but we could instead just walk boundaries of
+        // styles and inline boxes.
         let char_count = char_style_indices.len();
 
         // The first character of the item currently being built.

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -142,7 +142,7 @@ pub(crate) fn shape_text<'a, B: Brush>(
             };
 
             item_start_char = char_end;
-            Some(parley_engine::itemize::Item_ {
+            Some(parley_engine::itemize::Item {
                 char_end: char_end as u32,
                 options: ShapeOptions {
                     language: item_style.locale,
@@ -245,7 +245,7 @@ struct FontSelector<'a, 'b, B: Brush> {
 }
 
 impl<'a, 'b, B: Brush> parley_engine::FontSelector for FontSelector<'a, 'b, B> {
-    fn begin_item(&mut self, item: &parley_engine::itemize::Item, options: &ShapeOptions<'_>) {
+    fn begin_item(&mut self, item: &parley_engine::itemize::Segment, options: &ShapeOptions<'_>) {
         self.query.set_fallbacks(fontique::FallbackKey::new(
             item.script,
             options.language.as_ref(),
@@ -254,7 +254,7 @@ impl<'a, 'b, B: Brush> parley_engine::FontSelector for FontSelector<'a, 'b, B> {
 
     fn select_font(
         &mut self,
-        _item: &parley_engine::itemize::Item,
+        _item: &parley_engine::itemize::Segment,
         _options: &ShapeOptions<'_>,
         cluster: &mut CharCluster,
     ) -> Option<FontInstance> {

--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -14,7 +14,6 @@ use super::style::{Brush, FontFeature, FontVariation};
 use crate::inline_box::InlineBox;
 use crate::util::{nearly_eq, nearly_zero};
 use crate::{FontContext, FontData};
-use fontique::Language;
 
 use fontique::{self, Query, QueryFamily, QueryFont};
 use parlance::{BidiLevel, GenericFamily, Tag};
@@ -154,13 +153,7 @@ pub(crate) fn shape_text<'a, B: Brush>(
         })
     };
 
-    let font_selector = FontSelector::new(
-        &mut fq,
-        rcx,
-        styles,
-        char_style_indices,
-        analysis_data_sources,
-    );
+    let font_selector = FontSelector::new(&mut fq, rcx, styles, analysis_data_sources);
 
     scx.shape_text(
         text,
@@ -234,8 +227,6 @@ enum LastResortFont {
 }
 
 struct FontSelector<'a, 'b, B: Brush> {
-    char_style_indices: &'a [u16],
-
     query: &'b mut Query<'a>,
     fonts_id: Option<usize>,
     rcx: &'a ResolveContext,
@@ -379,7 +370,6 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
         query: &'b mut Query<'a>,
         rcx: &'a ResolveContext,
         styles: &'a [ResolvedStyle<B>],
-        char_style_indices: &'a [u16],
         analysis_data_sources: &'a AnalysisDataSources,
     ) -> Self {
         let attrs = fontique::Attributes::default();
@@ -395,7 +385,6 @@ impl<'a, 'b, B: Brush> FontSelector<'a, 'b, B> {
             features: &[],
             last_resort_font: LastResortFont::Unresolved,
 
-            char_style_indices,
             analysis_data_sources,
         }
     }

--- a/parley_engine/src/itemize.rs
+++ b/parley_engine/src/itemize.rs
@@ -51,7 +51,6 @@ pub struct Item_<'a> {
 
     /// The options to shape this item with.
     pub options: ShapeOptions<'a>,
-
     // TODO: we probably should allow users to pass in some data (like we allow passing
     // style_indices elsewhere), which we copy onto `ShapedRun`. That allows users to easily
     // correlate `ShapedRun`s with some data they themselves hold.

--- a/parley_engine/src/itemize.rs
+++ b/parley_engine/src/itemize.rs
@@ -52,6 +52,16 @@ pub struct Item<'a> {
     pub char_end: u32,
 
     /// The options to shape this item with.
+    //
+    // TODO: should users instead be allowed to build `options` at the `Segment` level (i.e.,
+    // through some callback)? The motivation is for users to have access to the segment's `Script`
+    // and be able to set font features based on that. If the entirety of `ShapeOptions` moves
+    // there, it would allow users to set, e.g., a font size per segment, even though it's not
+    // necessarily an item boundary; and note an item then doesn't mean a whole lot anymore. We
+    // could also allow only some options to be per-segment. In any case, we're probably moving
+    // towards a future where items reset grapheme segmentation, but segments do not (note Gecko and
+    // Blink also reset grapheme segmentation when something like font size changes, but not when
+    // the script changes).
     pub options: ShapeOptions<'a>,
     // TODO: we probably should allow users to pass in some data (like we allow passing
     // style_indices elsewhere), which we copy onto `ShapedRun`. That allows users to easily

--- a/parley_engine/src/itemize.rs
+++ b/parley_engine/src/itemize.rs
@@ -42,7 +42,10 @@ pub struct Segment {
 
 /// A span of text shaped with specific [`ShapeOptions`].
 ///
-/// While shaping text, items are divided into [`Segment`]s.
+/// An [`Item`] represents a sequence of constant [`ShapeOptions`], but cannot always be passed to
+/// the shaper as a single unit. Within an item, the script or bidirectional text embedding level
+/// may change, which requires further splitting the item into segments of constant script and bidi
+/// level (see [`Segment`]).
 #[derive(Debug)]
 pub struct Item<'a> {
     /// The character offset in the source text which this item ends.

--- a/parley_engine/src/itemize.rs
+++ b/parley_engine/src/itemize.rs
@@ -43,13 +43,24 @@ pub struct Item {
 /// An item produced by [`Analysis::itemize`].
 #[derive(Debug)]
 pub struct Item_<'a> {
-    /// The options to shape this item with.
-    pub options: ShapeOptions<'a>,
     /// The character offset in the source text which this item ends.
     ///
     /// This must be strictly greater than the previous item's end. For the first item, it must be
     /// greater than 0.
     pub char_end: u32,
+
+    /// The options to shape this item with.
+    pub options: ShapeOptions<'a>,
+
+    // TODO: we probably should allow users to pass in some data (like we allow passing
+    // style_indices elsewhere), which we copy onto `ShapedRun`. That allows users to easily
+    // correlate `ShapedRun`s with some data they themselves hold.
+    //
+    // This is potentially important for better correctness in `parley`: it itemizes based on
+    // `nearly_eq` of shaping-relevant styles like font size, i.e., it should then read that item's
+    // style to know the font size, even though it may be different for the run.
+    // /// Opaque data copied onto every `ShapedRun` produced from this item.
+    // pub user_data: u16,
 }
 
 /// Produces the items in a text via [`Self::next`]; created by [`Analysis::itemize`].

--- a/parley_engine/src/itemize.rs
+++ b/parley_engine/src/itemize.rs
@@ -8,7 +8,7 @@ use core::{ops::Range, str::CharIndices};
 use icu_properties::props::Script as IcuScript;
 use parlance::{BidiLevel, Script};
 
-use crate::{Analysis, CharInfo};
+use crate::{Analysis, CharInfo, ShapeOptions};
 
 /// A range of text.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -40,8 +40,21 @@ pub struct Item {
     pub script: Script,
 }
 
-/// An iterator over items in text, produced by [`Analysis::itemize`].
-pub struct Itemizer<'a, F> {
+/// An item produced by [`Analysis::itemize`].
+#[derive(Debug)]
+pub struct Item_<'a> {
+    /// The options to shape this item with.
+    pub options: ShapeOptions<'a>,
+    /// The character offset in the source text which this item ends.
+    ///
+    /// This must be strictly greater than the previous item's end. For the first item, it must be
+    /// greater than 0.
+    pub char_end: u32,
+}
+
+/// Produces the items in a text via [`Self::next`]; created by [`Analysis::itemize`].
+#[derive(Debug)]
+pub(crate) struct Itemizer<'a> {
     /// Our underlying iterator over the input text.
     char_indices: CharIndices<'a>,
     /// The per-char info, parallel to [`Self::char_indices`].
@@ -55,26 +68,10 @@ pub struct Itemizer<'a, F> {
     /// character.
     paragraph_bidi_level: BidiLevel,
 
-    /// User-provided itemization split predicate (e.g., if the font size changes).
-    split_after: F,
-
     /// The running character offset of the last-processed item.
     current_char_offset: usize,
     /// The running script of the last-processed item.
     current_script: IcuScript,
-}
-
-impl<F> core::fmt::Debug for Itemizer<'_, F> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Itemizer")
-            .field("char_indices", &self.char_indices)
-            .field("char_info", &self.char_info)
-            .field("bidi_levels", &self.bidi_levels)
-            .field("paragraph_bidi_level", &self.paragraph_bidi_level)
-            .field("current_char_offset", &self.current_char_offset)
-            .field("current_script", &self.current_script)
-            .finish_non_exhaustive()
-    }
 }
 
 impl Analysis {
@@ -82,24 +79,12 @@ impl Analysis {
     ///
     /// The `text` passed in must be the same as used for producing the `self` analysis.
     ///
-    /// The text is itemized into items of constant bidi level and script. For consecutive
-    /// characters where the bidi level and script are unchanging, the `split_after` predicate is
-    /// called with the growing item range, and can be used to split on additional properties like
-    /// shaping-relevant style changes (e.g., font size) or properties like language.
-    ///
-    /// The predicate is given a range encoding the current item and considers whether to split
-    /// after that item based on the next character. Iff the predicate returns `true`, the text is
-    /// split after that item; i.e., given a range of `start..end`, the predicate controls whether
-    /// that item is now finished, or whether it is extended to include the character at `end` (at
-    /// which point the item spans `start..end+1`).
+    /// The text is itemized into items of constant bidi level and script, intersected with items
+    /// produced by a predicate passed to [`Itemizer::next`].
     ///
     /// Characters that don't have a particular script have their script resolved based on
     /// surrounding context (see [`Item::script`]).
-    pub fn itemize<'a, F: FnMut(TextRange) -> bool>(
-        &'a self,
-        text: &'a str,
-        split_after: F,
-    ) -> Itemizer<'a, F> {
+    pub(crate) fn itemize<'a>(&'a self, text: &'a str) -> Itemizer<'a> {
         let first_real_script = self
             .char_info()
             .iter()
@@ -112,7 +97,6 @@ impl Analysis {
             char_info: self.char_info(),
             bidi_levels: self.bidi_levels(),
             paragraph_bidi_level: self.paragraph_level(),
-            split_after,
 
             current_char_offset: 0,
             current_script: first_real_script,
@@ -120,10 +104,21 @@ impl Analysis {
     }
 }
 
-impl<F: FnMut(TextRange) -> bool> Iterator for Itemizer<'_, F> {
-    type Item = Item;
-
-    fn next(&mut self) -> Option<Self::Item> {
+impl Itemizer<'_> {
+    /// Produce the next item, if any.
+    ///
+    /// For consecutive characters where the bidi level and script are unchanging, the `split_after`
+    /// predicate is called with the growing item range, and can be used to split on additional
+    /// properties like shaping-relevant style changes (e.g., font size) or properties like
+    /// language.
+    ///
+    /// The predicate is given a range encoding the current item and considers whether to split
+    /// after that item based on the next character. Iff the predicate returns `true`, the text is
+    /// split after that item; i.e., given a range of `start..end`, the predicate controls whether
+    /// that item is now finished, or whether it is extended to include the character at `end` (at
+    /// which point the item spans `start..end+1`).
+    #[inline]
+    pub(crate) fn next(&mut self, mut split_after: impl FnMut(TextRange) -> bool) -> Option<Item> {
         if self.char_info.is_empty() {
             // We're already finished.
             debug_assert!(
@@ -169,7 +164,7 @@ impl<F: FnMut(TextRange) -> bool> Iterator for Itemizer<'_, F> {
             }
 
             if item_char_len > 0
-                && (self.split_after)(TextRange {
+                && split_after(TextRange {
                     byte_range: start_byte_offset..byte_offset,
                     char_range: self.current_char_offset..self.current_char_offset + item_char_len,
                 })
@@ -243,7 +238,9 @@ mod tests {
     }
 
     fn items(text: &str) -> Vec<Item> {
-        analyze(text).itemize(text, |_| false).collect()
+        let analysis = analyze(text);
+        let mut itemizer = analysis.itemize(text);
+        core::iter::from_fn(|| itemizer.next(|_| false)).collect()
     }
 
     #[test]
@@ -277,9 +274,9 @@ mod tests {
     fn predicate() {
         let text = "abcdef";
         let analysis = analyze(text);
-        let items: Vec<_> = analysis
-            .itemize(text, |range| range.char_range.end == 3)
-            .collect();
+        let mut itemizer = analysis.itemize(text);
+        let items: Vec<_> =
+            core::iter::from_fn(|| itemizer.next(|range| range.char_range.end == 3)).collect();
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].range.byte_range, 0..3);
         assert_eq!(items[0].range.char_range, 0..3);

--- a/parley_engine/src/itemize.rs
+++ b/parley_engine/src/itemize.rs
@@ -20,9 +20,9 @@ pub struct TextRange {
     pub char_range: Range<usize>,
 }
 
-/// An item produced by [`Analysis::itemize`].
+/// A span of text inside an [`Item`] with constant script and bidirectional embedding level.
 #[derive(Clone, Debug)]
-pub struct Item {
+pub struct Segment {
     /// The text range of this item.
     pub range: TextRange,
 
@@ -40,9 +40,11 @@ pub struct Item {
     pub script: Script,
 }
 
-/// An item produced by [`Analysis::itemize`].
+/// A span of text shaped with specific [`ShapeOptions`].
+///
+/// While shaping text, items are divided into [`Segment`]s.
 #[derive(Debug)]
-pub struct Item_<'a> {
+pub struct Item<'a> {
     /// The character offset in the source text which this item ends.
     ///
     /// This must be strictly greater than the previous item's end. For the first item, it must be
@@ -85,15 +87,15 @@ pub(crate) struct Itemizer<'a> {
 }
 
 impl Analysis {
-    /// Itemize the `text` into individually-shapeable runs.
+    /// Divide the `text` into individually-shapeable segments.
     ///
     /// The `text` passed in must be the same as used for producing the `self` analysis.
     ///
-    /// The text is itemized into items of constant bidi level and script, intersected with items
-    /// produced by a predicate passed to [`Itemizer::next`].
+    /// The text is divided into items produced by a predicate passed to [`Itemizer::next`] and
+    /// further divided into segments of constant bidi level and script.
     ///
     /// Characters that don't have a particular script have their script resolved based on
-    /// surrounding context (see [`Item::script`]).
+    /// surrounding context (see [`Segment::script`]).
     pub(crate) fn itemize<'a>(&'a self, text: &'a str) -> Itemizer<'a> {
         let first_real_script = self
             .char_info()
@@ -115,7 +117,7 @@ impl Analysis {
 }
 
 impl Itemizer<'_> {
-    /// Produce the next item, if any.
+    /// Produce the next segment, if any.
     ///
     /// For consecutive characters where the bidi level and script are unchanging, the `split_after`
     /// predicate is called with the growing item range, and can be used to split on additional
@@ -127,8 +129,15 @@ impl Itemizer<'_> {
     /// split after that item; i.e., given a range of `start..end`, the predicate controls whether
     /// that item is now finished, or whether it is extended to include the character at `end` (at
     /// which point the item spans `start..end+1`).
+    //
+    // TODO: currently the items from `split_after` have the same effect as a change in bidi or
+    // script. This is not how browsers handle things. In particular, `split_after` should reset
+    // grapheme segmentation, whereas bidi and script should produce separately-shaped segments.
     #[inline]
-    pub(crate) fn next(&mut self, mut split_after: impl FnMut(TextRange) -> bool) -> Option<Item> {
+    pub(crate) fn next(
+        &mut self,
+        mut split_after: impl FnMut(TextRange) -> bool,
+    ) -> Option<Segment> {
         if self.char_info.is_empty() {
             // We're already finished.
             debug_assert!(
@@ -199,7 +208,7 @@ impl Itemizer<'_> {
         let start_char_offset = self.current_char_offset;
         self.current_char_offset += item_char_len;
 
-        Some(Item {
+        Some(Segment {
             range: TextRange {
                 byte_range: start_byte_offset..self.char_indices.offset(),
                 char_range: start_char_offset..self.current_char_offset,
@@ -233,7 +242,7 @@ mod tests {
 
     use crate::{Analysis, AnalysisOptions, Analyzer};
 
-    use super::Item;
+    use super::Segment;
 
     const LATN: Script = Script::from_bytes(*b"Latn");
     const GREK: Script = Script::from_bytes(*b"Grek");
@@ -247,7 +256,7 @@ mod tests {
         analysis
     }
 
-    fn items(text: &str) -> Vec<Item> {
+    fn items(text: &str) -> Vec<Segment> {
         let analysis = analyze(text);
         let mut itemizer = analysis.itemize(text);
         core::iter::from_fn(|| itemizer.next(|_| false)).collect()

--- a/parley_engine/src/lib.rs
+++ b/parley_engine/src/lib.rs
@@ -40,4 +40,4 @@ pub use analyzer::{AnalysisOptions, Analyzer};
 pub use glyph::Glyph;
 pub use shape::atom::{Atom, Atoms, Grapheme, Graphemes, ShapedSlice};
 pub use shape::shaped_text::{FontMetrics, NormalizedCoord, ShapedRun, ShapedText};
-pub use shape::shaper::{FontInstance, ShapeOptions, Shaper};
+pub use shape::shaper::{FontInstance, FontSelector, ShapeOptions, Shaper};

--- a/parley_engine/src/shape/atom.rs
+++ b/parley_engine/src/shape/atom.rs
@@ -852,7 +852,7 @@ mod tests {
 
         let char_style_indices = vec![0; text.chars().count()];
         let items = [Item {
-            char_end: text.chars().count() as u32,
+            char_end: text.chars().count().try_into().unwrap(),
             options: ShapeOptions {
                 font_size: 32.0,
                 language: None,

--- a/parley_engine/src/shape/atom.rs
+++ b/parley_engine/src/shape/atom.rs
@@ -802,7 +802,7 @@ mod tests {
     use crate::{
         Analysis, AnalysisOptions, Analyzer, FontInstance, FontSelector, ShapeOptions, ShapedText,
         Shaper,
-        itemize::{Item, Item_},
+        itemize::{Item, Segment},
         shape::CharCluster,
     };
 
@@ -815,7 +815,7 @@ mod tests {
     impl FontSelector for SingleFont {
         fn select_font(
             &mut self,
-            _item: &Item,
+            _segment: &Segment,
             _options: &ShapeOptions<'_>,
             _cluster: &mut CharCluster,
         ) -> Option<FontInstance> {
@@ -851,7 +851,7 @@ mod tests {
         let mut shaped = ShapedText::new();
 
         let char_style_indices = vec![0; text.chars().count()];
-        let items = [Item_ {
+        let items = [Item {
             char_end: text.chars().count() as u32,
             options: ShapeOptions {
                 font_size: 32.0,

--- a/parley_engine/src/shape/atom.rs
+++ b/parley_engine/src/shape/atom.rs
@@ -800,12 +800,28 @@ mod tests {
     use linebender_resource_handle::{Blob, FontData};
 
     use crate::{
-        Analysis, AnalysisOptions, Analyzer, FontInstance, ShapeOptions, ShapedText, Shaper,
-        itemize::Item,
+        Analysis, AnalysisOptions, Analyzer, FontInstance, FontSelector, ShapeOptions, ShapedText,
+        Shaper,
+        itemize::{Item, Item_},
+        shape::CharCluster,
     };
 
     const ROBOTO: &[u8] =
         include_bytes!("../../../parley_dev/assets/fonts/roboto_fonts/Roboto-Regular.ttf");
+
+    /// A [`FontSelector`] shaping everything with a single font.
+    struct SingleFont(FontInstance);
+
+    impl FontSelector for SingleFont {
+        fn select_font(
+            &mut self,
+            _item: &Item,
+            _options: &ShapeOptions<'_>,
+            _cluster: &mut CharCluster,
+        ) -> Option<FontInstance> {
+            Some(self.0.clone())
+        }
+    }
 
     fn analyze(text: &str) -> Analysis {
         let mut analysis = Analysis::new();
@@ -828,39 +844,24 @@ mod tests {
         }
     }
 
-    fn shape_item_with_font(
-        text: &str,
-        analysis: &Analysis,
-        item: &Item,
-        font: &FontInstance,
-        shaper: &mut Shaper,
-        shaped: &mut ShapedText,
-    ) {
+    fn shape_with_font(text: &str, font_data: &'static [u8]) -> ShapedText {
+        let analysis = analyze(text);
+        let font = font_instance(font_data);
+        let mut shaper = Shaper::default();
+        let mut shaped = ShapedText::new();
+
         let char_style_indices = vec![0; text.chars().count()];
-        shaper.shape_item(
-            text,
-            analysis,
-            item,
-            &ShapeOptions {
+        let items = [Item_ {
+            char_end: text.chars().count() as u32,
+            options: ShapeOptions {
                 font_size: 32.0,
                 language: None,
                 features: &[],
                 variations: &[],
                 char_style_indices: &char_style_indices,
             },
-            |_| Some(font.clone()),
-            shaped,
-        );
-    }
-
-    fn shape_with_font(text: &str, font_data: &'static [u8]) -> ShapedText {
-        let analysis = analyze(text);
-        let font = font_instance(font_data);
-        let mut shaper = Shaper::default();
-        let mut shaped = ShapedText::new();
-        for item in analysis.itemize(text, |_| false) {
-            shape_item_with_font(text, &analysis, &item, &font, &mut shaper, &mut shaped);
-        }
+        }];
+        shaper.shape_text(text, &analysis, items, SingleFont(font), &mut shaped);
         shaped
     }
 

--- a/parley_engine/src/shape/shaped_text.rs
+++ b/parley_engine/src/shape/shaped_text.rs
@@ -9,15 +9,13 @@ use alloc::vec::Vec;
 use parlance::BidiLevel;
 
 use crate::{
-    CharInfo, FontInstance, Glyph, ShapeOptions,
-    itemize::{Item, TextRange},
-    shape::ShapedClusterFlags,
+    CharInfo, FontInstance, Glyph,
+    itemize::{Segment, TextRange},
 };
 
 use super::{
-    ClusterInfo, Whitespace,
-    atom::ShapedSlice,
-    data::{Character, ShapedCluster},
+    Character, ClusterInfo, ShapedCluster, ShapedClusterFlags, Whitespace, atom::ShapedSlice,
+    shaper::ShapeOptions,
 };
 
 /// A normalized font coordinate.
@@ -235,7 +233,7 @@ impl ShapedText {
         &mut self,
         text: &str,
         range: TextRange,
-        item: &Item,
+        item: &Segment,
         options: &ShapeOptions<'_>,
         char_info: &[CharInfo],
         font: &FontInstance,
@@ -563,7 +561,7 @@ mod tests {
 
     use crate::{
         Analysis, AnalysisOptions, Analyzer, FontInstance, FontSelector, ShapeOptions, Shaper,
-        itemize::{Item, Item_},
+        itemize::{Item, Segment},
         shape::CharCluster,
     };
 
@@ -580,7 +578,7 @@ mod tests {
     impl FontSelector for SingleFont {
         fn select_font(
             &mut self,
-            _item: &Item,
+            _item: &Segment,
             _options: &ShapeOptions<'_>,
             _cluster: &mut CharCluster,
         ) -> Option<FontInstance> {
@@ -616,7 +614,7 @@ mod tests {
         let mut shaped = ShapedText::new();
 
         let char_style_indices = vec![0; text.chars().count()];
-        let items = [Item_ {
+        let items = [Item {
             char_end: text.chars().count().try_into().unwrap(),
             options: ShapeOptions {
                 font_size: 32.0,
@@ -727,7 +725,7 @@ mod tests {
 
         // ...split over two items.
         let items = [
-            Item_ {
+            Item {
                 char_end: 1,
                 options: ShapeOptions {
                     font_size: 32.0,
@@ -737,7 +735,7 @@ mod tests {
                     char_style_indices: &char_style_indices,
                 },
             },
-            Item_ {
+            Item {
                 char_end: text.chars().count() as u32,
                 options: ShapeOptions {
                     font_size: 32.0,

--- a/parley_engine/src/shape/shaped_text.rs
+++ b/parley_engine/src/shape/shaped_text.rs
@@ -617,7 +617,7 @@ mod tests {
 
         let char_style_indices = vec![0; text.chars().count()];
         let items = [Item_ {
-            char_end: text.chars().count() as u32,
+            char_end: text.chars().count().try_into().unwrap(),
             options: ShapeOptions {
                 font_size: 32.0,
                 language: None,

--- a/parley_engine/src/shape/shaped_text.rs
+++ b/parley_engine/src/shape/shaped_text.rs
@@ -562,7 +562,11 @@ mod tests {
     use fontique::Synthesis;
     use linebender_resource_handle::{Blob, FontData};
 
-    use crate::{Analysis, AnalysisOptions, Analyzer, FontInstance, ShapeOptions, Shaper};
+    use crate::{
+        Analysis, AnalysisOptions, Analyzer, FontInstance, FontSelector, ShapeOptions, Shaper,
+        itemize::{Item, Item_},
+        shape::CharCluster,
+    };
 
     use super::ShapedText;
 
@@ -570,6 +574,20 @@ mod tests {
         include_bytes!("../../../parley_dev/assets/fonts/roboto_fonts/Roboto-Regular.ttf");
     const NOTO_KUFI_ARABIC: &[u8] =
         include_bytes!("../../../parley_dev/assets/fonts/noto_fonts/NotoKufiArabic-Regular.otf");
+
+    /// A [`FontSelector`] shaping everything with a single font.
+    struct SingleFont(FontInstance);
+
+    impl FontSelector for SingleFont {
+        fn select_font(
+            &mut self,
+            _item: &Item,
+            _options: &ShapeOptions<'_>,
+            _cluster: &mut CharCluster,
+        ) -> Option<FontInstance> {
+            Some(self.0.clone())
+        }
+    }
 
     fn analyze(text: &str) -> Analysis {
         let mut analysis = Analysis::new();
@@ -592,39 +610,24 @@ mod tests {
         }
     }
 
-    fn shape_item_with_font(
-        text: &str,
-        analysis: &Analysis,
-        item: &crate::itemize::Item,
-        font: &FontInstance,
-        shaper: &mut Shaper,
-        shaped: &mut ShapedText,
-    ) {
+    fn shape_with_font(text: &str, font_data: &'static [u8]) -> ShapedText {
+        let analysis = analyze(text);
+        let font = font_instance(font_data);
+        let mut shaper = Shaper::default();
+        let mut shaped = ShapedText::new();
+
         let char_style_indices = vec![0; text.chars().count()];
-        shaper.shape_item(
-            text,
-            analysis,
-            item,
-            &ShapeOptions {
+        let items = [Item_ {
+            char_end: text.chars().count() as u32,
+            options: ShapeOptions {
                 font_size: 32.0,
                 language: None,
                 features: &[],
                 variations: &[],
                 char_style_indices: &char_style_indices,
             },
-            |_| Some(font.clone()),
-            shaped,
-        );
-    }
-
-    fn shape_with_font(text: &str, font_data: &'static [u8]) -> ShapedText {
-        let analysis = analyze(text);
-        let font = font_instance(font_data);
-        let mut shaper = Shaper::default();
-        let mut shaped = ShapedText::new();
-        for item in analysis.itemize(text, |_| false) {
-            shape_item_with_font(text, &analysis, &item, &font, &mut shaper, &mut shaped);
-        }
+        }];
+        shaper.shape_text(text, &analysis, items, SingleFont(font), &mut shaped);
         shaped
     }
 
@@ -708,6 +711,7 @@ mod tests {
     fn item_boundaries_force_grapheme_start() {
         // Two regional indicators forming a single flag grapheme...
         let text = "\u{1F1E6}\u{1F1E7}";
+        let char_style_indices = vec![0; text.chars().count()];
         let analysis = analyze(text);
         assert_eq!(
             analysis
@@ -718,18 +722,34 @@ mod tests {
             [true, false]
         );
 
-        // ...split over two items.
-        let items: Vec<_> = analysis
-            .itemize(text, |range| range.char_range.end == 1)
-            .collect();
-        assert_eq!(items.len(), 2);
-
         let font = font_instance(ROBOTO);
         let mut shaper = Shaper::default();
         let mut shaped = ShapedText::new();
-        for item in &items {
-            shape_item_with_font(text, &analysis, item, &font, &mut shaper, &mut shaped);
-        }
+
+        // ...split over two items.
+        let items = [
+            Item_ {
+                char_end: 1,
+                options: ShapeOptions {
+                    font_size: 32.0,
+                    language: None,
+                    features: &[],
+                    variations: &[],
+                    char_style_indices: &char_style_indices,
+                },
+            },
+            Item_ {
+                char_end: text.chars().count() as u32,
+                options: ShapeOptions {
+                    font_size: 32.0,
+                    language: None,
+                    features: &[],
+                    variations: &[],
+                    char_style_indices: &char_style_indices,
+                },
+            },
+        ];
+        shaper.shape_text(text, &analysis, items, SingleFont(font), &mut shaped);
 
         let grapheme_starts: Vec<bool> =
             shaped.characters.iter().map(|c| c.grapheme_start).collect();

--- a/parley_engine/src/shape/shaped_text.rs
+++ b/parley_engine/src/shape/shaped_text.rs
@@ -736,7 +736,7 @@ mod tests {
                 },
             },
             Item {
-                char_end: text.chars().count() as u32,
+                char_end: text.chars().count().try_into().unwrap(),
                 options: ShapeOptions {
                     font_size: 32.0,
                     language: None,

--- a/parley_engine/src/shape/shaped_text.rs
+++ b/parley_engine/src/shape/shaped_text.rs
@@ -89,9 +89,8 @@ pub struct FontMetrics {
 
 /// The result of shaping.
 ///
-/// After [itemizing][crate::itemize::Item] your text,
-/// [shape each item][crate::Shaper::shape_item], appending the result into this
-/// [`ShapedText`]. This then holds your shaped paragraph of text.
+/// After [analyzing][crate::Analysis] your text, [shape the text][crate::Shaper::shape_text],
+/// writing the result into this [`ShapedText`]. This then holds your shaped paragraph of text.
 ///
 /// This shaped text holds spans of the source text's characters that were shaped into
 /// [`ShapedCluster`]s. Note that the boundaries of shaped clusters and graphemes need not coincide;

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -133,7 +133,7 @@ impl Shaper {
                     )
                     .expect("A segment must be yielded, given items tile the full text exactly");
 
-                if shape_item(
+                if shape_segment(
                     self,
                     text,
                     &segment,
@@ -169,11 +169,11 @@ impl Shaper {
     }
 }
 
-/// Shape one item.
+/// Shape one segment.
 ///
 /// Returns `Err(())` if shaping should be aborted, which happens iff [`FontSelector::select_font`]
 /// returned `None`.
-fn shape_item(
+fn shape_segment(
     scx: &mut Shaper,
     text: &str,
     item: &Segment,
@@ -182,7 +182,7 @@ fn shape_item(
     char_info: &[CharInfo],
     shaped_text: &mut ShapedText,
 ) -> Result<(), ()> {
-    select_font.begin_item(item, options);
+    select_font.begin_segment(item, options);
 
     let text_range = &item.range.byte_range;
     let char_range = &item.range.char_range;
@@ -416,7 +416,7 @@ pub trait FontSelector {
     /// Called when a new item starts.
     ///
     /// This can be useful to inspect, e.g., the item's script.
-    fn begin_item(&mut self, item: &Segment, options: &ShapeOptions<'_>) {
+    fn begin_segment(&mut self, item: &Segment, options: &ShapeOptions<'_>) {
         let _ = (item, options);
     }
 

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -109,6 +109,7 @@ impl Shaper {
         shaped_text: &mut ShapedText,
     ) {
         shaped_text.clear();
+        shaped_text.reserve(text.len());
 
         let mut items = items.into_iter();
 

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -36,6 +36,8 @@ pub struct ShapeOptions<'a> {
     pub variations: &'a [FontVariation],
     /// The per-character style indices.
     // TODO: rename to something like `user_data` (s.t. we don't assume it's a style per se).
+    // TODO: probably move this out of `ShapeOptions`, and supply it as a parameter on
+    // `Shaper::shape_text`.
     pub char_style_indices: &'a [u16],
 }
 

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -50,7 +50,7 @@ pub struct FontInstance {
     pub synthesis: fontique::Synthesis,
 }
 
-/// Reusable scratch to shape [items][`Item`] into shaped text using [`Self::shape_item`].
+/// Reusable scratch to shape text using [`Self::shape_text`].
 pub struct Shaper {
     shape_data_cache: LruCache<cache::ShapeDataKey, harfrust::ShaperData>,
     shape_instance_cache: LruCache<cache::ShapeInstanceId, harfrust::ShaperInstance>,
@@ -81,16 +81,30 @@ impl core::fmt::Debug for Shaper {
 }
 
 impl Shaper {
+    /// Shape text into glyphs, overwriting `shaped_text`.
+    ///
+    /// The `text` passed in must be the same as used for producing `analysis`.
+    ///
+    /// This uses the items returned by `items`, and further itemizes the text into
+    /// individually-shapeable runs of constant bidi level and script. `items` should be used to
+    /// split on properties like shaping-relevant style changes (e.g., font size) or properties like
+    /// language.
+    ///
+    /// Characters that don't have a particular script have their script resolved based on
+    /// surrounding context (see [`crate::itemizer::Item::script`]).
+    ///
+    /// Each item is then broken into runs of maximal sequences of character clusters for which
+    /// `select_font` returns the same font.
     ///
     /// # Panics
     ///
-    /// Panics if `items` does not cover the entire source text.
+    /// Panics if `items` does not cover the entire source text, or the font returned by
+    /// `select_font` is malformed.
     pub fn shape_text<'options>(
         &mut self,
         text: &str,
         analysis: &Analysis,
         items: impl IntoIterator<Item = Item_<'options>>,
-        // mut select_font: impl FnMut(&mut CharCluster) -> FontInstance,
         mut select_font: impl FontSelector,
         shaped_text: &mut ShapedText,
     ) {

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -4,14 +4,14 @@
 //! Shaping of text.
 
 use alloc::vec::Vec;
-use core::{mem, ops::Range};
+use core::mem;
 use harfrust::ShapeOptions as HarfShapeOptions;
 use linebender_resource_handle::FontData;
 use parlance::{FontFeature, FontVariation, Language};
 
 use crate::{
     Analysis, CharInfo, ShapedText,
-    itemize::{Item, TextRange},
+    itemize::{Item, Item_, TextRange},
     lru_cache::LruCache,
     shape::{CharCluster, cache},
 };
@@ -81,62 +81,83 @@ impl core::fmt::Debug for Shaper {
 }
 
 impl Shaper {
-    /// Shape an [`Item`] produced by [`Analysis::itemize`] into glyphs.
-    ///
-    /// The item is broken into runs of maximal sequences of character clusters for which
-    /// `select_font` returns the same font. The resulting shaped runs are appended to
-    /// `shaped_text`.
-    ///
-    /// `text` must be the same text as originally passed to create [`Analysis`]. `item` must be an
-    /// [`Item`] produced by [`Analysis::itemize`] on this text's analysis.
-    ///
-    /// The `select_font` callback should return the font to shape `char_cluster` with. If
-    /// consecutive character clusters select a different font, they become separately-shaped runs.
-    /// Shaping is aborted if `select_font` returns `None`; [`ShapedText`] then contains a partial
-    /// result.
-    ///
-    /// Returns the index range of runs appended to `shaped_text`.
     ///
     /// # Panics
     ///
-    /// Panics if the font returned by `select_font` isn't a parseable font.
-    pub fn shape_item(
+    /// Panics if `items` does not cover the entire source text.
+    pub fn shape_text<'options>(
         &mut self,
         text: &str,
         analysis: &Analysis,
-        item: &Item,
-        options: &ShapeOptions<'_>,
-        select_font: impl FnMut(&mut CharCluster) -> Option<FontInstance>,
+        items: impl IntoIterator<Item = Item_<'options>>,
+        // mut select_font: impl FnMut(&mut CharCluster) -> FontInstance,
+        mut select_font: impl FontSelector,
         shaped_text: &mut ShapedText,
-    ) -> Range<usize> {
-        shaped_text.reserve(item.range.char_range.len());
+    ) {
+        shaped_text.clear();
 
-        let start = shaped_text.runs().len();
-        let _ = shape_item(
-            self,
-            text,
-            item,
-            options,
-            select_font,
-            analysis.char_info(),
-            shaped_text,
-        );
-        start..shaped_text.runs().len()
+        let mut items = items.into_iter();
+
+        let mut current_item = items
+            .next()
+            .expect("`items` does not cover the entire source text");
+
+        let mut itemizer = analysis.itemize(text);
+
+        while let Some(item) = itemizer.next(
+            #[inline(always)]
+            |text_range| text_range.char_range.end == current_item.char_end as usize,
+        ) {
+            let item_char_end = item.range.char_range.end;
+
+            if shape_item(
+                self,
+                text,
+                &item,
+                &current_item.options,
+                &mut select_font,
+                analysis.char_info(),
+                shaped_text,
+            )
+            .is_err()
+            {
+                // Abort on error. This happens iff `FontSelector::select_font` failed to return a
+                // font. By aborting we ensure `ShapedText` covers the source text contiguously (as
+                // we need a font to construct `ShapedRun`).
+                return;
+            };
+
+            if item_char_end == current_item.char_end as usize {
+                let Some(next_item) = items.next() else {
+                    // The last item's end coincides with the end of the source text, so the
+                    // itemizer should be finished as well.
+                    assert!(
+                        itemizer.next(|_| false).is_none(),
+                        "`items` does not cover the entire source text"
+                    );
+                    break;
+                };
+                current_item = next_item;
+            }
+        }
     }
 }
 
 /// Shape one item.
 ///
-/// Returns `Err(())` if shaping should be aborted, which happens iff `select_font` returned `None`.
+/// Returns `Err(())` if shaping should be aborted, which happens iff [`FontSelector::select_font`]
+/// returned `None`.
 fn shape_item(
     scx: &mut Shaper,
     text: &str,
     item: &Item,
     options: &ShapeOptions<'_>,
-    mut select_font: impl FnMut(&mut CharCluster) -> Option<FontInstance>,
+    select_font: &mut impl FontSelector,
     char_info: &[CharInfo],
     shaped_text: &mut ShapedText,
 ) -> Result<(), ()> {
+    select_font.begin_item(item, options);
+
     let text_range = &item.range.byte_range;
     let char_range = &item.range.char_range;
 
@@ -173,7 +194,7 @@ fn shape_item(
         &mut code_unit_offset_in_string,
     );
 
-    let Some(next_font) = select_font(char_cluster) else {
+    let Some(next_font) = select_font.select_font(item, options, char_cluster) else {
         return Err(());
     };
     let mut current_font = Some(next_font);
@@ -195,7 +216,7 @@ fn shape_item(
                 &mut code_unit_offset_in_string,
             );
 
-            let Some(next_font) = select_font(char_cluster) else {
+            let Some(next_font) = select_font.select_font(item, options, char_cluster) else {
                 return Err(());
             };
             if next_font != font {
@@ -362,4 +383,23 @@ fn variations_iter<'a>(
 pub(crate) fn script_to_harfrust(script: fontique::Script) -> harfrust::Script {
     harfrust::Script::from_iso15924_tag(harfrust::Tag::new(&script.to_bytes()))
         .unwrap_or(harfrust::script::UNKNOWN)
+}
+
+pub trait FontSelector {
+    fn begin_item(&mut self, item: &Item, options: &ShapeOptions<'_>) {
+        let _ = (item, options);
+    }
+
+    /// Called once per character cluster within the current segment.
+    ///
+    /// A character cluster will usually be a grapheme, though if text direction or script changes
+    /// mid-grapheme, it will be split over segments.
+    ///
+    /// Shaping is aborted if this returns `None`; [`ShapedText`] then contains a partial result.
+    fn select_font(
+        &mut self,
+        item: &Item,
+        options: &ShapeOptions<'_>,
+        cluster: &mut CharCluster,
+    ) -> Option<FontInstance>;
 }

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -111,54 +111,61 @@ impl Shaper {
         shaped_text.clear();
         shaped_text.reserve(text.len());
 
-        let mut items = items.into_iter();
-
-        let Some(mut current_item) = items.next() else {
-            assert!(
-                text.is_empty(),
-                "`items` does not cover the entire source text"
-            );
-            return;
-        };
-
+        let char_count = analysis.char_info().len();
+        let mut previous_item_end = 0;
         let mut itemizer = analysis.itemize(text);
 
-        while let Some(item) = itemizer.next(
-            #[inline(always)]
-            |text_range| text_range.char_range.end == current_item.char_end as usize,
-        ) {
-            let item_char_end = item.range.char_range.end;
+        for item in items {
+            assert!(
+                item.char_end > previous_item_end,
+                "item ends must be strictly increasing"
+            );
+            assert!(
+                item.char_end as usize <= char_count,
+                "items must not span past the text"
+            );
 
-            if shape_item(
-                self,
-                text,
-                &item,
-                &current_item.options,
-                &mut select_font,
-                analysis.char_info(),
-                shaped_text,
-            )
-            .is_err()
-            {
-                // Abort on error. This happens iff `FontSelector::select_font` failed to return a
-                // font. By aborting we ensure `ShapedText` covers the source text contiguously (as
-                // we need a font to construct `ShapedRun`).
-                return;
-            };
+            loop {
+                let segment = itemizer
+                    .next(
+                        #[inline(always)]
+                        |text_range| text_range.char_range.end == item.char_end as usize,
+                    )
+                    .expect("A segment must be yielded, given items tile the full text exactly");
 
-            if item_char_end == current_item.char_end as usize {
-                let Some(next_item) = items.next() else {
-                    // The last item's end coincides with the end of the source text, so the
-                    // itemizer should be finished as well.
-                    assert!(
-                        itemizer.next(|_| false).is_none(),
-                        "`items` does not cover the entire source text"
-                    );
-                    break;
+                if shape_item(
+                    self,
+                    text,
+                    &segment,
+                    &item.options,
+                    &mut select_font,
+                    analysis.char_info(),
+                    shaped_text,
+                )
+                .is_err()
+                {
+                    // Abort on error. This happens iff `FontSelector::select_font` failed to return a
+                    // font. By aborting we ensure `ShapedText` covers the source text contiguously (as
+                    // we need a font to construct `ShapedRun`).
+                    return;
                 };
-                current_item = next_item;
+
+                debug_assert!(
+                    segment.range.char_range.end <= item.char_end as usize,
+                    "Segments must not span past the item."
+                );
+                if segment.range.char_range.end == item.char_end as usize {
+                    break;
+                }
             }
+
+            previous_item_end = item.char_end;
         }
+
+        assert_eq!(
+            previous_item_end as usize, char_count,
+            "`items` does not cover the entire source text"
+        );
     }
 }
 

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -404,7 +404,11 @@ pub(crate) fn script_to_harfrust(script: fontique::Script) -> harfrust::Script {
         .unwrap_or(harfrust::script::UNKNOWN)
 }
 
+/// Implements font selection for shaping.
 pub trait FontSelector {
+    /// Called when a new item starts.
+    ///
+    /// This can be useful to inspect, e.g., the item's script.
     fn begin_item(&mut self, item: &Item, options: &ShapeOptions<'_>) {
         let _ = (item, options);
     }

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -113,9 +113,13 @@ impl Shaper {
 
         let mut items = items.into_iter();
 
-        let mut current_item = items
-            .next()
-            .expect("`items` does not cover the entire source text");
+        let Some(mut current_item) = items.next() else {
+            assert!(
+                text.is_empty(),
+                "`items` does not cover the entire source text"
+            );
+            return;
+        };
 
         let mut itemizer = analysis.itemize(text);
 

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -11,7 +11,7 @@ use parlance::{FontFeature, FontVariation, Language};
 
 use crate::{
     Analysis, CharInfo, ShapedText,
-    itemize::{Item, Item_, TextRange},
+    itemize::{Item, Segment, TextRange},
     lru_cache::LruCache,
     shape::{CharCluster, cache},
 };
@@ -19,8 +19,8 @@ use crate::{
 /// Shaping options for one item.
 ///
 /// These are styling options relevant for shaping. They're styling, in that they're not derived
-/// from the underlying text. When you [itemize][`Analysis::itemize`] the text, you should split the
-/// text at points where these options change.
+/// from the underlying text. When you [shape the text][`Shaper::shape_text`], you should split the
+/// text into [`Item`]s at the points where these options change.
 #[derive(Debug)]
 pub struct ShapeOptions<'a> {
     /// The font size to shape the item with.
@@ -86,14 +86,14 @@ impl Shaper {
     /// The `text` passed in must be the same as used for producing `analysis`.
     ///
     /// This uses the items returned by `items`, and further itemizes the text into
-    /// individually-shapeable runs of constant bidi level and script. `items` should be used to
+    /// individually-shapeable segments of constant bidi level and script. `items` should be used to
     /// split on properties like shaping-relevant style changes (e.g., font size) or properties like
     /// language.
     ///
     /// Characters that don't have a particular script have their script resolved based on
-    /// surrounding context (see [`crate::itemizer::Item::script`]).
+    /// surrounding context (see [`Segment::script`]).
     ///
-    /// Each item is then broken into runs of maximal sequences of character clusters for which
+    /// Each segment is then broken into runs of maximal sequences of character clusters for which
     /// `select_font` returns the same font.
     ///
     /// # Panics
@@ -104,7 +104,7 @@ impl Shaper {
         &mut self,
         text: &str,
         analysis: &Analysis,
-        items: impl IntoIterator<Item = Item_<'options>>,
+        items: impl IntoIterator<Item = Item<'options>>,
         mut select_font: impl FontSelector,
         shaped_text: &mut ShapedText,
     ) {
@@ -169,7 +169,7 @@ impl Shaper {
 fn shape_item(
     scx: &mut Shaper,
     text: &str,
-    item: &Item,
+    item: &Segment,
     options: &ShapeOptions<'_>,
     select_font: &mut impl FontSelector,
     char_info: &[CharInfo],
@@ -409,7 +409,7 @@ pub trait FontSelector {
     /// Called when a new item starts.
     ///
     /// This can be useful to inspect, e.g., the item's script.
-    fn begin_item(&mut self, item: &Item, options: &ShapeOptions<'_>) {
+    fn begin_item(&mut self, item: &Segment, options: &ShapeOptions<'_>) {
         let _ = (item, options);
     }
 
@@ -421,7 +421,7 @@ pub trait FontSelector {
     /// Shaping is aborted if this returns `None`; [`ShapedText`] then contains a partial result.
     fn select_font(
         &mut self,
-        item: &Item,
+        item: &Segment,
         options: &ShapeOptions<'_>,
         cluster: &mut CharCluster,
     ) -> Option<FontInstance>;


### PR DESCRIPTION
To shape, you now call `Shaper::shape_text`, which owns the itemization loop. Together with font selection being infallible (#722), `ShapedText` is then guaranteed to represent the full source text contiguously. That's useful to simplify some bookkeeping. See https://github.com/linebender/parley/pull/715#discussion_r3680380707 for some prior discussion on this. Because users previously looped items themselves and would call `Shaper::shape_item`, that meant items could be skipped or submitted out-of-order.

Because control flow moved into `parley_engine`, some structures are introduced. `Shaper::shape_text` takes an iterator of items encoding the span and holding the item's `ShapeOptions` (previously, `parley` constructed the options inside the loop and passed them as a parameter to `Shaper::shape_item`). Font selection is now a trait instead of a callback, with one method for selection and one method called at the start of each segment.

Note, "segment" is a new name, and encodes maximal spans within the user's items that have constant bidi level and script. The distinction between items and segments becomes more important later on, because browsers reset grapheme segmentation at item boundaries (where shaping options change), but not at segment boundaries.

Performance on the Japanese benchmarks is improved quite a bit, mostly because we're smarter about reusing the `FontSelector`. Performance on Arabic and Latin is about +1.5%, but addressing the TODO I left on the the item iterator in `parley` appears to make this a net small performance win on those scripts (i.e., iterating style runs and inline boxes to figure out where item boundaries are, instead of an `O(chars)` walk). That's for a separate PR: I just had an LLM address that TODO for an initial measurement, and have not reviewed that code at all.

<details>
<summary>Benchmarks with the state as in this PR</summary>

```
$ cargo bench --bench main -- compare ../target/benchmarks/main -t 8.

Default Style - arabic 20 characters               [   9.0 us ...   9.2 us ]      +1.42%*
Default Style - latin 20 characters                [   4.5 us ...   4.5 us ]      +1.62%*
Default Style - japanese 20 characters             [   8.6 us ...   8.0 us ]      -7.29%*
Default Style - arabic 1 paragraph                 [  48.6 us ...  49.1 us ]      +1.12%*
Default Style - latin 1 paragraph                  [  17.4 us ...  17.7 us ]      +1.75%*
Default Style - japanese 1 paragraph               [  72.6 us ...  64.9 us ]     -10.66%*
Default Style - arabic 4 paragraph                 [ 202.9 us ... 205.2 us ]      +1.11%*
Default Style - latin 4 paragraph                  [  65.7 us ...  66.3 us ]      +0.82%
Default Style - japanese 4 paragraph               [ 102.4 us ...  90.8 us ]     -11.28%*
Styled - arabic 20 characters                      [  10.1 us ...  10.2 us ]      +1.15%*
Styled - latin 20 characters                       [   5.6 us ...   5.7 us ]      +1.68%*
Styled - japanese 20 characters                    [   9.3 us ...   8.5 us ]      -8.89%*
Styled - arabic 1 paragraph                        [  51.0 us ...  51.7 us ]      +1.25%*
Styled - latin 1 paragraph                         [  21.9 us ...  22.3 us ]      +1.94%*
Styled - japanese 1 paragraph                      [  78.8 us ...  71.1 us ]      -9.77%*
Styled - arabic 4 paragraph                        [ 222.8 us ... 226.6 us ]      +1.72%*
Styled - latin 4 paragraph                         [  84.9 us ...  85.4 us ]      +0.57%
Styled - japanese 4 paragraph                      [ 111.6 us ... 101.0 us ]      -9.55%*
```

</details>

<details>
<summary>Experimental: benchmarks after addressing the item iterator TODO</summary>

```
$ cargo bench --bench main -- compare ../target/benchmarks/main -t 8.

Default Style - arabic 20 characters               [   9.0 us ...   8.9 us ]      -1.04%*
Default Style - latin 20 characters                [   4.5 us ...   4.5 us ]      -0.29%
Default Style - japanese 20 characters             [   8.7 us ...   7.8 us ]      -9.50%*
Default Style - arabic 1 paragraph                 [  48.6 us ...  48.3 us ]      -0.51%
Default Style - latin 1 paragraph                  [  17.5 us ...  17.5 us ]      +0.09%
Default Style - japanese 1 paragraph               [  72.5 us ...  63.3 us ]     -12.76%*
Default Style - arabic 4 paragraph                 [ 203.0 us ... 201.7 us ]      -0.64%
Default Style - latin 4 paragraph                  [  65.7 us ...  66.2 us ]      +0.64%
Default Style - japanese 4 paragraph               [ 102.5 us ...  88.8 us ]     -13.34%*
Styled - arabic 20 characters                      [  10.1 us ...  10.0 us ]      -0.78%
Styled - latin 20 characters                       [   5.7 us ...   5.6 us ]      -1.37%*
Styled - japanese 20 characters                    [   9.3 us ...   8.4 us ]      -9.73%*
Styled - arabic 1 paragraph                        [  51.3 us ...  50.7 us ]      -1.23%*
Styled - latin 1 paragraph                         [  21.9 us ...  21.9 us ]      +0.03%
Styled - japanese 1 paragraph                      [  78.9 us ...  69.4 us ]     -12.10%*
Styled - arabic 4 paragraph                        [ 222.8 us ... 220.8 us ]      -0.92%
Styled - latin 4 paragraph                         [  84.9 us ...  84.8 us ]      -0.15%
Styled - japanese 4 paragraph                      [ 111.7 us ...  97.8 us ]     -12.45%*
```

</details>