### PR TITLE
Simplify whitespace collapsing code somewhat

### DIFF
--- a/parley/src/resolve/tree.rs
+++ b/parley/src/resolve/tree.rs
@@ -100,16 +100,12 @@ impl<B: Brush> TreeStyleBuilder<B> {
 
                 if self.is_span_first
                     || (self.last_item_kind == ItemKind::TextRun
-                        && self
-                            .text
-                            .chars()
-                            .last()
-                            .is_some_and(|c| c.is_ascii_whitespace()))
+                        && self.text.ends_with(|c: char| c.is_ascii_whitespace()))
                 {
-                    span_text = span_text.trim_start_matches(|c: char| c.is_ascii_whitespace());
+                    span_text = span_text.trim_ascii_start();
                 }
                 if is_span_last {
-                    span_text = span_text.trim_end_matches(|c: char| c.is_ascii_whitespace());
+                    span_text = span_text.trim_ascii_end();
                 }
 
                 // Collapse spaces


### PR DESCRIPTION
This uses `str::trim_ascii_{start,end}` instead of the manual matching and `str::ends_with`. Behaviorally and performance-wise this should be the same (in particular, `ends_with` and `chars().last()` should both just do an O(1) `next_back` under the hood).

Follow-up to https://github.com/linebender/parley/pull/734, which corrected our whitespace collapsing.