### PR TITLE
Preserve (don't clamp) negative half-leading

### DIFF
--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -97,14 +97,29 @@ struct Extents {
 
 impl Default for Extents {
     fn default() -> Self {
+        // Initialized to negative infinity so that content with negative extents (e.g. text with
+        // negative half-leading from a small `line-height`) is not floored at zero. Lines with no
+        // contributing content resolve to zero via [`Self::or_zero`], keeping the sentinel
+        // internal.
+        //
+        // Ideally, a line's initial extents should be sourced from the primary font.
         Self {
-            // NOTE: these should be `f32::NEG_INFINITY`, but that's currently causing
-            // `tests::test_builders::builders_empty` to fail with a `NaN`.
-            //
-            // And even more ideally, a line's initial extents should be sourced from the primary
-            // font.
-            over: 0.,
-            under: 0.,
+            over: f32::NEG_INFINITY,
+            under: f32::NEG_INFINITY,
+        }
+    }
+}
+
+impl Extents {
+    /// Resolve unset (default) extents to zero.
+    fn or_zero(self) -> Self {
+        if self.over == f32::NEG_INFINITY && self.under == f32::NEG_INFINITY {
+            Self {
+                over: 0.,
+                under: 0.,
+            }
+        } else {
+            self
         }
     }
 }
@@ -113,7 +128,8 @@ impl LineBoxMetrics {
     /// The line height seen so far.
     #[inline(always)]
     fn line_height(self) -> f32 {
-        self.line_box.over + self.line_box.under
+        let line_box = self.line_box.or_zero();
+        line_box.over + line_box.under
     }
 
     fn add_text(&mut self, metrics: &FontMetrics, line_height: f32, quantize: bool) {
@@ -625,26 +641,36 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                     // and the portion below to its descent. By default (no explicit baseline) the
                     // bottom of the box is aligned with the text baseline, i.e. the box is all
                     // ascent and zero descent. Out-of-flow boxes contribute nothing.
-                    let (width_contribution, height_contribution, resolved_baseline) =
-                        match inline_box.kind {
-                            InlineBoxKind::InFlow => {
-                                let baseline = inline_box.baseline.unwrap_or(inline_box.height);
-                                (inline_box.width, inline_box.height, baseline)
-                            }
-                            InlineBoxKind::OutOfFlow => (0.0, 0.0, 0.0),
-                            // If the box is a `CustomOutOfFlow` box then we yield control flow back to the caller.
-                            // It is then the caller's responsibility to handle placement of the box.
-                            InlineBoxKind::CustomOutOfFlow => {
-                                return Some(YieldData::InlineBoxBreak(BoxBreakData {
-                                    inline_box_id: inline_box.id,
-                                    inline_box_index: item.index,
-                                    advance: self.state.line.x,
-                                }));
-                            }
-                        };
-
-                    let ascent_contribution = resolved_baseline;
-                    let descent_contribution = height_contribution - resolved_baseline;
+                    let (
+                        width_contribution,
+                        height_contribution,
+                        ascent_contribution,
+                        descent_contribution,
+                    ) = match inline_box.kind {
+                        InlineBoxKind::InFlow => {
+                            let baseline = inline_box.baseline.unwrap_or(inline_box.height);
+                            (
+                                inline_box.width,
+                                inline_box.height,
+                                baseline,
+                                inline_box.height - baseline,
+                            )
+                        }
+                        // Negative infinity extents are a no-op when maxed into the line's
+                        // extents, so out-of-flow boxes truly contribute nothing.
+                        InlineBoxKind::OutOfFlow => {
+                            (0.0, 0.0, f32::NEG_INFINITY, f32::NEG_INFINITY)
+                        }
+                        // If the box is a `CustomOutOfFlow` box then we yield control flow back to the caller.
+                        // It is then the caller's responsibility to handle placement of the box.
+                        InlineBoxKind::CustomOutOfFlow => {
+                            return Some(YieldData::InlineBoxBreak(BoxBreakData {
+                                inline_box_id: inline_box.id,
+                                inline_box_index: item.index,
+                                advance: self.state.line.x,
+                            }));
+                        }
+                    };
 
                     // Compute the x position of the content being currently processed
                     let next_x = self.state.line.x + width_contribution;
@@ -941,8 +967,8 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                     if inline_box.kind != InlineBoxKind::InFlow {
                         self.state.append_inline_box_to_line(
                             self.state.line.x,
-                            0.0,
-                            0.0,
+                            f32::NEG_INFINITY,
+                            f32::NEG_INFINITY,
                             self.layout.data.quantize,
                         );
                         continue;
@@ -1223,8 +1249,8 @@ impl<'a, B: Brush> BreakLines<'a, B> {
         // Whether metrics should be quantized to pixel boundaries
         let quantize = self.layout.data.quantize;
 
-        let mut line_box_extents = self.state.line.box_metrics.line_box;
-        let mut content_box_extents = self.state.line.box_metrics.content_box;
+        let mut line_box_extents = self.state.line.box_metrics.line_box.or_zero();
+        let mut content_box_extents = self.state.line.box_metrics.content_box.or_zero();
         if !have_metrics
             && line.item_range.is_empty()
             && let Some(metrics) = prev_line_metrics

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -97,10 +97,11 @@ struct Extents {
 
 impl Default for Extents {
     fn default() -> Self {
-        // Initialized to negative infinity so that content with negative extents (e.g. text with
-        // negative half-leading from a small `line-height`) is not floored at zero. Lines with no
-        // contributing content resolve to zero via [`Self::or_zero`], keeping the sentinel
-        // internal.
+        // Content with small line heights and/or with inline boxes sitting entirely above or
+        // below the baseline can cause the baseline to fall outside the line box; i.e., extents
+        // can be negative. Hence, we initialize the space over and under the line box's
+        // baseline to negative infinity. Lines with no contributing content resolve to zero via
+        // [`Self::or_zero`], keeping the sentinel internal.
         //
         // Ideally, a line's initial extents should be sourced from the primary font.
         Self {

--- a/parley_tests/tests/lines.rs
+++ b/parley_tests/tests/lines.rs
@@ -534,6 +534,51 @@ fn lines_negative_leading_inline_box_grows_line_box() {
     env.check_layout_snapshot(&layout);
 }
 
+/// Test that a line height small enough to make the half-leading exceed the descent keeps the
+/// resulting negative extent below the baseline, rather than clamping it to zero.
+#[test]
+fn lines_zero_line_height_keeps_negative_under_extent() {
+    let font_size = 16.0;
+    let line_height_px = 0.0;
+    let text = "dig\npug\nyak";
+
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut builder = env.ranged_builder(text);
+    builder.push_default(StyleProperty::FontSize(font_size));
+    builder.push_default(LineHeight::Absolute(line_height_px));
+    let mut layout: Layout<ColorBrush> = builder.build(text);
+    layout.break_all_lines(None);
+
+    let (ascent, descent) = roboto_ascent_descent(font_size);
+    let half_leading = (line_height_px - (ascent.round() + descent.round())) / 2.;
+    let expected_above = ascent.round() + half_leading.floor();
+    let expected_below = line_height_px - expected_above;
+    assert!(
+        expected_below < 0.,
+        "expected a negative extent below the baseline, but got {expected_below}"
+    );
+
+    for line in layout.lines() {
+        let metrics = line.metrics();
+        assert_eq!(
+            metrics.baseline - metrics.block_min_coord,
+            expected_above,
+            "expected {expected_above} above the baseline"
+        );
+        assert_eq!(
+            metrics.block_max_coord - metrics.baseline,
+            expected_below,
+            "expected {expected_below} below the baseline"
+        );
+        assert_eq!(
+            metrics.block_max_coord - metrics.block_min_coord,
+            line_height_px,
+            "expected the line box height to equal the line height {line_height_px}"
+        );
+    }
+    assert_eq!(layout.height(), line_height_px * 3.);
+}
+
 /// Test fractional line height with a positive leading.
 ///
 /// The line box height must be increased by the leading,


### PR DESCRIPTION
### Summary

When `line-height < ascent + descent`, half-leading is legitimately negative:

- Extents now default to `f32::NEG_INFINITY` so legitimately negative extents are preserved.
- Lines with no extent contributions are resolved to zero in finish_line.
- Out-of-flow inline boxes no longer contribute extents. 

### LLM Contributions

Code generated with Devin Ultra.

### Changelog Entry

> ### Fixed
>
> - Line boxes with negative half-leading (line-height smaller than ascent + descent) are no longer floored at the content height; out-of-flow inline boxes no longer floor a line's extents at zero.