### PR TITLE
Make `append_atom_to_line` private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ This release has an [MSRV] of 1.88.
   Shaped clusters that cross grapheme boundaries are represented using the existing `Cluster::is_ligature_start` and `Cluster::is_ligature_continuation`; note these methods previously encoded graphemes as well.
   Shaped clusters' advances are split evenly over the grapheme clusters they overlap.
   `Run::cluster_range` now returns grapheme cluster indices relative to the run's shaped run.
-  `BreakerState::append_cluster_to_line` was replaced by `BreakerState::append_atom_to_line`.
 - Breaking change: lines with mixed inline content, like different fonts or sizes, or inline boxes, are now sized more closely to the CSS line-box model. ([#697][] by [@tomcur][])  
   The `LineMetrics::{ascent,descent,leading}` fields were removed, and `LineMetrics::block_{min,max}_coord` now describe the block-axis layout bounds of each line box.
   Glyphs may overflow these layout bounds, especially when a small line height is used.

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -306,7 +306,7 @@ impl BreakerState {
     /// line height of the atom (i.e. including the full leading), which may be smaller than
     /// `ascent + descent` when the leading is negative.
     #[inline]
-    pub fn append_atom_to_line(
+    fn append_atom_to_line(
         &mut self,
         atom: &Atom<'_>,
         next_x: f32,


### PR DESCRIPTION
This can't usefully be called externally. The user has nothing they could pass to this method.