### PR TITLE
Add benchmarks for word/letter spacing and repeated justification

### DIFF
--- a/parley_bench/benches/main.rs
+++ b/parley_bench/benches/main.rs
@@ -5,7 +5,13 @@
 
 use tango_bench::tango_benchmarks;
 
-use parley_bench::benches::{defaults, styled};
+use parley_bench::benches::{defaults, repeated_justification, spacing, styled};
 use parley_bench::fontique_benches::system_fonts_init;
 
-tango_benchmarks!(defaults(), styled(), system_fonts_init());
+tango_benchmarks!(
+    defaults(),
+    styled(),
+    spacing(),
+    repeated_justification(),
+    system_fonts_init()
+);

--- a/parley_bench/src/benches.rs
+++ b/parley_bench/src/benches.rs
@@ -47,6 +47,100 @@ pub fn defaults() -> Vec<Benchmark> {
         .collect()
 }
 
+/// Benchmark for nonzero word and letter spacing.
+pub fn spacing() -> Vec<Benchmark> {
+    const DISPLAY_SCALE: f32 = 1.0;
+    const QUANTIZE: bool = true;
+    const MAX_ADVANCE: f32 = 200.0 * DISPLAY_SCALE;
+    const WORD_SPACING: f32 = 2.0;
+    const LETTER_SPACING: f32 = 1.0;
+
+    let samples = get_samples();
+
+    samples
+        .iter()
+        .map(|sample| {
+            benchmark_fn(
+                format!(
+                    "Word + Letter Spacing - {} {}",
+                    sample.name, sample.modification
+                ),
+                |b| {
+                    b.iter(|| {
+                        let text = &sample.text;
+                        with_contexts(|font_cx, layout_cx| {
+                            let mut builder =
+                                layout_cx.ranged_builder(font_cx, text, DISPLAY_SCALE, QUANTIZE);
+                            builder.push_default(FontFamily::from(FONT_FAMILY_LIST));
+                            builder.push_default(StyleProperty::WordSpacing(WORD_SPACING));
+                            builder.push_default(StyleProperty::LetterSpacing(LETTER_SPACING));
+
+                            let mut layout: Layout<ColorBrush> = builder.build(text);
+                            layout.break_all_lines(Some(MAX_ADVANCE));
+                            layout.align(Alignment::Start, AlignmentOptions::default());
+
+                            black_box(layout);
+                        });
+                    })
+                },
+            )
+        })
+        .collect()
+}
+
+/// Benchmark repeatedly justifying an already line-broken layout.
+pub fn repeated_justification() -> [Benchmark; 1] {
+    const DISPLAY_SCALE: f32 = 1.0;
+    const QUANTIZE: bool = true;
+    const MAX_ADVANCE: f32 = 200.0 * DISPLAY_SCALE;
+
+    let sample = get_samples()
+        .iter()
+        .find(|sample| sample.name == "latin" && sample.modification == "4 paragraph")
+        .expect("the Latin four-paragraph benchmark sample should exist");
+
+    [benchmark_fn(
+        format!(
+            "Repeated Justification - {} {}",
+            sample.name, sample.modification
+        ),
+        move |b| {
+            let text = &sample.text;
+            let mut layout = with_contexts(|font_cx, layout_cx| {
+                let mut builder = layout_cx.ranged_builder(font_cx, text, DISPLAY_SCALE, QUANTIZE);
+                builder.push_default(FontFamily::from(FONT_FAMILY_LIST));
+
+                let mut layout: Layout<ColorBrush> = builder.build(text);
+                layout.break_all_lines(Some(MAX_ADVANCE));
+                layout
+            });
+
+            b.iter(move || {
+                layout.align(Alignment::Justify, AlignmentOptions::default());
+
+                // Pass to black box so the optimizer cannot optimize alignment away.
+                black_box(
+                    layout
+                        .lines()
+                        .flat_map(|line| line.runs())
+                        .map(|run| run.advance())
+                        .sum::<f32>(),
+                );
+                layout.align(Alignment::Start, AlignmentOptions::default());
+
+                // Pass to black box so the optimizer cannot optimize alignment away.
+                black_box(
+                    layout
+                        .lines()
+                        .flat_map(|line| line.runs())
+                        .map(|run| run.advance())
+                        .sum::<f32>(),
+                )
+            })
+        },
+    )]
+}
+
 /// Benchmark for styled text.
 pub fn styled() -> Vec<Benchmark> {
     const DISPLAY_SCALE: f32 = 1.0;


### PR DESCRIPTION
LLM Contributions: Mostly generated.

This adds two benchmarks, motivated by a PR that's following.

One benchmark exercises layout when letter and word spacing are applied, which (especially in the PR that follows) does some additional work relative to the zero-spacing path.

The other benchmark exercises performance of re-justifying (similar to what was proposed in https://github.com/linebender/parley/pull/707).

**Changelog: None**