### PR TITLE
Add a pull request template to allow changelog entries

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,6 @@ We expect you to have fully understood and self-reviewed your contributions to L
 If you did not use any LLM tools, please replace "Unspecified" with 'None'. -->
 LLM Contributions: Unspecified.
 
-**Description**
-
 _Describe what problem this is solving, and how it's solved. Use your own words - descriptions authored by LLMs are not allowed._
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!--
+Thanks for opening a PR for this Linebender project!
+-->
+
+<!-- If you used any LLM ("AI") tools in making this PR, please ensure that you have reviewed our
+LLM policy at https://linebender.org/wiki/llm-policy/.
+Please list how you used it (e.g. writing code, reviewing, fact finding) below.
+We expect you to have fully understood and self-reviewed your contributions to Linebender.
+
+If you did not use any LLM tools, please replace "Unspecified" with 'None'. -->
+LLM Contributions: Unspecified.
+
+**Description**
+
+_Describe what problem this is solving, and how it's solved. Use your own words - descriptions authored by LLMs are not allowed._
+
+<!--
+If this change has any user facing effects, please describe them in the quote block below.
+What you write here will be edited by us later - it doesn't need to be perfect.
+If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**` and delete
+the quote block. Do not use an LLM to write the changelog entry.
+-->
+**Changelog**
+
+> ### Added
+>
+> - [Breaking change:] Changelog entry.


### PR DESCRIPTION
LLM Contributions: None.

For automated changelog generation with Gazeto (currently found at https://github.com/DJMcNab/release_eng/). As discussed in [#office hours > 2026-08-05](https://xi.zulipchat.com/#narrow/channel/359642-office-hours/topic/2026-08-05/with/614856459). See its agenda for more information, and Gazeto's README.

**Changelog: None**