### PR TITLE
Add opt-in deferred layout rebuilds to PlainEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ This release has an [MSRV] of 1.88.
 
 - `Collection::family_ids` to iterate over unique font family identifiers. ([#725][] by [@tomcur][])
 
+#### Parley
+
+- `PlainEditor::{set_defer_layout, defers_layout}` to opt in to deferring layout rebuilds after edits to the next read, so a batch of edits performs a single rebuild. ([#729][] by [@AdrianEddy][])
+
 ### Changed
 
 #### Parley
@@ -542,6 +546,7 @@ This release has an [MSRV][] of 1.70.
 
 [MSRV]: README.md#minimum-supported-rust-version-msrv
 
+[@AdrianEddy]: https://github.com/AdrianEddy
 [@areopagitics]: https://github.com/areopagitics
 [@conor-93]: https://github.com/conor-93
 [@devunt]: https://github.com/devunt
@@ -727,6 +732,7 @@ This release has an [MSRV][] of 1.70.
 [#717]: https://github.com/linebender/parley/pull/717
 [#725]: https://github.com/linebender/parley/pull/725
 [#728]: https://github.com/linebender/parley/pull/728
+[#729]: https://github.com/linebender/parley/pull/729
 
 [Unreleased]: https://github.com/linebender/parley/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/linebender/parley/compare/v0.10.0...v0.11.0

--- a/parley/src/editing/cursor.rs
+++ b/parley/src/editing/cursor.rs
@@ -41,6 +41,15 @@ impl Cursor {
         }
     }
 
+    /// Creates a provisional cursor, without snapping to a cluster boundary.
+    ///
+    /// Only for use while the layout is dirty; `index` must be a char
+    /// boundary of the text, and the next rebuild refreshes the cursor
+    /// against the new layout (see [`Self::refresh`]).
+    pub(crate) fn provisional(index: usize, affinity: Affinity) -> Self {
+        Self { index, affinity }
+    }
+
     /// Creates a new cursor from the given coordinates.
     pub fn from_point<B: Brush>(layout: &Layout<B>, x: f32, y: f32) -> Self {
         let (index, affinity) = if let Some((cluster, side)) = Cluster::from_point(layout, x, y) {

--- a/parley/src/editing/editor.rs
+++ b/parley/src/editing/editor.rs
@@ -108,6 +108,9 @@ where
     font_size: f32,
     scale: f32,
     quantize: bool,
+    /// When `true`, operations defer the layout rebuild to the next read
+    /// instead of flushing it before returning.
+    defer_layout: bool,
     // Simple tracking of when the layout needs to be updated
     // before it can be used for `Selection` calculations or
     // for drawing.
@@ -141,6 +144,7 @@ where
             font_size,
             scale: 1.0,
             quantize: true,
+            defer_layout: false,
             layout_dirty: true,
             alignment: Alignment::Start,
             // We don't use the `default` value to start with, as our consumers
@@ -196,7 +200,7 @@ where
         self.editor.buffer.replace_range(range.clone(), "");
         self.editor
             .update_compose_for_replaced_range(range.clone(), 0);
-        self.update_layout();
+        self.editor.layout_dirty = true;
         let old_anchor = old_selection.anchor();
         let old_focus = old_selection.focus();
         // When doing the equivalent of a backspace on a collapsed selection,
@@ -207,17 +211,12 @@ where
             (old_anchor.affinity(), old_focus.affinity())
         };
         self.editor.set_selection(Selection::new(
-            Cursor::from_byte_index(
-                &self.editor.layout,
-                old_anchor.index() - range.len(),
-                anchor_affinity,
-            ),
-            Cursor::from_byte_index(
-                &self.editor.layout,
-                old_focus.index() - range.len(),
-                focus_affinity,
-            ),
+            self.editor
+                .cursor_for_index(old_anchor.index() - range.len(), anchor_affinity),
+            self.editor
+                .cursor_for_index(old_focus.index() - range.len(), focus_affinity),
         ));
+        self.flush_layout();
     }
 
     /// Delete the specified numbers of bytes after the selection.
@@ -237,11 +236,14 @@ where
         }
         self.editor.buffer.replace_range(range.clone(), "");
         self.editor.update_compose_for_replaced_range(range, 0);
-        self.update_layout();
+        self.editor.layout_dirty = true;
+        self.flush_layout();
     }
 
     /// Delete the selection or the next cluster (typical ‘delete’ behavior).
     pub fn delete(&mut self) {
+        // Reads cluster boundaries, so the layout must be fresh.
+        self.refresh_layout();
         if self.editor.selection.is_collapsed() {
             // Upstream cluster range
             if let Some(range) = self
@@ -255,7 +257,8 @@ where
             {
                 self.editor.buffer.replace_range(range.clone(), "");
                 self.editor.update_compose_for_replaced_range(range, 0);
-                self.update_layout();
+                self.editor.layout_dirty = true;
+                self.flush_layout();
             }
         } else {
             self.delete_selection();
@@ -264,6 +267,8 @@ where
 
     /// Delete the selection or up to the next word boundary (typical ‘ctrl + delete’ behavior).
     pub fn delete_word(&mut self) {
+        // Reads word boundaries, so the layout must be fresh.
+        self.refresh_layout();
         if self.editor.selection.is_collapsed() {
             let focus = self.editor.selection.focus();
             let start = focus.index();
@@ -271,11 +276,13 @@ where
             if self.editor.buffer.get(start..end).is_some() {
                 self.editor.buffer.replace_range(start..end, "");
                 self.editor.update_compose_for_replaced_range(start..end, 0);
-                self.update_layout();
+                self.editor.layout_dirty = true;
                 self.editor.set_selection(
-                    Cursor::from_byte_index(&self.editor.layout, start, Affinity::Downstream)
+                    self.editor
+                        .cursor_for_index(start, Affinity::Downstream)
                         .into(),
                 );
+                self.flush_layout();
             }
         } else {
             self.delete_selection();
@@ -284,6 +291,8 @@ where
 
     /// Delete the selection or the previous cluster (typical ‘backspace’ behavior).
     pub fn backdelete(&mut self) {
+        // Reads cluster boundaries, so the layout must be fresh.
+        self.refresh_layout();
         if self.editor.selection.is_collapsed() {
             // Upstream cluster
             if let Some(cluster) = self
@@ -311,11 +320,13 @@ where
                 };
                 self.editor.buffer.replace_range(start..end, "");
                 self.editor.update_compose_for_replaced_range(start..end, 0);
-                self.update_layout();
+                self.editor.layout_dirty = true;
                 self.editor.set_selection(
-                    Cursor::from_byte_index(&self.editor.layout, start, Affinity::Downstream)
+                    self.editor
+                        .cursor_for_index(start, Affinity::Downstream)
                         .into(),
                 );
+                self.flush_layout();
             }
         } else {
             self.delete_selection();
@@ -324,6 +335,8 @@ where
 
     /// Delete the selection or back to the previous word boundary (typical ‘ctrl + backspace’ behavior).
     pub fn backdelete_word(&mut self) {
+        // Reads word boundaries, so the layout must be fresh.
+        self.refresh_layout();
         if self.editor.selection.is_collapsed() {
             let focus = self.editor.selection.focus();
             let end = focus.index();
@@ -331,11 +344,13 @@ where
             if self.editor.buffer.get(start..end).is_some() {
                 self.editor.buffer.replace_range(start..end, "");
                 self.editor.update_compose_for_replaced_range(start..end, 0);
-                self.update_layout();
+                self.editor.layout_dirty = true;
                 self.editor.set_selection(
-                    Cursor::from_byte_index(&self.editor.layout, start, Affinity::Downstream)
+                    self.editor
+                        .cursor_for_index(start, Affinity::Downstream)
                         .into(),
                 );
+                self.flush_layout();
             }
         } else {
             self.delete_selection();
@@ -378,7 +393,7 @@ where
         };
         self.editor.compose = Some(start..start + text.len());
         self.editor.show_cursor = cursor.is_some();
-        self.update_layout();
+        self.editor.layout_dirty = true;
 
         // Select the location indicated by the IME. If `cursor` is none, collapse the selection to
         // a caret at the start of the preedit text. As `self.editor.show_cursor` is `false`, it
@@ -388,6 +403,7 @@ where
             self.editor.cursor_at(start + cursor.0),
             self.editor.cursor_at(start + cursor.1),
         ));
+        self.flush_layout();
     }
 
     /// Set the preedit range to a range of byte indices.
@@ -397,7 +413,8 @@ where
     pub fn set_compose_byte_range(&mut self, start: usize, end: usize) {
         if self.editor.buffer.is_char_boundary(start) && self.editor.buffer.is_char_boundary(end) {
             self.editor.compose = Some(start..end);
-            self.update_layout();
+            self.editor.layout_dirty = true;
+            self.flush_layout();
         }
     }
 
@@ -409,10 +426,11 @@ where
         if let Some(preedit_range) = self.editor.compose.take() {
             self.editor.buffer.replace_range(preedit_range.clone(), "");
             self.editor.show_cursor = true;
-            self.update_layout();
+            self.editor.layout_dirty = true;
 
             self.editor
                 .set_selection(self.editor.cursor_at(preedit_range.start).into());
+            self.flush_layout();
         }
     }
 
@@ -423,7 +441,8 @@ where
     pub fn finish_compose(&mut self) {
         if self.editor.compose.take().is_some() {
             self.editor.show_cursor = true;
-            self.update_layout();
+            self.editor.layout_dirty = true;
+            self.flush_layout();
         }
     }
 
@@ -803,9 +822,10 @@ where
         self.editor.refresh_layout(self.font_cx, self.layout_cx);
     }
 
-    /// Update the layout unconditionally.
-    fn update_layout(&mut self) {
-        self.editor.update_layout(self.font_cx, self.layout_cx);
+    /// Rebuild a dirty layout now, unless deferral is enabled
+    /// (see [`PlainEditor::set_defer_layout`]).
+    fn flush_layout(&mut self) {
+        self.editor.flush_layout(self.font_cx, self.layout_cx);
     }
 }
 
@@ -1028,6 +1048,30 @@ where
         self.layout_dirty = true;
     }
 
+    /// Set whether operations flush the layout rebuild before returning (the
+    /// default) or defer it to the next read.
+    ///
+    /// Every operation marks the layout dirty; this only controls when the
+    /// rebuild runs. With deferral enabled, a batch of edits performs a
+    /// single rebuild at the next read of the layout
+    /// ([`refresh_layout`](Self::refresh_layout), [`layout`](Self::layout),
+    /// or any driver method that needs it). While the layout is dirty,
+    /// [`try_layout`](Self::try_layout) returns `None`, selection indices
+    /// are provisional (snapped to cluster boundaries by the rebuild), the
+    /// `&self` geometry readers return geometry of the last-built layout,
+    /// and the [`Generation`] may not be nudged until the rebuild.
+    ///
+    /// Disabling deferral does not rebuild by itself; a dirty layout is
+    /// rebuilt at the next read.
+    pub fn set_defer_layout(&mut self, defer: bool) {
+        self.defer_layout = defer;
+    }
+
+    /// Whether mutations defer the layout rebuild to the next read.
+    pub fn defers_layout(&self) -> bool {
+        self.defer_layout
+    }
+
     /// Modify the styles provided for this editor.
     pub fn edit_styles(&mut self) -> &mut StyleSet<T> {
         self.layout_dirty = true;
@@ -1117,15 +1161,40 @@ where
         }
     }
 
+    /// Rebuild a dirty layout now, unless deferral is enabled
+    /// (see [`set_defer_layout`](Self::set_defer_layout)).
+    ///
+    /// Operations call this before returning, so with deferral off the
+    /// layout is always fresh after each call.
+    fn flush_layout(&mut self, font_cx: &mut FontContext, layout_cx: &mut LayoutContext<T>) {
+        if !self.defer_layout {
+            self.refresh_layout(font_cx, layout_cx);
+        }
+    }
+
+    /// Make a provisional cursor at a byte index and affinity.
+    ///
+    /// Only called while the layout is dirty (every mutation marks it dirty
+    /// before placing cursors): the index is clamped to the nearest char
+    /// boundary at or before it, and the next rebuild's selection refresh
+    /// snaps it to a cluster boundary.
+    fn cursor_for_index(&self, index: usize, affinity: Affinity) -> Cursor {
+        debug_assert!(self.layout_dirty);
+        let mut index = index.min(self.buffer.len());
+        while !self.buffer.is_char_boundary(index) {
+            index -= 1;
+        }
+        Cursor::provisional(index, affinity)
+    }
+
     // --- MARK: Internal Helpers ---
     /// Make a cursor at a given byte index.
     fn cursor_at(&self, index: usize) -> Cursor {
-        // TODO: Do we need to be non-dirty?
         // FIXME: `Selection` should make this easier
         if index >= self.buffer.len() {
-            Cursor::from_byte_index(&self.layout, self.buffer.len(), Affinity::Upstream)
+            self.cursor_for_index(self.buffer.len(), Affinity::Upstream)
         } else {
-            Cursor::from_byte_index(&self.layout, index, Affinity::Downstream)
+            self.cursor_for_index(index, Affinity::Downstream)
         }
     }
 
@@ -1173,14 +1242,15 @@ where
         }
         self.update_compose_for_replaced_range(range, s.len());
 
-        self.update_layout(font_cx, layout_cx);
+        self.layout_dirty = true;
         let new_index = start.saturating_add(s.len());
         let affinity = if s.ends_with(['\n', '\r', '\u{2028}', '\u{2029}']) {
             Affinity::Downstream
         } else {
             Affinity::Upstream
         };
-        self.set_selection(Cursor::from_byte_index(&self.layout, new_index, affinity).into());
+        self.set_selection(self.cursor_for_index(new_index, affinity).into());
+        self.flush_layout(font_cx, layout_cx);
     }
 
     /// Update the selection, and nudge the `Generation` if something other than `h_pos` changed.

--- a/parley_tests/tests/editor.rs
+++ b/parley_tests/tests/editor.rs
@@ -3,6 +3,8 @@
 
 //! `PlainEditor` tests.
 
+use core::num::NonZeroUsize;
+
 use crate::test_name;
 use crate::util::TestEnv;
 use parley::Affinity;
@@ -115,4 +117,116 @@ fn editor_insert_regular_text_set_upstream_affinity() {
     assert!(sel.is_collapsed());
     assert_eq!(sel.focus().index(), 2);
     assert_eq!(sel.focus().affinity(), Affinity::Upstream);
+}
+
+#[test]
+fn editor_defer_layout_batches_rebuilds() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("");
+    editor.set_defer_layout(true);
+    {
+        let mut drv = env.driver(&mut editor);
+        drv.insert_or_replace_selection("Hello");
+        drv.insert_or_replace_selection(", ");
+        drv.insert_or_replace_selection("world");
+    }
+    // No rebuild has happened yet; the provisional selection is already correct.
+    assert!(editor.try_layout().is_none());
+    assert_eq!(editor.raw_selection().focus().index(), 12);
+    env.driver(&mut editor).refresh_layout();
+    assert!(editor.try_layout().is_some());
+    assert_eq!(editor.raw_text(), "Hello, world");
+    assert!(editor.raw_selection().is_collapsed());
+    assert_eq!(editor.raw_selection().focus().index(), 12);
+}
+
+#[test]
+fn editor_defer_layout_boundary_deletes_use_fresh_layout() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut editor = env.editor("");
+    editor.set_defer_layout(true);
+    {
+        let mut drv = env.driver(&mut editor);
+        drv.insert_or_replace_selection("a😀");
+        // The layout is dirty here; backdelete refreshes before reading clusters
+        // and must delete the whole emoji cluster.
+        drv.backdelete();
+        drv.refresh_layout();
+    }
+    assert_eq!(editor.raw_text(), "a");
+    assert_eq!(editor.raw_selection().focus().index(), 1);
+}
+
+#[test]
+fn editor_defer_layout_matches_eager() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut eager = env.editor("Hi 😀 all");
+    let mut deferred = env.editor("Hi 😀 all");
+    deferred.set_defer_layout(true);
+
+    for editor in [&mut eager, &mut deferred] {
+        let mut drv = env.driver(editor);
+        drv.move_to_text_end();
+        drv.insert_or_replace_selection("!");
+        drv.backdelete_word();
+        drv.insert_or_replace_selection("folks");
+        drv.move_left();
+        drv.backdelete();
+        drv.set_compose("ne", Some((2, 2)));
+        drv.finish_compose();
+        drv.refresh_layout();
+    }
+
+    assert_eq!(eager.raw_text(), deferred.raw_text());
+    let (e, d) = (eager.raw_selection(), deferred.raw_selection());
+    assert_eq!(e.focus().index(), d.focus().index());
+    assert_eq!(e.focus().affinity(), d.focus().affinity());
+    assert_eq!(e.anchor().index(), d.anchor().index());
+}
+
+#[test]
+fn editor_defer_layout_clamps_ime_cursor_offsets() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut eager = env.editor("");
+    let mut deferred = env.editor("");
+    deferred.set_defer_layout(true);
+
+    for editor in [&mut eager, &mut deferred] {
+        let mut drv = env.driver(editor);
+        // Mid-cluster IME cursor offsets must not leave a mid-cluster
+        // provisional selection behind.
+        drv.set_compose("😀", Some((2, 2)));
+        drv.insert_or_replace_selection("x");
+        drv.refresh_layout();
+    }
+
+    assert_eq!(eager.raw_text(), deferred.raw_text());
+    assert_eq!(
+        eager.raw_selection().focus().index(),
+        deferred.raw_selection().focus().index()
+    );
+}
+
+#[test]
+fn editor_defer_layout_delete_bytes_matches_eager() {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut eager = env.editor("hello world");
+    let mut deferred = env.editor("hello world");
+    deferred.set_defer_layout(true);
+
+    for editor in [&mut eager, &mut deferred] {
+        let mut drv = env.driver(editor);
+        drv.move_to_text_end();
+        drv.insert_or_replace_selection("!!");
+        drv.move_left();
+        drv.delete_bytes_before_selection(NonZeroUsize::new(1).unwrap());
+        drv.delete_bytes_after_selection(NonZeroUsize::new(1).unwrap());
+        drv.refresh_layout();
+    }
+
+    assert_eq!(eager.raw_text(), "hello world");
+    assert_eq!(eager.raw_text(), deferred.raw_text());
+    let (e, d) = (eager.raw_selection(), deferred.raw_selection());
+    assert_eq!(e.focus().index(), d.focus().index());
+    assert_eq!(e.anchor().index(), d.anchor().index());
 }


### PR DESCRIPTION
Every mutating `PlainEditor` operation (insert, delete, IME compose/commit) rebuilds the full layout before returning. Hosts that apply several operations in one frame — replaying a batch of input events, multi-step IME commits, programmatic multi-part edits — pay one full relayout per operation, even though only the final layout is ever read or drawn.

This PR adds an opt-in mode that defers the rebuild to the next read:

```rust
editor.set_defer_layout(true);
// ... apply a batch of edits: one rebuild happens at the next
// refresh_layout()/layout() or any driver method that reads geometry.
```

- **Default behavior is unchanged.** With deferral off (the default), every call site behaves exactly as before.
- While the layout is dirty, selections are stored as provisional byte-offset cursors; the rebuild's existing selection refresh snaps them to cluster boundaries, so the end state is identical to eager mode (covered by an eager-vs-deferred equivalence test).
- Operations that must read the layout *before* mutating (`delete`, `delete_word`, `backdelete`, `backdelete_word` — cluster and word boundaries) now call `refresh_layout()` first. Besides making them correct mid-batch, this closes a latent stale-read: today these methods read the old layout if called right after `set_text`.
- `try_layout()` returning `None` while dirty, `&self` geometry readers (`cursor_geometry`, `selection_geometry`, `ime_cursor_area`) returning last-built geometry mid-batch, and the `Generation` nudge moving to rebuild time are the observable differences — all documented on `set_defer_layout` — which is why the mode is opt-in rather than the new default.

Tests cover: a batch performing a single rebuild with correct text and selection, an emoji-cluster backspace mid-batch (fresh-layout boundary read), provisional-cursor clamping for mid-cluster IME offsets, byte-wise deletes matching eager mode, and a mixed op sequence (moves, word deletes, IME compose/commit) asserting eager and deferred editors end in identical states.

<sup>This PR was generated by Claude</sup>
