### PR TITLE
Add `parlance::Script::is_cursive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This release has an [MSRV] of 1.88.
 #### Parlance
 
 - `BidiLevel` to encode bidirectional text embedding levels. ([#710][] by [@tomcur][])
+- `Script::is_cursive` returning whether a script is cursive. ([#728][] by [@tomcur][])  
+  This can be used to decide, for example, whether to apply letter spacing.
 
 #### Fontique
 
@@ -718,6 +720,7 @@ This release has an [MSRV][] of 1.70.
 [#710]: https://github.com/linebender/parley/pull/710
 [#717]: https://github.com/linebender/parley/pull/717
 [#725]: https://github.com/linebender/parley/pull/725
+[#728]: https://github.com/linebender/parley/pull/728
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/linebender/parley/compare/v0.10.0...v0.11.0

--- a/parlance/src/script.rs
+++ b/parlance/src/script.rs
@@ -73,6 +73,30 @@ impl Script {
     pub fn parse(s: &str) -> Result<Self, ParseScriptError> {
         s.parse()
     }
+
+    /// Whether this is a cursive script according to [CSS Text 3 Appendix D][css-cursive-scripts].
+    ///
+    /// As per that specification, "these scripts do not admit gaps between their letters for either
+    /// justification or letter-spacing."
+    ///
+    /// See also [CSS Text 3 § 6.4.4][css-cursive-justification] on cursive justification.
+    ///
+    /// [css-cursive-scripts]: https://www.w3.org/TR/css-text-3/#script-groups
+    /// [css-cursive-justification]: https://www.w3.org/TR/css-text-3/#justify-cursive
+    #[inline(always)]
+    pub const fn is_cursive(self) -> bool {
+        // Script identifiers from UAX #31: <https://www.unicode.org/reports/tr31/>.
+        matches!(
+            &self.raw,
+            b"Arab" | // Arabic
+            b"Rohg" | // Hanifi Rohingya
+            b"Mand" | // Mandaic
+            b"Mong" | // Mongolian
+            b"Nkoo" | // N'ko
+            b"Phag" | // Phags Pa
+            b"Syrc" // Syriac
+        )
+    }
 }
 
 impl fmt::Debug for Script {


### PR DESCRIPTION
This encodes whether a script is cursive according to [CSS Text 3](https://www.w3.org/TR/css-text-3/#script-groups).

Letter spacing in the form of gaps should not be applied between graphemes of these scripts, and perhaps optional ligation should not be turned off. This doesn't wire it up yet in `parley`. See also [CSS Text 3 § 6.4.4](https://www.w3.org/TR/css-text-3/#justify-cursive) about cursive justification by elongation.

Because this list is spec'd by CSS, it's probably general enough to live in `parlance`, though it does mean `parlance` grows a data table.

See the same list in
- Gecko: https://github.com/mozilla-firefox/firefox/blob/d0d8c04b85032c5bd92bbc60d0c73bfdfbeed6ce/intl/components/src/UnicodeProperties.h#L348-L355
- Blink: https://github.com/chromium/chromium/blob/41fe3640cac5688a644a7a04799d996b898a74c0/third_party/blink/renderer/platform/text/character.cc#L353-L363