### PR TITLE
docs: explain parley engine shaping pipeline

### DIFF
--- a/parley_engine/src/lib.rs
+++ b/parley_engine/src/lib.rs
@@ -6,6 +6,26 @@
 //! ## Features
 //!
 //! - `std` (enabled by default): This is currently unused and is provided for forward compatibility.
+//!
+//! ## Typical shaping pipeline
+//!
+//! A caller normally reuses an [`Analyzer`], [`Analysis`], and [`Shaper`] while
+//! laying out text. The analysis must be produced before itemization and
+//! shaping, and the same source string must be passed to each stage:
+//!
+//! ```text
+//! analyzer.analyze(text, &options, &mut analysis);
+//! for item in analysis.itemize(text, split_after) {
+//!     shaper.shape_item(text, &analysis, &item, &shape_options, select_font, &mut shaped_text);
+//! }
+//! ```
+//!
+//! [`Analysis::itemize`] divides text into runs with compatible bidi and
+//! script properties. [`Shaper::shape_item`] then turns each run into glyphs;
+//! the `select_font` callback chooses a [`FontInstance`] for each character
+//! cluster. Higher-level users should generally prefer `parley`'s
+//! [`LayoutContext`](https://docs.rs/parley/latest/parley/struct.LayoutContext.html),
+//! which manages these stages and adds style resolution and line layout.
 
 // LINEBENDER LINT SET - lib.rs - v3
 // See https://linebender.org/wiki/canonical-lints/


### PR DESCRIPTION
<!--
Thanks for opening a PR for this Linebender project!
-->

<!-- If you used any LLM ("AI") tools in making this PR, please ensure that you have reviewed our
LLM policy at https://linebender.org/wiki/llm-policy/.
Please list how you used it (e.g. writing code, reviewing, fact finding) below.
We expect you to have fully understood and self-reviewed your contributions to Linebender.

If you did not use any LLM tools, please replace "Unspecified" with 'None'. -->
LLM Contributions: Documentation drafting and review.

This adds a concise usage overview to `parley_engine`'s crate documentation. It explains the expected Analysis → itemization → shaping order and when higher-level users should use `parley::LayoutContext`.

**Changelog: None**
