### PR TITLE
Preserve non-breaking spaces when collapsing whitespace

### DIFF
--- a/parley/src/resolve/tree.rs
+++ b/parley/src/resolve/tree.rs
@@ -106,10 +106,10 @@ impl<B: Brush> TreeStyleBuilder<B> {
                             .last()
                             .is_some_and(|c| c.is_ascii_whitespace()))
                 {
-                    span_text = span_text.trim_start();
+                    span_text = span_text.trim_start_matches(|c: char| c.is_ascii_whitespace());
                 }
                 if is_span_last {
-                    span_text = span_text.trim_end();
+                    span_text = span_text.trim_end_matches(|c: char| c.is_ascii_whitespace());
                 }
 
                 // Collapse spaces
@@ -235,6 +235,20 @@ mod tests {
     use super::*;
     use alloc::vec::Vec;
     use core::ops::Range;
+
+    #[test]
+    fn collapses_ascii_whitespace_without_trimming_non_ascii_whitespace() {
+        let mut builder = TreeStyleBuilder::<u32>::default();
+        builder.begin(ResolvedStyle::default());
+        builder.set_white_space_mode(WhiteSpaceCollapse::Collapse);
+        builder.push_text(" \u{00a0}text\u{00a0} ");
+
+        let mut style_table = Vec::new();
+        let mut style_runs = Vec::new();
+        let text = builder.finish(&mut style_table, &mut style_runs);
+
+        assert_eq!(text, "\u{00a0}text\u{00a0}");
+    }
 
     #[test]
     fn reuses_style_id_when_returning_to_parent_span() {


### PR DESCRIPTION
Use ASCII-only trimming at collapsed text boundaries, matching the existing internal whitespace-collapse logic. This preserves non-breaking spaces while continuing to remove surrounding ASCII whitespace.

Includes a focused regression test.

Fixes #684.
