### PR TITLE
`parley_engine`: Move glyph iteration to `ShapedSlice`

### DIFF
--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -251,7 +251,7 @@ impl<'a, B: Brush> Cluster<'a, B> {
     pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + Clone + use<'a, B> {
         self.grapheme
             .is_atom_start()
-            .then(|| self.atom.glyphs())
+            .then(|| self.atom.slice().glyphs())
             .into_iter()
             .flatten()
     }

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -251,7 +251,7 @@ impl<'a, B: Brush> Cluster<'a, B> {
     pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + Clone + use<'a, B> {
         self.grapheme
             .is_atom_start()
-            .then(|| self.atom.slice().glyphs())
+            .then(|| self.run.glyphs_in(self.atom.shaped_clusters_range()))
             .into_iter()
             .flatten()
     }

--- a/parley/src/layout/line.rs
+++ b/parley/src/layout/line.rs
@@ -276,9 +276,9 @@ impl<'a, B: Brush> GlyphRun<'a, B> {
 
     /// Returns an iterator over the glyphs in the run.
     pub fn glyphs(&'a self) -> impl Iterator<Item = Glyph> + 'a + Clone {
+        let clusters = self.run.line_slice().shaped_clusters_range();
         self.run
-            .line_slice()
-            .glyphs()
+            .glyphs_in(clusters)
             .skip(self.glyph_start)
             .take(self.glyph_count)
     }

--- a/parley/src/layout/line.rs
+++ b/parley/src/layout/line.rs
@@ -277,8 +277,8 @@ impl<'a, B: Brush> GlyphRun<'a, B> {
     /// Returns an iterator over the glyphs in the run.
     pub fn glyphs(&'a self) -> impl Iterator<Item = Glyph> + 'a + Clone {
         self.run
-            .visual_clusters()
-            .flat_map(|cluster| cluster.glyphs())
+            .line_slice()
+            .glyphs()
             .skip(self.glyph_start)
             .take(self.glyph_count)
     }
@@ -333,6 +333,10 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                     }));
                 }
                 LineItem::Run(run) => {
+                    // TODO: this is taking the glyphs and style indices from `parley`'s `Cluster`,
+                    // which means style indices are taken from the atom's first character. We could
+                    // get the style index from `parley_engine`'s `ShapedCluster` instead, which
+                    // would be somewhat finer-grained.
                     let mut glyphs = run
                         .visual_clusters()
                         .flat_map(|c| {

--- a/parley/src/layout/run.rs
+++ b/parley/src/layout/run.rs
@@ -9,7 +9,8 @@ use crate::style::Brush;
 use core::ops::Range;
 use fontique::Synthesis;
 use parley_engine::{
-    Atom, Atoms, FontInstance, FontMetrics, Graphemes, NormalizedCoord, ShapedRun, ShapedSlice,
+    Atom, Atoms, FontInstance, FontMetrics, Glyph, Graphemes, NormalizedCoord, ShapedRun,
+    ShapedSlice,
 };
 
 /// Sequence of clusters with a single font and style.
@@ -213,6 +214,32 @@ impl<'a, B: Brush> Run<'a, B> {
     /// Returns an iterator over the clusters in visual order.
     pub fn visual_clusters(&self) -> impl Iterator<Item = Cluster<'a, B>> + Clone + use<'a, B> {
         Clusters::new(*self, self.is_rtl())
+    }
+
+    /// An iterator over the glyphs in `clusters`.
+    pub(crate) fn glyphs_in(
+        self,
+        clusters: Range<u32>,
+    ) -> impl Iterator<Item = Glyph> + Clone + use<'a, B> {
+        let slice = self
+            .layout
+            .data
+            .shaped_text
+            .run_slice(self.shaped_text_run_index);
+
+        (!self.is_rtl())
+            .then(|| clusters.clone())
+            .into_iter()
+            .flatten()
+            // we chain because `.rev()` wraps the iterator in `Rev` - a different type than the LTR
+            // iterator.
+            .chain(
+                (self.is_rtl())
+                    .then(|| clusters.rev())
+                    .into_iter()
+                    .flatten(),
+            )
+            .flat_map(move |cluster_idx| slice.shaped_cluster_glyphs(cluster_idx))
     }
 }
 

--- a/parley/src/layout/run.rs
+++ b/parley/src/layout/run.rs
@@ -216,7 +216,7 @@ impl<'a, B: Brush> Run<'a, B> {
         Clusters::new(*self, self.is_rtl())
     }
 
-    /// An iterator over the glyphs in `clusters`.
+    /// An iterator over the glyphs in `clusters` in visual left-to-right order.
     pub(crate) fn glyphs_in(
         self,
         clusters: Range<u32>,

--- a/parley_engine/src/shape/atom.rs
+++ b/parley_engine/src/shape/atom.rs
@@ -97,6 +97,41 @@ impl<'a> ShapedSlice<'a> {
         &self.shaped_clusters[clusters_range.start as usize..clusters_range.end as usize]
     }
 
+    /// Iterate shaped clusters in visual left-to-right order.
+    #[inline(always)]
+    pub fn shaped_clusters_visual(&self) -> impl ExactSizeIterator<Item = u32> + Clone + use<> {
+        #[derive(Clone)]
+        struct ShapedClusters {
+            range: Range<u32>,
+            rev: bool,
+        }
+
+        impl Iterator for ShapedClusters {
+            type Item = u32;
+
+            #[inline(always)]
+            fn next(&mut self) -> Option<Self::Item> {
+                if self.rev {
+                    self.range.next_back()
+                } else {
+                    self.range.next()
+                }
+            }
+
+            #[inline(always)]
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.range.size_hint()
+            }
+        }
+
+        impl ExactSizeIterator for ShapedClusters {}
+
+        ShapedClusters {
+            range: self.clusters.0..self.clusters.1,
+            rev: self.bidi_level.is_rtl(),
+        }
+    }
+
     /// The byte range in the source text of the given range of [`Self::characters`].
     ///
     /// If `chars` is empty, this is the empty range at the byte position of `chars.start`; see
@@ -134,6 +169,45 @@ impl<'a> ShapedSlice<'a> {
         } else {
             self.characters[char_idx as usize].text_byte_start as usize
         }
+    }
+
+    /// Get an iterator over glyphs in visual left-to-right order of the shaped cluster with the
+    /// given index.
+    #[inline]
+    pub fn shaped_cluster_glyphs(
+        &self,
+        cluster_idx: u32,
+    ) -> impl Iterator<Item = Glyph> + Clone + use<'a> {
+        debug_assert!(
+            self.clusters.0 <= cluster_idx && cluster_idx < self.clusters.1,
+            "cluster index out of this slice's range"
+        );
+
+        let shaped_cluster = self.shaped_clusters[cluster_idx as usize];
+
+        let inline = shaped_cluster.has_inline_glyph().then_some(Glyph {
+            id: shaped_cluster.glyph_offset,
+            x: 0.,
+            y: 0.,
+            advance: shaped_cluster.advance,
+        });
+
+        let stored: &'a [Glyph] = if shaped_cluster.has_inline_glyph() {
+            &[]
+        } else {
+            let start = shaped_cluster.glyph_offset as usize;
+            &self.glyphs[start..start + usize::from(shaped_cluster.glyph_len())]
+        };
+
+        inline.into_iter().chain(stored.iter().copied())
+    }
+
+    /// Get an iterator over this slice's glyphs in visual left-to-right order.
+    #[inline(always)]
+    pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + Clone + use<'a> {
+        let slice = *self;
+        self.shaped_clusters_visual()
+            .flat_map(move |cluster_idx| slice.shaped_cluster_glyphs(cluster_idx))
     }
 
     /// Get a cursor to walk atoms from the logical start of this slice.
@@ -431,37 +505,6 @@ impl<'a> Atom<'a> {
     #[inline(always)]
     pub fn shaped_clusters(&self) -> &'a [ShapedCluster] {
         self.slice.shaped_clusters_in(self.shaped_clusters_range())
-    }
-
-    /// The atom's glyphs in visual left-to-right order.
-    pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + Clone + use<'a> {
-        let clusters = self.shaped_clusters();
-        let glyphs = self.slice.glyphs;
-
-        let rtl = self.slice.bidi_level.is_rtl();
-        rtl.then(|| clusters.iter().rev())
-            .into_iter()
-            .flatten()
-            // we chain because `.rev()` wraps the iterator in `Rev` - a different type than the LTR
-            // iterator.
-            .chain((!rtl).then(|| clusters.iter()).into_iter().flatten())
-            .flat_map(move |cluster| {
-                let inline = cluster.has_inline_glyph().then_some(Glyph {
-                    id: cluster.glyph_offset,
-                    x: 0.,
-                    y: 0.,
-                    advance: cluster.advance,
-                });
-
-                let stored: &'a [Glyph] = if cluster.has_inline_glyph() {
-                    &[]
-                } else {
-                    let start = cluster.glyph_offset as usize;
-                    &glyphs[start..start + cluster.glyph_len() as usize]
-                };
-
-                inline.into_iter().chain(stored.iter().copied())
-            })
     }
 
     /// This atom as a [`ShapedSlice`].

--- a/parley_engine/src/shape/atom.rs
+++ b/parley_engine/src/shape/atom.rs
@@ -3,8 +3,6 @@
 
 use core::ops::Range;
 
-use parlance::BidiLevel;
-
 use crate::{Boundary, Glyph, shape::Whitespace};
 
 use super::data::{Character, ShapedCluster};
@@ -27,7 +25,6 @@ pub struct ShapedSlice<'a> {
 
     pub(crate) shaped_clusters: &'a [ShapedCluster],
     pub(crate) glyphs: &'a [Glyph],
-    pub(crate) bidi_level: BidiLevel,
 
     /// The range of [`Self::shaped_clusters`] this slice covers.
     pub(crate) clusters: (u32, u32),
@@ -95,41 +92,6 @@ impl<'a> ShapedSlice<'a> {
             "cluster range out of this slice's range"
         );
         &self.shaped_clusters[clusters_range.start as usize..clusters_range.end as usize]
-    }
-
-    /// Iterate shaped clusters in visual left-to-right order.
-    #[inline(always)]
-    pub fn shaped_clusters_visual(&self) -> impl ExactSizeIterator<Item = u32> + Clone + use<> {
-        #[derive(Clone)]
-        struct ShapedClusters {
-            range: Range<u32>,
-            rev: bool,
-        }
-
-        impl Iterator for ShapedClusters {
-            type Item = u32;
-
-            #[inline(always)]
-            fn next(&mut self) -> Option<Self::Item> {
-                if self.rev {
-                    self.range.next_back()
-                } else {
-                    self.range.next()
-                }
-            }
-
-            #[inline(always)]
-            fn size_hint(&self) -> (usize, Option<usize>) {
-                self.range.size_hint()
-            }
-        }
-
-        impl ExactSizeIterator for ShapedClusters {}
-
-        ShapedClusters {
-            range: self.clusters.0..self.clusters.1,
-            rev: self.bidi_level.is_rtl(),
-        }
     }
 
     /// The byte range in the source text of the given range of [`Self::characters`].
@@ -200,14 +162,6 @@ impl<'a> ShapedSlice<'a> {
         };
 
         inline.into_iter().chain(stored.iter().copied())
-    }
-
-    /// Get an iterator over this slice's glyphs in visual left-to-right order.
-    #[inline(always)]
-    pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + Clone + use<'a> {
-        let slice = *self;
-        self.shaped_clusters_visual()
-            .flat_map(move |cluster_idx| slice.shaped_cluster_glyphs(cluster_idx))
     }
 
     /// Get a cursor to walk atoms from the logical start of this slice.

--- a/parley_engine/src/shape/shaped_text.rs
+++ b/parley_engine/src/shape/shaped_text.rs
@@ -145,7 +145,6 @@ impl ShapedText {
 
             shaped_clusters: &self.shaped_clusters,
             glyphs: &self.glyphs,
-            bidi_level: run.bidi_level,
 
             clusters: (
                 run.shaped_clusters_range.start,


### PR DESCRIPTION
It currently lives on `Atom`, but in principle iterating glyphs doesn't need to form atoms.

~The old behavior is expressible as `atom.slice().glyphs()`.~ Edit: I've removed `ShapedSlice::glyphs` that I introduced in the first commit. I was thinking a bit about the bidi reordering that needs to happen after line wrapping, and I think it makes sense to do that closer to reshaping (when the lines are known). With that in mind, it probably makes most sense to keep `ShapedSlice` in terms of logical (memory) order, as it does not know the final visual order.

As a result, this now also removes `BidiLevel` from `ShapedSlice`. This makes it simpler for a `ShapedSlice` to cross bidi boundaries, too, which is likely useful, because graphemes can cross bidi boundaries.

As `parley` already has `Run`s in hand when it needs the glyphs, I've instead added a helper on `parley` for the time being.