### PR TITLE
Add rich text editor API and example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "accesskit_atspi_common"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023da0e5097f46df7092d5280b02efb9bbf8d93298daeced42652463e357d636"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.38.0",
+ "atspi-common",
+ "phf",
+ "serde",
+ "zvariant",
+]
+
+[[package]]
 name = "accesskit_consumer"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,22 +77,36 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950720ce064757a1b629caad3a408e8d2c63bb01f29b8a3ff8daa331053ffeb"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
 dependencies = [
  "accesskit",
  "hashbrown 0.16.1",
 ]
 
 [[package]]
-name = "accesskit_macos"
-version = "0.26.2"
+name = "accesskit_ios"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cb8b66cef272d48161b02a6317cc2bdd5f98bb0a5e79c68f704a5862aa396b"
+checksum = "750c4e9f6ce888dfe8a10c0f1b5ceb646a7854fd46579d74919219d1bb314083"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.37.0",
+ "accesskit_consumer 0.38.0",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.38.0",
  "hashbrown 0.16.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
@@ -92,7 +120,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b016ca8db0ea0ea2ceff29a9d6240391492d960716aa471967c00e8cc8cb197c"
 dependencies = [
  "accesskit",
- "accesskit_atspi_common",
+ "accesskit_atspi_common 0.18.1",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e156ed3802e35eefe894ef2671bc6c889303d8a7e110b5e1b48f504b91362f"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common 0.19.1",
  "async-channel",
  "async-executor",
  "async-task",
@@ -118,6 +164,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "accesskit_windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106c2b961215864d1c2e703ee63269c25c4e80a577ffb2c1017b9c17dcdf83a1"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.38.0",
+ "hashbrown 0.16.1",
+ "static_assertions",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "accesskit_winit"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,8 +185,23 @@ checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
 dependencies = [
  "accesskit",
  "accesskit_macos",
- "accesskit_unix",
- "accesskit_windows",
+ "accesskit_unix 0.21.1",
+ "accesskit_windows 0.32.1",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
+name = "accesskit_winit"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5b41e63a69f36d9f1f41e70464c7e5f72eee485ef26aab19f0b4f86e6c0a84c"
+dependencies = [
+ "accesskit",
+ "accesskit_ios",
+ "accesskit_macos",
+ "accesskit_unix 0.22.1",
+ "accesskit_windows 0.34.0",
  "raw-window-handle",
  "winit",
 ]
@@ -242,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayref"
@@ -1098,7 +1173,7 @@ name = "editor"
 version = "0.1.0"
 dependencies = [
  "accesskit",
- "accesskit_winit",
+ "accesskit_winit 0.32.2",
  "anyhow",
  "clipboard-rs",
  "parley",
@@ -2961,6 +3036,7 @@ name = "parley"
 version = "0.11.0"
 dependencies = [
  "accesskit",
+ "attributed_text",
  "bytemuck",
  "core_maths",
  "fontique",
@@ -3518,6 +3594,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "rich_editor"
+version = "0.1.0"
+dependencies = [
+ "accesskit",
+ "accesskit_winit 0.33.2",
+ "anyhow",
+ "clipboard-rs",
+ "parley",
+ "peniko",
+ "softbuffer",
+ "ui-events",
+ "ui-events-winit",
+ "vello_cpu",
+ "web-time",
+ "winit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "examples/tiny_skia_render",
     "examples/vello_cpu_render",
     "examples/editor",
+    "examples/rich_editor",
     "xtask",
 ]
 
@@ -33,6 +34,7 @@ repository = "https://github.com/linebender/parley"
 
 [workspace.dependencies]
 # Local crates
+attributed_text = { version = "0.1.0", default-features = false, path = "attributed_text" }
 parlance = { version = "0.1.0", default-features = false, path = "parlance" }
 fontique = { version = "0.11.0", default-features = false, path = "fontique" }
 parley = { version = "0.11.0", default-features = false, path = "parley" }

--- a/attributed_text/src/attribute_segments.rs
+++ b/attributed_text/src/attribute_segments.rs
@@ -364,7 +364,9 @@ pub struct AttributeSegments<'w, 'a, T: Clone + Debug + TextStorage, Attr: Clone
     index: usize,
 }
 
-impl<'w, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> AttributeSegments<'w, 'a, T, Attr> {
+impl<'w, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug>
+    AttributeSegments<'w, 'a, T, Attr>
+{
     fn update_active_for_boundary(&mut self, boundary_index: usize) {
         update_active_for_boundary(self.workspace, boundary_index);
     }
@@ -403,7 +405,9 @@ pub struct AttributeSegment<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone 
     attributed: &'a AttributedText<T, Attr>,
 }
 
-impl<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> AttributeSegment<'s, 'a, T, Attr> {
+impl<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug>
+    AttributeSegment<'s, 'a, T, Attr>
+{
     /// Returns the segment range.
     #[must_use]
     pub const fn range(&self) -> TextRange {
@@ -420,7 +424,9 @@ impl<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> AttributeSegme
     }
 }
 
-impl<T: Clone + Debug + TextStorage, Attr: Clone + Debug> Iterator for AttributeSegments<'_, '_, T, Attr> {
+impl<T: Clone + Debug + TextStorage, Attr: Clone + Debug> Iterator
+    for AttributeSegments<'_, '_, T, Attr>
+{
     type Item = TextRange;
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -448,7 +454,9 @@ impl<T: Clone + Debug + TextStorage, Attr: Clone + Debug> Iterator for Attribute
     }
 }
 
-impl<T: Clone + Debug + TextStorage, Attr: Clone + Debug> ExactSizeIterator for AttributeSegments<'_, '_, T, Attr> {
+impl<T: Clone + Debug + TextStorage, Attr: Clone + Debug> ExactSizeIterator
+    for AttributeSegments<'_, '_, T, Attr>
+{
     fn len(&self) -> usize {
         // Remaining segments are remaining adjacent boundary pairs: [i, i + 1).
         self.workspace
@@ -478,7 +486,9 @@ pub struct ActiveSpansIter<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone +
     attributed: &'a AttributedText<T, Attr>,
 }
 
-impl<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> Iterator for ActiveSpansIter<'s, 'a, T, Attr> {
+impl<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> Iterator
+    for ActiveSpansIter<'s, 'a, T, Attr>
+{
     type Item = (TextRange, &'a Attr);
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -495,7 +505,10 @@ impl<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> Iterator for A
     }
 }
 
-impl<T: Clone + Debug + TextStorage, Attr: Clone + Debug> ExactSizeIterator for ActiveSpansIter<'_, '_, T, Attr> {}
+impl<T: Clone + Debug + TextStorage, Attr: Clone + Debug> ExactSizeIterator
+    for ActiveSpansIter<'_, '_, T, Attr>
+{
+}
 
 impl<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> DoubleEndedIterator
     for ActiveSpansIter<'s, 'a, T, Attr>

--- a/attributed_text/src/attribute_segments.rs
+++ b/attributed_text/src/attribute_segments.rs
@@ -145,7 +145,7 @@ fn build_segment_state_from_ranges<I>(
     }
 }
 
-fn build_segment_state<T: Debug + TextStorage, Attr: Debug>(
+fn build_segment_state<T: Clone + Debug + TextStorage, Attr: Clone + Debug>(
     attributed: &AttributedText<T, Attr>,
     workspace: &mut AttributeSegmentsWorkspace,
 ) {
@@ -202,7 +202,7 @@ impl AttributeSegmentsWorkspace {
     }
 
     /// Build an iterator using this workspace's retained allocations.
-    pub fn segments<'w, 'a, T: Debug + TextStorage, Attr: Debug>(
+    pub fn segments<'w, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug>(
         &'w mut self,
         attributed: &'a AttributedText<T, Attr>,
     ) -> AttributeSegments<'w, 'a, T, Attr> {
@@ -271,7 +271,7 @@ impl AttributeSegmentsWorkspace {
 /// ```
 /// use attributed_text::{AttributeSegmentsWorkspace, AttributedText, TextRange};
 ///
-/// #[derive(Debug, PartialEq, Eq)]
+/// #[derive(Clone, Debug, PartialEq, Eq)]
 /// enum Color {
 ///     Red,
 ///     Blue,
@@ -358,13 +358,13 @@ impl AttributeSegmentsWorkspace {
 /// Zero-length attribute ranges are excluded from the active span set, but their boundaries are
 /// still included in segmentation, so they can split output ranges.
 #[derive(Debug)]
-pub struct AttributeSegments<'w, 'a, T: Debug + TextStorage, Attr: Debug> {
+pub struct AttributeSegments<'w, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> {
     attributed: &'a AttributedText<T, Attr>,
     workspace: &'w mut AttributeSegmentsWorkspace,
     index: usize,
 }
 
-impl<'w, 'a, T: Debug + TextStorage, Attr: Debug> AttributeSegments<'w, 'a, T, Attr> {
+impl<'w, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> AttributeSegments<'w, 'a, T, Attr> {
     fn update_active_for_boundary(&mut self, boundary_index: usize) {
         update_active_for_boundary(self.workspace, boundary_index);
     }
@@ -397,13 +397,13 @@ impl<'w, 'a, T: Debug + TextStorage, Attr: Debug> AttributeSegments<'w, 'a, T, A
 
 /// A range yielded by [`AttributeSegments`] with its active attribute spans.
 #[derive(Clone, Debug)]
-pub struct AttributeSegment<'s, 'a, T: Debug + TextStorage, Attr: Debug> {
+pub struct AttributeSegment<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> {
     range: TextRange,
     active_ids: &'s [u32],
     attributed: &'a AttributedText<T, Attr>,
 }
 
-impl<'s, 'a, T: Debug + TextStorage, Attr: Debug> AttributeSegment<'s, 'a, T, Attr> {
+impl<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> AttributeSegment<'s, 'a, T, Attr> {
     /// Returns the segment range.
     #[must_use]
     pub const fn range(&self) -> TextRange {
@@ -420,7 +420,7 @@ impl<'s, 'a, T: Debug + TextStorage, Attr: Debug> AttributeSegment<'s, 'a, T, At
     }
 }
 
-impl<T: Debug + TextStorage, Attr: Debug> Iterator for AttributeSegments<'_, '_, T, Attr> {
+impl<T: Clone + Debug + TextStorage, Attr: Clone + Debug> Iterator for AttributeSegments<'_, '_, T, Attr> {
     type Item = TextRange;
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -448,7 +448,7 @@ impl<T: Debug + TextStorage, Attr: Debug> Iterator for AttributeSegments<'_, '_,
     }
 }
 
-impl<T: Debug + TextStorage, Attr: Debug> ExactSizeIterator for AttributeSegments<'_, '_, T, Attr> {
+impl<T: Clone + Debug + TextStorage, Attr: Clone + Debug> ExactSizeIterator for AttributeSegments<'_, '_, T, Attr> {
     fn len(&self) -> usize {
         // Remaining segments are remaining adjacent boundary pairs: [i, i + 1).
         self.workspace
@@ -463,7 +463,7 @@ impl<T: Debug + TextStorage, Attr: Debug> ExactSizeIterator for AttributeSegment
 /// Provides iteration in both application order (ascending span id) and reverse
 /// application order (descending span id — useful for last-writer-wins resolution).
 #[derive(Clone, Debug)]
-pub struct ActiveSpans<'s, 'a, T: Debug + TextStorage, Attr: Debug> {
+pub struct ActiveSpans<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> {
     active_ids: &'s [u32],
     attributed: &'a AttributedText<T, Attr>,
 }
@@ -473,12 +473,12 @@ pub struct ActiveSpans<'s, 'a, T: Debug + TextStorage, Attr: Debug> {
 /// Obtain this by calling [`ActiveSpans::iter`] or by iterating `&ActiveSpans`
 /// via [`IntoIterator`].
 #[derive(Clone, Debug)]
-pub struct ActiveSpansIter<'s, 'a, T: Debug + TextStorage, Attr: Debug> {
+pub struct ActiveSpansIter<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> {
     ids: core::slice::Iter<'s, u32>,
     attributed: &'a AttributedText<T, Attr>,
 }
 
-impl<'s, 'a, T: Debug + TextStorage, Attr: Debug> Iterator for ActiveSpansIter<'s, 'a, T, Attr> {
+impl<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> Iterator for ActiveSpansIter<'s, 'a, T, Attr> {
     type Item = (TextRange, &'a Attr);
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -495,9 +495,9 @@ impl<'s, 'a, T: Debug + TextStorage, Attr: Debug> Iterator for ActiveSpansIter<'
     }
 }
 
-impl<T: Debug + TextStorage, Attr: Debug> ExactSizeIterator for ActiveSpansIter<'_, '_, T, Attr> {}
+impl<T: Clone + Debug + TextStorage, Attr: Clone + Debug> ExactSizeIterator for ActiveSpansIter<'_, '_, T, Attr> {}
 
-impl<'s, 'a, T: Debug + TextStorage, Attr: Debug> DoubleEndedIterator
+impl<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> DoubleEndedIterator
     for ActiveSpansIter<'s, 'a, T, Attr>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -510,7 +510,7 @@ impl<'s, 'a, T: Debug + TextStorage, Attr: Debug> DoubleEndedIterator
     }
 }
 
-impl<'s, 'a, T: Debug + TextStorage, Attr: Debug> ActiveSpans<'s, 'a, T, Attr> {
+impl<'s, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> ActiveSpans<'s, 'a, T, Attr> {
     /// Iterate over the active spans in application order (ascending span id).
     ///
     /// Each item is `(TextRange, &Attr)`.
@@ -532,7 +532,7 @@ impl<'s, 'a, T: Debug + TextStorage, Attr: Debug> ActiveSpans<'s, 'a, T, Attr> {
     }
 }
 
-impl<'active, 's, 'a, T: Debug + TextStorage, Attr: Debug> IntoIterator
+impl<'active, 's, 'a, T: Clone + Debug + TextStorage, Attr: Clone + Debug> IntoIterator
     for &'active ActiveSpans<'s, 'a, T, Attr>
 {
     type Item = (TextRange, &'a Attr);

--- a/attributed_text/src/attributed_text.rs
+++ b/attributed_text/src/attributed_text.rs
@@ -9,13 +9,13 @@ use crate::text_range::validate_range;
 use crate::{Error, TextChunk, TextRange, TextStorage};
 
 /// A block of text with attributes applied to ranges within the text.
-#[derive(Debug)]
-pub struct AttributedText<T: Debug + TextStorage, Attr: Debug> {
+#[derive(Clone, Debug)]
+pub struct AttributedText<T: Clone + Debug + TextStorage, Attr: Clone + Debug> {
     text: T,
     attributes: Vec<(TextRange, Attr)>,
 }
 
-impl<T: Debug + TextStorage, Attr: Debug> AttributedText<T, Attr> {
+impl<T: Clone + Debug + TextStorage, Attr: Clone + Debug> AttributedText<T, Attr> {
     /// Create an `AttributedText` with no attributes applied.
     pub fn new(text: T) -> Self {
         Self {
@@ -166,7 +166,7 @@ mod tests {
     use alloc::vec;
     use alloc::vec::Vec;
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     enum TestAttribute {
         Keep,
         Remove,

--- a/examples/rich_editor/Cargo.toml
+++ b/examples/rich_editor/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "rich_editor"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+vello_cpu = { workspace = true, default-features = false, features = ["std", "text"] }
+softbuffer = "0.4.6"
+anyhow = "1.0.104"
+ui-events-winit = "0.3"
+ui-events = "0.3"
+winit = "0.30.13"
+parley = { workspace = true, default-features = true, features = ["accesskit"] }
+peniko = { workspace = true, default-features = false, features = ["std"] }
+accesskit = { workspace = true }
+accesskit_winit = "0.33.2"
+
+[lints]
+workspace = true
+
+[target.'cfg(target_os = "android")'.dependencies]
+winit = { version = "0.30.13", features = ["android-native-activity"] }
+
+[target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))'.dependencies]
+clipboard-rs = "0.3.3"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time = "1.1.0"

--- a/examples/rich_editor/src/access_ids.rs
+++ b/examples/rich_editor/src/access_ids.rs
@@ -1,0 +1,13 @@
+// Copyright 2024 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use accesskit::NodeId;
+use core::sync::atomic::{AtomicU64, Ordering};
+
+pub const WINDOW_ID: NodeId = NodeId(0);
+pub const TEXT_INPUT_ID: NodeId = NodeId(1);
+
+pub fn next_node_id() -> NodeId {
+    static NEXT: AtomicU64 = AtomicU64::new(2);
+    NodeId(NEXT.fetch_add(1, Ordering::Relaxed))
+}

--- a/examples/rich_editor/src/main.rs
+++ b/examples/rich_editor/src/main.rs
@@ -1,0 +1,413 @@
+// Copyright 2024 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![allow(missing_docs, reason = "We have many as-yet undocumented items.")]
+#![expect(
+    missing_debug_implementations,
+    unreachable_pub,
+    clippy::allow_attributes_without_reason,
+    clippy::cast_possible_truncation,
+    reason = "Deferred"
+)]
+
+use accesskit::{Node, Role, Tree, TreeId, TreeUpdate};
+use anyhow::Result;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+use ui_events_winit::{WindowEventReducer, WindowEventTranslation};
+use vello_cpu::peniko::Color;
+use vello_cpu::peniko::color::PremulRgba8;
+use vello_cpu::{Pixmap, RenderContext, kurbo::Rect};
+use winit::application::ApplicationHandler;
+use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
+use winit::event::{StartCause, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
+use winit::window::Window;
+
+/// The window background color.
+const BACKGROUND_COLOR: Color = Color::from_rgb8(30, 30, 30);
+
+type SoftbufferSurface = softbuffer::Surface<Arc<Window>, Arc<Window>>;
+
+mod access_ids;
+use access_ids::{TEXT_INPUT_ID, WINDOW_ID};
+
+mod text;
+
+const WINDOW_TITLE: &str = "Rich Text Editor";
+
+// Simple struct to hold the state of the renderer
+pub struct ActiveRenderState {
+    // The fields MUST be in this order, so that the surface and AccessKit adapter are dropped before the window
+    surface: SoftbufferSurface,
+    access_adapter: accesskit_winit::Adapter,
+    window: Arc<Window>,
+    sent_initial_access_update: bool,
+}
+
+impl ActiveRenderState {
+    fn access_update(&mut self, editor: &mut text::Editor) {
+        self.access_adapter.update_if_active(|| {
+            let mut update = TreeUpdate {
+                tree_id: TreeId::ROOT,
+                nodes: vec![],
+                tree: (!self.sent_initial_access_update).then(|| Tree::new(WINDOW_ID)),
+                focus: TEXT_INPUT_ID,
+            };
+            if !self.sent_initial_access_update {
+                let mut node = Node::new(Role::Window);
+                node.set_label(WINDOW_TITLE);
+                node.push_child(TEXT_INPUT_ID);
+                update.nodes.push((WINDOW_ID, node));
+                self.sent_initial_access_update = true;
+            }
+            let mut node = Node::new(Role::TextInput);
+            let size = self.window.inner_size();
+            node.set_bounds(accesskit::Rect {
+                x0: 0.0,
+                y0: 0.0,
+                x1: size.width as _,
+                y1: size.height as _,
+            });
+            let rgba = text::BACKGROUND_COLOR.to_rgba8();
+            node.set_background_color(accesskit::Color {
+                red: rgba.r,
+                green: rgba.g,
+                blue: rgba.b,
+                alpha: rgba.a,
+            });
+            editor.accessibility(&mut update, &mut node);
+            update.nodes.push((TEXT_INPUT_ID, node));
+            update
+        });
+    }
+}
+
+enum RenderState {
+    Active(ActiveRenderState),
+    // Cache a window so that it can be reused when the app is resumed after being suspended
+    Suspended(Option<Arc<Window>>),
+}
+
+struct SimpleVelloApp {
+    /// The softbuffer context used to create surfaces for windows.
+    context: Option<softbuffer::Context<Arc<Window>>>,
+
+    /// State for our example where we store the winit Window and the softbuffer Surface.
+    state: RenderState,
+
+    /// The `vello_cpu` render context into which the editor layout is drawn.
+    renderer: RenderContext,
+
+    /// The pixmap that the `vello_cpu` renderer rasterizes into.
+    pixmap: Pixmap,
+
+    /// Our `Editor`, which owns a `parley::RichEditor`.
+    editor: text::Editor,
+
+    /// The last generation of the editor layout that we drew.
+    last_drawn_generation: text::Generation,
+
+    /// The IME cursor area we last sent to the platform.
+    last_sent_ime_cursor_area: parley::BoundingBox,
+
+    /// The event loop proxy required by the AccessKit winit adapter.
+    event_loop_proxy: EventLoopProxy<accesskit_winit::Event>,
+
+    /// Translate winit events into ui-events events.
+    event_reducer: WindowEventReducer,
+}
+
+impl SimpleVelloApp {
+    /// Ensure the `vello_cpu` render context and pixmap match the given size, recreating
+    /// them (and forcing a redraw) if the size has changed.
+    fn handle_resize(&mut self, width: u16, height: u16) {
+        if self.renderer.width() != width || self.renderer.height() != height {
+            self.renderer = RenderContext::new(width, height);
+            self.pixmap = Pixmap::new(width, height);
+            // Force the editor to be re-rasterized into the new pixmap.
+            self.last_drawn_generation = text::Generation::default();
+        }
+    }
+}
+
+impl ApplicationHandler<accesskit_winit::Event> for SimpleVelloApp {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        let RenderState::Suspended(cached_window) = &mut self.state else {
+            return;
+        };
+
+        // Get the winit window cached in a previous Suspended event or else create a new window
+        let window = cached_window
+            .take()
+            .unwrap_or_else(|| create_winit_window(event_loop));
+        let access_adapter = accesskit_winit::Adapter::with_event_loop_proxy(
+            event_loop,
+            &window,
+            self.event_loop_proxy.clone(),
+        );
+        window.set_visible(true);
+        window.set_ime_allowed(true);
+
+        let size = window.inner_size();
+
+        // Create (or reuse) the softbuffer context and create a surface for this window.
+        let context = self
+            .context
+            .get_or_insert_with(|| softbuffer::Context::new(window.clone()).unwrap());
+        let mut surface = softbuffer::Surface::new(context, window.clone()).unwrap();
+        if let (Some(width), Some(height)) =
+            (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
+        {
+            surface.resize(width, height).unwrap();
+        }
+
+        // Ensure the CPU renderer and pixmap match the window size.
+        self.handle_resize(to_nonzero_u16(size.width), to_nonzero_u16(size.height));
+
+        // Save the Window and Surface to a state variable
+        self.state = RenderState::Active(ActiveRenderState {
+            surface,
+            access_adapter,
+            window,
+            sent_initial_access_update: false,
+        });
+
+        event_loop.set_control_flow(ControlFlow::Wait);
+    }
+
+    fn suspended(&mut self, event_loop: &ActiveEventLoop) {
+        if let RenderState::Active(state) = &self.state {
+            self.state = RenderState::Suspended(Some(state.window.clone()));
+        }
+        event_loop.set_control_flow(ControlFlow::Wait);
+    }
+
+    fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: StartCause) {
+        match cause {
+            StartCause::Init => {
+                self.editor.cursor_reset();
+                if let Some(next_time) = self.editor.next_blink_time() {
+                    event_loop.set_control_flow(ControlFlow::WaitUntil(next_time));
+                }
+            }
+            StartCause::ResumeTimeReached { .. } => {
+                self.editor.cursor_blink();
+
+                if let Some(next_time) = self.editor.next_blink_time() {
+                    self.last_drawn_generation = text::Generation::default();
+                    if let RenderState::Active(state) = &self.state {
+                        state.window.request_redraw();
+                    }
+                    event_loop.set_control_flow(ControlFlow::WaitUntil(next_time));
+                }
+            }
+            StartCause::WaitCancelled { .. } => {
+                if let Some(next_time) = self.editor.next_blink_time() {
+                    event_loop.set_control_flow(ControlFlow::WaitUntil(next_time));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: winit::window::WindowId,
+        event: WindowEvent,
+    ) {
+        // Ignore the event (return from the function) if
+        //   - we have no render_state
+        //   - OR the window id of the event doesn't match the window id of our render_state
+        //
+        // Else extract a mutable reference to the render state from its containing option for use below
+        let render_state = match &mut self.state {
+            RenderState::Active(state) if state.window.id() == window_id => state,
+            _ => return,
+        };
+
+        render_state
+            .access_adapter
+            .process_event(&render_state.window, &event);
+
+        if !matches!(
+            event,
+            WindowEvent::KeyboardInput {
+                is_synthetic: true,
+                ..
+            }
+        ) {
+            if let Some(wet) = self
+                .event_reducer
+                .reduce(render_state.window.scale_factor(), &event)
+            {
+                match wet {
+                    WindowEventTranslation::Keyboard(k) => {
+                        self.editor.handle_keyboard_event(&k);
+                    }
+                    WindowEventTranslation::Pointer(p) => {
+                        self.editor.handle_pointer_event(&p);
+                    }
+                }
+            } else {
+                self.editor.handle_event(event.clone());
+            }
+        }
+
+        if self.last_drawn_generation != self.editor.generation() {
+            render_state.window.request_redraw();
+            let area = self.editor.editor().ime_cursor_area();
+            if self.last_sent_ime_cursor_area != area {
+                self.last_sent_ime_cursor_area = area;
+                // Note: on X11 `set_ime_cursor_area` may cause the exclusion area to be obscured
+                // until https://github.com/rust-windowing/winit/pull/3966 is in the Winit release
+                // used by this example.
+                render_state.window.set_ime_cursor_area(
+                    PhysicalPosition::new(
+                        area.x0 + text::INSET as f64,
+                        area.y0 + text::INSET as f64,
+                    ),
+                    PhysicalSize::new(area.width(), area.height()),
+                );
+            }
+        }
+
+        match event {
+            // Exit the event loop when a close is requested (e.g. window's close button is pressed)
+            WindowEvent::CloseRequested => event_loop.exit(),
+
+            // Resize the surface when the window is resized
+            WindowEvent::Resized(size) => {
+                if let (Some(width), Some(height)) =
+                    (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
+                {
+                    render_state.surface.resize(width, height).unwrap();
+                }
+                self.handle_resize(to_nonzero_u16(size.width), to_nonzero_u16(size.height));
+                let editor = self.editor.editor();
+                editor.set_scale(1.0);
+                editor.set_width(Some(size.width as f32 - 2_f32 * text::INSET));
+                if let RenderState::Active(state) = &self.state {
+                    state.window.request_redraw();
+                }
+            }
+
+            // Don't blink the cursor when we're not focused.
+            WindowEvent::Focused(false) => {
+                self.editor.disable_blink();
+                self.editor.cursor_blink();
+                self.last_drawn_generation = text::Generation::default();
+                if let RenderState::Active(state) = &self.state {
+                    state.window.request_redraw();
+                }
+            }
+            // Make sure cursor is visible when we regain focus.
+            WindowEvent::Focused(true) => self.editor.cursor_reset(),
+
+            // This is where all the rendering happens
+            WindowEvent::RedrawRequested => {
+                // Send an accessibility update if accessibility is active.
+                render_state.access_update(&mut self.editor);
+
+                let width = self.renderer.width();
+                let height = self.renderer.height();
+
+                // Sometimes the pixmap is stale and needs to be redrawn.
+                if self.last_drawn_generation != self.editor.generation() {
+                    // Clear the render context and paint the background.
+                    self.renderer.reset();
+                    self.renderer.set_paint(BACKGROUND_COLOR);
+                    self.renderer
+                        .fill_rect(&Rect::new(0.0, 0.0, width as f64, height as f64));
+
+                    self.last_drawn_generation = self.editor.draw(&mut self.renderer);
+
+                    // Rasterize the scene into the pixmap.
+                    self.renderer.flush();
+                    self.renderer.render_to_pixmap(&mut self.pixmap);
+                }
+
+                // Copy the pixmap into the softbuffer surface and present it.
+                let mut buffer = render_state.surface.buffer_mut().unwrap();
+                for (dst, src) in buffer.iter_mut().zip(self.pixmap.data()) {
+                    *dst = premul_rgba8_to_softbuffer(*src);
+                }
+                render_state.window.pre_present_notify();
+                buffer.present().unwrap();
+            }
+            _ => {}
+        }
+    }
+
+    fn user_event(&mut self, _: &ActiveEventLoop, event: accesskit_winit::Event) {
+        let render_state = match &mut self.state {
+            RenderState::Active(state) if state.window.id() == event.window_id => state,
+            _ => return,
+        };
+
+        match event.window_event {
+            accesskit_winit::WindowEvent::InitialTreeRequested => {
+                render_state.access_update(&mut self.editor);
+            }
+            accesskit_winit::WindowEvent::ActionRequested(req) => {
+                if req.target_node == TEXT_INPUT_ID {
+                    self.editor.handle_accesskit_action_request(&req);
+                    if self.last_drawn_generation != self.editor.generation() {
+                        render_state.window.request_redraw();
+                    }
+                }
+            }
+            accesskit_winit::WindowEvent::AccessibilityDeactivated => {
+                render_state.sent_initial_access_update = false;
+            }
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    // Create a winit event loop:
+    let event_loop = EventLoop::with_user_event().build()?;
+
+    // Setup a bunch of state:
+    let mut app = SimpleVelloApp {
+        context: None,
+        state: RenderState::Suspended(None),
+        // These are placeholders; they are recreated to match the window size in `resumed`.
+        renderer: RenderContext::new(1, 1),
+        pixmap: Pixmap::new(1, 1),
+        editor: text::Editor::new(text::RICH_TEXT),
+        last_drawn_generation: text::Generation::default(),
+        last_sent_ime_cursor_area: parley::BoundingBox::new(f64::NAN, f64::NAN, f64::NAN, f64::NAN),
+        event_loop_proxy: event_loop.create_proxy(),
+        event_reducer: WindowEventReducer::default(),
+    };
+
+    // Run the winit event loop
+    event_loop
+        .run_app(&mut app)
+        .expect("Couldn't run event loop");
+    let text = app.editor.text();
+    print!("{text}");
+    Ok(())
+}
+
+/// Helper function that creates a Winit window and returns it (wrapped in an Arc for sharing between threads)
+fn create_winit_window(event_loop: &ActiveEventLoop) -> Arc<Window> {
+    let attr = Window::default_attributes()
+        .with_inner_size(LogicalSize::new(1044, 800))
+        .with_resizable(true)
+        .with_title(WINDOW_TITLE)
+        .with_visible(false);
+    Arc::new(event_loop.create_window(attr).unwrap())
+}
+
+/// Clamp a physical pixel dimension to a non-zero `u16`, as required by `vello_cpu`.
+fn to_nonzero_u16(value: u32) -> u16 {
+    value.clamp(1, u16::MAX as u32) as u16
+}
+
+/// Convert a premultiplied RGBA8 pixel into the `0RGB` `u32` format expected by softbuffer.
+fn premul_rgba8_to_softbuffer(pixel: PremulRgba8) -> u32 {
+    (u32::from(pixel.r) << 16) | (u32::from(pixel.g) << 8) | u32::from(pixel.b)
+}

--- a/examples/rich_editor/src/text.rs
+++ b/examples/rich_editor/src/text.rs
@@ -1,0 +1,567 @@
+// Copyright 2024 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
+
+use accesskit::{Node, TextDecoration, TextDecorationStyle, TreeUpdate};
+use core::default::Default;
+use parley::editing::SplitString;
+use parley::layout::{PositionedLayoutItem, Style};
+use parley::{FontWeight, GenericFamily, StyleProperty};
+use peniko::{
+    Color, Fill,
+    color::{AlphaColor, Srgb, palette},
+    kurbo::{Affine, Line, Shape, Stroke},
+};
+use std::time::Duration;
+use ui_events::pointer::PointerButton;
+use ui_events::{
+    keyboard::{Key, KeyboardEvent, NamedKey},
+    pointer::{PointerButtonEvent, PointerEvent, PointerInfo, PointerState, PointerType},
+};
+use vello_cpu::{Glyph, RenderContext};
+use winit::event::{Ime, WindowEvent};
+
+pub use parley::editing::Generation;
+use parley::{FontContext, LayoutContext, RichEditor, RichEditorDriver};
+
+use crate::access_ids::next_node_id;
+
+pub const BACKGROUND_COLOR: AlphaColor<Srgb> = palette::css::STEEL_BLUE;
+pub const INSET: f32 = 32.0;
+
+/// A newtype wrapper around [`peniko::Color`] used as the [`Brush`](parley::style::Brush) for text.
+///
+/// `vello_cpu`'s `PaintType` uses its own image/gradient types, so we can't pass a
+/// `peniko::Brush` directly. This example only ever uses solid-color brushes.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ColorBrush(pub Color);
+
+impl Default for ColorBrush {
+    fn default() -> Self {
+        Self(Color::BLACK)
+    }
+}
+
+impl From<Color> for ColorBrush {
+    fn from(color: Color) -> Self {
+        Self(color)
+    }
+}
+
+pub struct Editor {
+    font_cx: FontContext,
+    layout_cx: LayoutContext<ColorBrush>,
+    editor: RichEditor<ColorBrush>,
+    cursor_visible: bool,
+    start_time: Option<Instant>,
+    blink_period: Duration,
+}
+
+fn convert_rect(rect: &parley::BoundingBox) -> peniko::kurbo::Rect {
+    peniko::kurbo::Rect::new(rect.x0, rect.y0, rect.x1, rect.y1)
+}
+
+/// Set the current paint from a [`ColorBrush`].
+fn set_brush(renderer: &mut RenderContext, brush: &ColorBrush) {
+    renderer.set_paint(brush.0);
+}
+
+fn to_accesskit_color(brush: &ColorBrush) -> accesskit::Color {
+    let rgba = brush.0.to_rgba8();
+    accesskit::Color {
+        red: rgba.r,
+        green: rgba.g,
+        blue: rgba.b,
+        alpha: rgba.a,
+    }
+}
+
+fn set_accesskit_brush_properties(node: &mut Node, style: &Style<ColorBrush>) {
+    node.set_foreground_color(to_accesskit_color(&style.brush));
+    if let Some(deco) = &style.underline {
+        node.set_underline(TextDecoration {
+            style: TextDecorationStyle::Solid,
+            color: to_accesskit_color(&deco.brush),
+        });
+    }
+    if let Some(deco) = &style.strikethrough {
+        node.set_strikethrough(TextDecoration {
+            style: TextDecorationStyle::Solid,
+            color: to_accesskit_color(&deco.brush),
+        });
+    }
+}
+
+/// Style the first occurrence of `word` in `text` with `property`, if present.
+fn style_word(
+    editor: &mut RichEditor<ColorBrush>,
+    text: &str,
+    word: &str,
+    property: StyleProperty<'static, ColorBrush>,
+) {
+    if let Some(start) = text.find(word) {
+        editor.set_style(property, start..start + word.len());
+    }
+}
+
+impl Editor {
+    pub fn new(text: &str) -> Self {
+        let mut editor = RichEditor::new(32.0);
+        editor.set_text(text);
+        editor.set_scale(1.0);
+        let styles = editor.edit_styles();
+        styles.insert(GenericFamily::SystemUi.into());
+        styles.insert(StyleProperty::Brush(ColorBrush(palette::css::WHITE)));
+
+        // Demonstrate that spans of the same text can carry independent styles.
+        style_word(
+            &mut editor,
+            text,
+            "bold",
+            StyleProperty::FontWeight(FontWeight::BOLD),
+        );
+        style_word(
+            &mut editor,
+            text,
+            "colored",
+            StyleProperty::Brush(ColorBrush(palette::css::GOLD)),
+        );
+        style_word(&mut editor, text, "larger", StyleProperty::FontSize(48.0));
+
+        Self {
+            font_cx: FontContext::default(),
+            layout_cx: LayoutContext::default(),
+            editor,
+            cursor_visible: false,
+            start_time: None,
+            // TODO: Why initialize to zero?
+            blink_period: Duration::ZERO,
+        }
+    }
+
+    fn driver(&mut self) -> RichEditorDriver<'_, ColorBrush> {
+        self.editor.driver(&mut self.font_cx, &mut self.layout_cx)
+    }
+
+    pub fn editor(&mut self) -> &mut RichEditor<ColorBrush> {
+        &mut self.editor
+    }
+
+    pub fn text(&self) -> SplitString<'_> {
+        self.editor.text()
+    }
+
+    /// Toggle bold on the current selection.
+    ///
+    /// If the start of the selection is already bold, the selection is set to normal weight;
+    /// otherwise it's set to bold.
+    fn toggle_bold_selection(&mut self) {
+        let range = self.editor.raw_selection().text_range();
+        if range.is_empty() {
+            return;
+        }
+        // Spans are never removed, only appended, so the *last* matching entry is the one
+        // that currently wins at this position; `any` would incorrectly match stale spans.
+        let is_bold = self
+            .editor
+            .style_at(range.start)
+            .filter_map(|(_, property)| match property {
+                StyleProperty::FontWeight(weight) => Some(*weight),
+                _ => None,
+            })
+            .last()
+            == Some(FontWeight::BOLD);
+        let weight = if is_bold {
+            FontWeight::NORMAL
+        } else {
+            FontWeight::BOLD
+        };
+        self.editor
+            .set_style(StyleProperty::FontWeight(weight), range);
+    }
+
+    pub fn cursor_reset(&mut self) {
+        self.start_time = Some(Instant::now());
+        // TODO: for real world use, this should be reading from the system settings
+        self.blink_period = Duration::from_millis(500);
+        self.cursor_visible = true;
+    }
+
+    pub fn disable_blink(&mut self) {
+        self.start_time = None;
+    }
+
+    pub fn next_blink_time(&self) -> Option<Instant> {
+        self.start_time.map(|start_time| {
+            let phase = Instant::now().duration_since(start_time);
+
+            start_time
+                + Duration::from_nanos(
+                    ((phase.as_nanos() / self.blink_period.as_nanos() + 1)
+                        * self.blink_period.as_nanos()) as u64,
+                )
+        })
+    }
+
+    pub fn cursor_blink(&mut self) {
+        self.cursor_visible = self.start_time.is_some_and(|start_time| {
+            let elapsed = Instant::now().duration_since(start_time);
+            (elapsed.as_millis() / self.blink_period.as_millis()).is_multiple_of(2)
+        });
+    }
+
+    pub fn handle_keyboard_event(&mut self, event: &KeyboardEvent) {
+        match event {
+            KeyboardEvent {
+                state,
+                key,
+                modifiers,
+                ..
+            } if !self.editor.is_composing() && state.is_down() => {
+                self.cursor_reset();
+                #[allow(unused)]
+                let action_mod = if cfg!(target_os = "macos") {
+                    modifiers.meta()
+                } else {
+                    modifiers.ctrl()
+                };
+                if action_mod
+                    && let Key::Character(c) = key
+                    && c.to_lowercase() == "b"
+                {
+                    self.toggle_bold_selection();
+                    return;
+                }
+                let mut drv = self.editor.driver(&mut self.font_cx, &mut self.layout_cx);
+                let shift = modifiers.shift();
+
+                match key {
+                    #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+                    Key::Character(c) if action_mod && matches!(c.as_str(), "c" | "x" | "v") => {
+                        use clipboard_rs::{Clipboard, ClipboardContext};
+                        match c.to_lowercase().as_str() {
+                            "c" => {
+                                if let Some(text) = drv.editor.selected_text() {
+                                    let cb = ClipboardContext::new().unwrap();
+                                    cb.set_text(text.to_owned()).ok();
+                                }
+                            }
+                            "x" => {
+                                if let Some(text) = drv.editor.selected_text() {
+                                    let cb = ClipboardContext::new().unwrap();
+                                    cb.set_text(text.to_owned()).ok();
+                                    drv.delete_selection();
+                                }
+                            }
+                            "v" => {
+                                let cb = ClipboardContext::new().unwrap();
+                                let text = cb.get_text().unwrap_or_default();
+                                drv.insert_or_replace_selection(&text);
+                            }
+                            _ => (),
+                        }
+                    }
+                    Key::Character(c) if action_mod && matches!(c.to_lowercase().as_str(), "a") => {
+                        if shift {
+                            drv.collapse_selection();
+                        } else {
+                            drv.select_all();
+                        }
+                    }
+                    Key::Named(NamedKey::ArrowLeft) => {
+                        if action_mod {
+                            if shift {
+                                drv.select_word_left();
+                            } else {
+                                drv.move_word_left();
+                            }
+                        } else if shift {
+                            drv.select_left();
+                        } else {
+                            drv.move_left();
+                        }
+                    }
+                    Key::Named(NamedKey::ArrowRight) => {
+                        if action_mod {
+                            if shift {
+                                drv.select_word_right();
+                            } else {
+                                drv.move_word_right();
+                            }
+                        } else if shift {
+                            drv.select_right();
+                        } else {
+                            drv.move_right();
+                        }
+                    }
+                    Key::Named(NamedKey::ArrowUp) => {
+                        if shift {
+                            drv.select_up();
+                        } else {
+                            drv.move_up();
+                        }
+                    }
+                    Key::Named(NamedKey::ArrowDown) => {
+                        if shift {
+                            drv.select_down();
+                        } else {
+                            drv.move_down();
+                        }
+                    }
+                    Key::Named(NamedKey::Home) => {
+                        if action_mod {
+                            if shift {
+                                drv.select_to_text_start();
+                            } else {
+                                drv.move_to_text_start();
+                            }
+                        } else if shift {
+                            drv.select_to_line_start();
+                        } else {
+                            drv.move_to_line_start();
+                        }
+                    }
+                    Key::Named(NamedKey::End) => {
+                        let this = &mut *self;
+                        let mut drv = this.driver();
+
+                        if action_mod {
+                            if shift {
+                                drv.select_to_text_end();
+                            } else {
+                                drv.move_to_text_end();
+                            }
+                        } else if shift {
+                            drv.select_to_line_end();
+                        } else {
+                            drv.move_to_line_end();
+                        }
+                    }
+                    Key::Named(NamedKey::Delete) => {
+                        if action_mod {
+                            drv.delete_word();
+                        } else {
+                            drv.delete();
+                        }
+                    }
+                    Key::Named(NamedKey::Backspace) => {
+                        if action_mod {
+                            drv.backdelete_word();
+                        } else {
+                            drv.backdelete();
+                        }
+                    }
+                    Key::Named(NamedKey::Enter) => {
+                        drv.insert_or_replace_selection("\n");
+                    }
+                    Key::Character(s) => {
+                        drv.insert_or_replace_selection(s);
+                    }
+                    _ => (),
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_pointer_event(&mut self, event: &PointerEvent) {
+        let pressed = |i: &PointerInfo, s: &PointerState| {
+            s.buttons.contains(PointerButton::Primary)
+                || (s.pressure >= 0.5
+                    && matches!(i.pointer_type, PointerType::Touch | PointerType::Pen))
+        };
+        match event {
+            // TODO: Handle touch long press specially, for SelectWordAtPoint.
+            PointerEvent::Down(PointerButtonEvent { pointer, state, .. })
+                if pressed(pointer, state) && !self.editor.is_composing() =>
+            {
+                self.cursor_reset();
+                let mut drv = self.editor.driver(&mut self.font_cx, &mut self.layout_cx);
+                let cursor_pos = (
+                    state.position.x as f32 - INSET,
+                    state.position.y as f32 - INSET,
+                );
+                match state.count {
+                    2 => drv.select_word_at_point(cursor_pos.0, cursor_pos.1),
+                    3 => drv.select_hard_line_at_point(cursor_pos.0, cursor_pos.1),
+                    _ => {
+                        if state.modifiers.shift() {
+                            drv.shift_click_extension(cursor_pos.0, cursor_pos.1);
+                        } else {
+                            drv.move_to_point(cursor_pos.0, cursor_pos.1);
+                        }
+                    }
+                }
+            }
+            PointerEvent::Move(u)
+                if pressed(&u.pointer, &u.current) && !self.editor.is_composing() =>
+            {
+                let cursor_pos = (
+                    u.current.position.x as f32 - INSET,
+                    u.current.position.y as f32 - INSET,
+                );
+                self.cursor_reset();
+                self.driver()
+                    .extend_selection_to_point(cursor_pos.0, cursor_pos.1);
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_event(&mut self, event: WindowEvent) {
+        match event {
+            WindowEvent::Resized(size) => {
+                self.editor
+                    .set_width(Some(size.width as f32 - 2_f32 * INSET));
+            }
+            WindowEvent::Ime(Ime::Disabled) => {
+                self.driver().clear_compose();
+            }
+            WindowEvent::Ime(Ime::Commit(text)) => {
+                self.driver().insert_or_replace_selection(&text);
+            }
+            WindowEvent::Ime(Ime::Preedit(text, cursor)) => {
+                if text.is_empty() {
+                    self.driver().clear_compose();
+                } else {
+                    self.driver().set_compose(&text, cursor);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_accesskit_action_request(&mut self, req: &accesskit::ActionRequest) {
+        if req.action == accesskit::Action::SetTextSelection
+            && let Some(accesskit::ActionData::SetTextSelection(selection)) = &req.data
+        {
+            self.driver().select_from_accesskit(selection);
+        }
+    }
+
+    /// Return the current `Generation` of the layout.
+    pub fn generation(&self) -> Generation {
+        self.editor.generation()
+    }
+
+    /// Draw into the `vello_cpu` render context.
+    ///
+    /// Returns drawn `Generation`.
+    pub fn draw(&mut self, renderer: &mut RenderContext) -> Generation {
+        let transform = Affine::translate((INSET as f64, INSET as f64));
+        renderer.set_transform(transform);
+        renderer.set_fill_rule(Fill::NonZero);
+        renderer.set_paint(BACKGROUND_COLOR);
+        self.editor.selection_geometry_with(|rect, _| {
+            renderer.fill_rect(&convert_rect(&rect));
+        });
+        if self.cursor_visible
+            && let Some(cursor) = self.editor.cursor_geometry(1.5)
+        {
+            renderer.set_paint(palette::css::WHITE);
+            renderer.fill_rect(&convert_rect(&cursor));
+        }
+        let layout = self.editor.layout(&mut self.font_cx, &mut self.layout_cx);
+        for line in layout.lines() {
+            for item in line.items() {
+                let PositionedLayoutItem::GlyphRun(glyph_run) = item else {
+                    continue;
+                };
+                let style = glyph_run.style();
+                // We draw underlines under the text, then the strikethrough on top, following:
+                // https://drafts.csswg.org/css-text-decor/#painting-order
+                if let Some(underline) = &style.underline {
+                    let run_metrics = glyph_run.run().font_metrics();
+                    let offset = match underline.offset {
+                        Some(offset) => offset,
+                        None => run_metrics.underline_offset,
+                    };
+                    let width = match underline.size {
+                        Some(size) => size,
+                        None => run_metrics.underline_size,
+                    };
+                    // The `offset` is the distance from the baseline to the top of the underline
+                    // so we move the line down by half the width
+                    // Remember that we are using a y-down coordinate system
+                    // If there's a custom width, because this is an underline, we want the custom
+                    // width to go down from the default expectation
+                    let y = glyph_run.baseline() - offset + width / 2.;
+
+                    let line = Line::new(
+                        (glyph_run.offset() as f64, y as f64),
+                        ((glyph_run.offset() + glyph_run.advance()) as f64, y as f64),
+                    );
+                    renderer.set_stroke(Stroke::new(width.into()));
+                    set_brush(renderer, &style.brush);
+                    renderer.stroke_path(&line.to_path(0.0));
+                }
+                let run = glyph_run.run();
+                let font = run.font();
+                let font_size = run.font_size();
+                let synthesis = run.synthesis();
+                let glyph_xform = synthesis
+                    .skew()
+                    .map(|angle| Affine::skew(angle.to_radians().tan() as f64, 0.0));
+                set_brush(renderer, &style.brush);
+                let normalized_coords =
+                    &Vec::from_iter(run.normalized_coords().iter().map(|c| c.to_bits()));
+                let mut builder = renderer
+                    .glyph_run(&font.font)
+                    .font_size(font_size)
+                    .hint(true)
+                    .normalized_coords(normalized_coords);
+                if let Some(glyph_xform) = glyph_xform {
+                    builder = builder.glyph_transform(glyph_xform);
+                }
+                builder.fill_glyphs(glyph_run.positioned_glyphs().map(|glyph| Glyph {
+                    id: glyph.id,
+                    x: glyph.x,
+                    y: glyph.y,
+                }));
+                if let Some(strikethrough) = &style.strikethrough {
+                    let run_metrics = glyph_run.run().font_metrics();
+                    let offset = match strikethrough.offset {
+                        Some(offset) => offset,
+                        None => run_metrics.strikethrough_offset,
+                    };
+                    let width = match strikethrough.size {
+                        Some(size) => size,
+                        None => run_metrics.strikethrough_size,
+                    };
+                    // The `offset` is the distance from the baseline to the *top* of the strikethrough
+                    // so we calculate the middle y-position of the strikethrough based on the font's
+                    // standard strikethrough width.
+                    // Remember that we are using a y-down coordinate system
+                    let y = glyph_run.baseline() - offset + run_metrics.strikethrough_size / 2.;
+
+                    let line = Line::new(
+                        (glyph_run.offset() as f64, y as f64),
+                        ((glyph_run.offset() + glyph_run.advance()) as f64, y as f64),
+                    );
+                    renderer.set_stroke(Stroke::new(width.into()));
+                    set_brush(renderer, &style.brush);
+                    renderer.stroke_path(&line.to_path(0.0));
+                }
+            }
+        }
+        self.editor.generation()
+    }
+
+    pub fn accessibility(&mut self, update: &mut TreeUpdate, node: &mut Node) {
+        let mut drv = self.editor.driver(&mut self.font_cx, &mut self.layout_cx);
+        drv.accessibility(
+            update,
+            node,
+            next_node_id,
+            INSET.into(),
+            INSET.into(),
+            set_accesskit_brush_properties,
+        );
+    }
+}
+
+pub const RICH_TEXT: &str = "This is a rich text editor example, built on parley's RichEditor.\n\nUnlike a plain editor, this one supports multiple styles applied to different ranges of the same text: some words are bold, some are colored, and some are larger.\n\nSelect some text and press Ctrl+B (Cmd+B on macOS) to toggle bold on the selection.";

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -18,7 +18,14 @@ workspace = true
 
 [features]
 default = ["system"]
-std = ["fontique/std", "parley_engine/std", "peniko/std", "skrifa?/std", "parlance/std", "attributed_text/std"]
+std = [
+    "fontique/std",
+    "parley_engine/std",
+    "peniko/std",
+    "skrifa?/std",
+    "parlance/std",
+    "attributed_text/std"
+]
 libm = ["fontique/libm", "parley_engine/libm", "peniko/libm", "skrifa?/libm", "dep:core_maths"]
 # Enables support for system font backends
 system = ["std", "fontique/system"]

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -24,7 +24,7 @@ std = [
     "peniko/std",
     "skrifa?/std",
     "parlance/std",
-    "attributed_text/std"
+    "attributed_text/std",
 ]
 libm = ["fontique/libm", "parley_engine/libm", "peniko/libm", "skrifa?/libm", "dep:core_maths"]
 # Enables support for system font backends

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 
 [features]
 default = ["system"]
-std = ["fontique/std", "parley_engine/std", "peniko/std", "skrifa?/std", "parlance/std"]
+std = ["fontique/std", "parley_engine/std", "peniko/std", "skrifa?/std", "parlance/std", "attributed_text/std"]
 libm = ["fontique/libm", "parley_engine/libm", "peniko/libm", "skrifa?/libm", "dep:core_maths"]
 # Enables support for system font backends
 system = ["std", "fontique/system"]
@@ -34,6 +34,7 @@ linebender_resource_handle = { workspace = true }
 fontique = { workspace = true }
 parlance = { workspace = true }
 parley_engine = { workspace = true }
+attributed_text = { workspace = true }
 core_maths = { version = "0.1.1", optional = true }
 accesskit = { workspace = true, optional = true }
 hashbrown = { workspace = true }

--- a/parley/src/editing/mod.rs
+++ b/parley/src/editing/mod.rs
@@ -3,8 +3,10 @@
 
 mod cursor;
 mod editor;
+mod rich_editor;
 mod selection;
 
 pub use self::cursor::*;
 pub use self::editor::*;
+pub use self::rich_editor::*;
 pub use self::selection::*;

--- a/parley/src/editing/rich_editor.rs
+++ b/parley/src/editing/rich_editor.rs
@@ -1,105 +1,95 @@
-// Copyright 2024 the Parley Authors
+// Copyright 2026 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! A simple plain text editor and related types.
+//! A text editor supporting multiple styles applied to ranges ("spans") of the text.
 
-use alloc::{borrow::ToOwned, string::String, vec::Vec};
-use core::{
-    cmp::PartialEq,
-    default::Default,
-    fmt::{Debug, Display},
-    num::NonZeroUsize,
-    ops::Range,
-};
+use alloc::{string::String, vec::Vec};
+use core::{cmp::PartialEq, default::Default, fmt::Debug, num::NonZeroUsize, ops::Range};
 
-use crate::editing::{Cursor, Selection};
+use attributed_text::{AttributedText, TextRange};
+
+use crate::editing::{Cursor, Generation, Selection, SplitString};
 use crate::layout::{Affinity, Alignment, AlignmentOptions, Layout};
 use crate::style::Brush;
-use crate::{BoundingBox, FontContext, LayoutContext, StyleProperty, StyleSet};
+use crate::{BoundingBox, FontContext, LayoutContext, StyleSet};
 
 #[cfg(feature = "accesskit")]
 use crate::layout::LayoutAccessibility;
 #[cfg(feature = "accesskit")]
 use accesskit::{Node, NodeId, TreeUpdate};
 
-/// Opaque representation of a generation.
+/// A style applied to a range of text, owned for the lifetime of a [`RichEditor`].
+type StyleProperty<Brush> = crate::StyleProperty<'static, Brush>;
+
+/// Compute the new range for a style span after `old_range` in the text is replaced by
+/// `new_len` bytes of new content.
 ///
-/// Obtained from [`PlainEditor::generation`].
-// Overflow handling: the generations are only compared,
-// so wrapping is fine. This could only fail if exactly
-// `u32::MAX` generations happen between drawing
-// operations. This is implausible and so can be ignored.
-#[derive(PartialEq, Eq, Default, Clone, Copy, Debug)]
-pub struct Generation(pub u32);
-
-impl Generation {
-    /// Make it not what it currently is.
-    pub(crate) fn nudge(&mut self) {
-        self.0 = self.0.wrapping_add(1);
+/// A span which ends exactly where the edit starts absorbs the new content, so that typing
+/// at the end of a styled run continues in that style. Returns `None` if the edit fully
+/// consumes the span.
+fn shift_span_range(
+    span: Range<usize>,
+    old_range: Range<usize>,
+    new_len: usize,
+) -> Option<Range<usize>> {
+    let old_len = old_range.len();
+    if new_len == old_len {
+        return Some(span);
     }
-}
-
-/// A string which is potentially discontiguous in memory.
-///
-/// This is returned by [`PlainEditor::text`], as the IME preedit
-/// area needs to be efficiently excluded from its return value.
-#[derive(Debug, Clone, Copy)]
-pub struct SplitString<'source>([&'source str; 2]);
-
-impl<'source> SplitString<'source> {
-    /// Construct a `SplitString` from its two constituent parts.
-    pub(crate) fn new(parts: [&'source str; 2]) -> Self {
-        Self(parts)
-    }
-
-    /// Get the characters of this string.
-    pub fn chars(self) -> impl Iterator<Item = char> + 'source {
-        self.into_iter().flat_map(str::chars)
-    }
-}
-
-impl PartialEq<&'_ str> for SplitString<'_> {
-    fn eq(&self, other: &&'_ str) -> bool {
-        let [a, b] = self.0;
-        let mid = a.len();
-        match other.split_at_checked(mid) {
-            Some((a_1, b_1)) => a_1 == a && b_1 == b,
-            None => false,
+    // Translate a position which lies at or after `old_range.end` by the change in length.
+    let shift = |index: usize| -> usize {
+        if new_len >= old_len {
+            index + (new_len - old_len)
+        } else {
+            index - (old_len - new_len)
         }
-    }
-}
-// We intentionally choose not to:
-// impl PartialEq<Self> for SplitString<'_> {}
-// for simplicity, as the impl wouldn't be useful and is non-trivial
+    };
 
-impl Display for SplitString<'_> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let [a, b] = self.0;
-        write!(f, "{a}{b}")
+    // Entirely before the edit: unaffected.
+    if span.end < old_range.start {
+        return Some(span);
     }
+    // Touches the edit's start: absorb the new content, continuing this span's style.
+    if span.end == old_range.start {
+        return Some(span.start..span.end + new_len);
+    }
+    // Entirely after the edit: shift both ends.
+    if span.start >= old_range.end {
+        return Some(shift(span.start)..shift(span.end));
+    }
+
+    // The span overlaps the edited range.
+    let new_start = if span.start <= old_range.start {
+        span.start
+    } else {
+        // The span started inside the edited range; it now begins right after the replacement.
+        old_range.start + new_len
+    };
+    let new_end = if span.end > old_range.end {
+        // The span extends past the edit; shift its end like a span entirely after it would.
+        shift(span.end)
+    } else {
+        // The span's end was inside the edited range; clip it to just before the edit.
+        old_range.start
+    };
+    (new_start < new_end).then_some(new_start..new_end)
 }
 
-/// Iterate through the source strings.
-impl<'source> IntoIterator for SplitString<'source> {
-    type Item = &'source str;
-    type IntoIter = <[&'source str; 2] as IntoIterator>::IntoIter;
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-/// Basic plain text editor with a single style applied to the entire text.
+/// A text editor supporting multiple styles applied to ranges of the text.
 ///
-/// Internally, this is a wrapper around a string buffer and its corresponding [`Layout`],
-/// which is kept up-to-date as needed.
-/// This layout is invalidated by a number.
+/// This is the rich-text counterpart to [`PlainEditor`](crate::editing::PlainEditor): instead of
+/// a single [`StyleSet`] applied to the whole buffer, styles can additionally be applied to
+/// arbitrary byte ranges via [`RichEditor::set_style`].
+///
+/// Internally, this is a wrapper around an [`AttributedText`] buffer and its corresponding
+/// [`Layout`], which is kept up-to-date as needed.
 #[derive(Clone, Debug)]
-pub struct PlainEditor<T>
+pub struct RichEditor<T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,
 {
     layout: Layout<T>,
-    buffer: String,
+    spans: AttributedText<String, StyleProperty<T>>,
     default_style: StyleSet<T>,
     #[cfg(feature = "accesskit")]
     layout_access: LayoutAccessibility,
@@ -113,21 +103,12 @@ where
     font_size: f32,
     scale: f32,
     quantize: bool,
-    // Simple tracking of when the layout needs to be updated
-    // before it can be used for `Selection` calculations or
-    // for drawing.
-    // Not all operations on `PlainEditor` need to operate on a
-    // clean layout, and not all operations trigger a layout.
     layout_dirty: bool,
-    // TODO: We could avoid redoing the full text layout if only
-    // linebreaking or alignment were changed.
-    // linebreak_dirty: bool,
-    // alignment_dirty: bool,
     alignment: Alignment,
     generation: Generation,
 }
 
-impl<T> PlainEditor<T>
+impl<T> RichEditor<T>
 where
     T: Brush,
 {
@@ -135,7 +116,7 @@ where
     pub fn new(font_size: f32) -> Self {
         Self {
             default_style: StyleSet::new(font_size),
-            buffer: String::default(),
+            spans: AttributedText::new(String::new()),
             layout: Layout::default(),
             #[cfg(feature = "accesskit")]
             layout_access: LayoutAccessibility::default(),
@@ -148,28 +129,25 @@ where
             quantize: true,
             layout_dirty: true,
             alignment: Alignment::Start,
-            // We don't use the `default` value to start with, as our consumers
-            // will choose to use that as their initial value, but will probably need
-            // to redraw if they haven't already.
             generation: Generation(1),
         }
     }
 }
 
-/// A short-lived wrapper around [`PlainEditor`].
+/// A short-lived wrapper around [`RichEditor`].
 ///
 /// This can perform operations which require the editor's layout to
 /// be up-to-date by refreshing it as necessary.
-pub struct PlainEditorDriver<'a, T>
+pub struct RichEditorDriver<'a, T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,
 {
-    pub editor: &'a mut PlainEditor<T>,
+    pub editor: &'a mut RichEditor<T>,
     pub font_cx: &'a mut FontContext,
     pub layout_cx: &'a mut LayoutContext<T>,
 }
 
-impl<T> PlainEditorDriver<'_, T>
+impl<T> RichEditorDriver<'_, T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,
 {
@@ -195,12 +173,10 @@ where
         let old_selection = self.editor.selection;
         let selection_range = old_selection.text_range();
         let range = selection_range.start.saturating_sub(len.get())..selection_range.start;
-        if range.is_empty() || !self.editor.buffer.is_char_boundary(range.start) {
+        if range.is_empty() || !self.editor.spans.text().is_char_boundary(range.start) {
             return;
         }
-        self.editor.buffer.replace_range(range.clone(), "");
-        self.editor
-            .update_compose_for_replaced_range(range.clone(), 0);
+        self.editor.replace_text(range.clone(), "");
         self.update_layout();
         let old_anchor = old_selection.anchor();
         let old_focus = old_selection.focus();
@@ -236,12 +212,11 @@ where
             ..selection_range
                 .end
                 .saturating_add(len.get())
-                .min(self.editor.buffer.len());
-        if range.is_empty() || !self.editor.buffer.is_char_boundary(range.end) {
+                .min(self.editor.spans.len());
+        if range.is_empty() || !self.editor.spans.text().is_char_boundary(range.end) {
             return;
         }
-        self.editor.buffer.replace_range(range.clone(), "");
-        self.editor.update_compose_for_replaced_range(range, 0);
+        self.editor.replace_text(range, "");
         self.update_layout();
     }
 
@@ -258,8 +233,7 @@ where
                 .map(|cluster| cluster.text_range())
                 .and_then(|range| (!range.is_empty()).then_some(range))
             {
-                self.editor.buffer.replace_range(range.clone(), "");
-                self.editor.update_compose_for_replaced_range(range, 0);
+                self.editor.replace_text(range, "");
                 self.update_layout();
             }
         } else {
@@ -273,9 +247,8 @@ where
             let focus = self.editor.selection.focus();
             let start = focus.index();
             let end = focus.next_logical_word(&self.editor.layout).index();
-            if self.editor.buffer.get(start..end).is_some() {
-                self.editor.buffer.replace_range(start..end, "");
-                self.editor.update_compose_for_replaced_range(start..end, 0);
+            if self.editor.spans.text().get(start..end).is_some() {
+                self.editor.replace_text(start..end, "");
                 self.update_layout();
                 self.editor.set_selection(
                     Cursor::from_byte_index(&self.editor.layout, start, Affinity::Downstream)
@@ -306,7 +279,8 @@ where
                     // Otherwise, delete the previous character
                     let Some((start, _)) = self
                         .editor
-                        .buffer
+                        .spans
+                        .text()
                         .get(..end)
                         .and_then(|str| str.char_indices().next_back())
                     else {
@@ -314,8 +288,7 @@ where
                     };
                     start
                 };
-                self.editor.buffer.replace_range(start..end, "");
-                self.editor.update_compose_for_replaced_range(start..end, 0);
+                self.editor.replace_text(start..end, "");
                 self.update_layout();
                 self.editor.set_selection(
                     Cursor::from_byte_index(&self.editor.layout, start, Affinity::Downstream)
@@ -333,9 +306,8 @@ where
             let focus = self.editor.selection.focus();
             let end = focus.index();
             let start = focus.previous_logical_word(&self.editor.layout).index();
-            if self.editor.buffer.get(start..end).is_some() {
-                self.editor.buffer.replace_range(start..end, "");
-                self.editor.update_compose_for_replaced_range(start..end, 0);
+            if self.editor.spans.text().get(start..end).is_some() {
+                self.editor.replace_text(start..end, "");
                 self.update_layout();
                 self.editor.set_selection(
                     Cursor::from_byte_index(&self.editor.layout, start, Affinity::Downstream)
@@ -364,22 +336,13 @@ where
         debug_assert!(!text.is_empty());
         debug_assert!(cursor.map(|cursor| cursor.1 <= text.len()).unwrap_or(true));
 
-        let start = if let Some(preedit_range) = &self.editor.compose {
-            self.editor
-                .buffer
-                .replace_range(preedit_range.clone(), text);
+        let start = if let Some(preedit_range) = self.editor.compose.clone() {
+            self.editor.replace_text(preedit_range.clone(), text);
             preedit_range.start
         } else {
-            if self.editor.selection.is_collapsed() {
-                self.editor
-                    .buffer
-                    .insert_str(self.editor.selection.text_range().start, text);
-            } else {
-                self.editor
-                    .buffer
-                    .replace_range(self.editor.selection.text_range(), text);
-            }
-            self.editor.selection.text_range().start
+            let range = self.editor.selection.text_range();
+            self.editor.replace_text(range.clone(), text);
+            range.start
         };
         self.editor.compose = Some(start..start + text.len());
         self.editor.show_cursor = cursor.is_some();
@@ -400,7 +363,8 @@ where
     ///
     /// No-op if either index is not a char boundary.
     pub fn set_compose_byte_range(&mut self, start: usize, end: usize) {
-        if self.editor.buffer.is_char_boundary(start) && self.editor.buffer.is_char_boundary(end) {
+        let text = self.editor.spans.text();
+        if text.is_char_boundary(start) && text.is_char_boundary(end) {
             self.editor.compose = Some(start..end);
             self.update_layout();
         }
@@ -412,7 +376,7 @@ where
     /// and moves the cursor to the start of the former preedit region.
     pub fn clear_compose(&mut self) {
         if let Some(preedit_range) = self.editor.compose.take() {
-            self.editor.buffer.replace_range(preedit_range.clone(), "");
+            self.editor.replace_text(preedit_range.clone(), "");
             self.editor.show_cursor = true;
             self.update_layout();
 
@@ -444,7 +408,7 @@ where
     ///
     /// No-op if index is not a char boundary.
     pub fn move_to_byte(&mut self, index: usize) {
-        if self.editor.buffer.is_char_boundary(index) {
+        if self.editor.spans.text().is_char_boundary(index) {
             self.refresh_layout();
             self.editor
                 .set_selection(self.editor.cursor_at(index).into());
@@ -740,7 +704,7 @@ where
     ///
     /// No-op if index is not a char boundary.
     pub fn extend_selection_to_byte(&mut self, index: usize) {
-        if self.editor.buffer.is_char_boundary(index) {
+        if self.editor.spans.text().is_char_boundary(index) {
             self.refresh_layout();
             self.editor
                 .set_selection(self.editor.selection.extend(self.editor.cursor_at(index)));
@@ -751,7 +715,8 @@ where
     ///
     /// No-op if either index is not a char boundary.
     pub fn select_byte_range(&mut self, start: usize, end: usize) {
-        if self.editor.buffer.is_char_boundary(start) && self.editor.buffer.is_char_boundary(end) {
+        let text = self.editor.spans.text();
+        if text.is_char_boundary(start) && text.is_char_boundary(end) {
             self.refresh_layout();
             self.editor.set_selection(Selection::new(
                 self.editor.cursor_at(start),
@@ -814,11 +779,11 @@ where
     }
 }
 
-impl<T> PlainEditor<T>
+impl<T> RichEditor<T>
 where
     T: Brush + Clone + Debug + PartialEq + Default,
 {
-    /// Run a series of [`PlainEditorDriver`] methods.
+    /// Run a series of [`RichEditorDriver`] methods.
     ///
     /// This type is only used to simplify methods which require both
     /// the editor and the provided contexts.
@@ -826,24 +791,45 @@ where
         &'drv mut self,
         font_cx: &'drv mut FontContext,
         layout_cx: &'drv mut LayoutContext<T>,
-    ) -> PlainEditorDriver<'drv, T> {
-        PlainEditorDriver {
+    ) -> RichEditorDriver<'drv, T> {
+        RichEditorDriver {
             editor: self,
             font_cx,
             layout_cx,
         }
     }
 
+    /// Apply `property` to the given byte `range` of text.
+    ///
+    /// Spans may overlap, including other spans of the same property: conflicts are resolved
+    /// when the layout is next rebuilt, with the most-recently-applied span winning for the
+    /// bytes it covers.
+    ///
+    /// No-op if `range` is not a valid byte range for the current text.
+    pub fn set_style(&mut self, property: StyleProperty<T>, range: Range<usize>) {
+        if let Ok(range) = TextRange::new(self.spans.text(), range) {
+            self.spans.apply_attribute(range, property);
+            self.layout_dirty = true;
+        }
+    }
+
+    /// Iterate over the styles applied at a given byte `index`, in application order.
+    pub fn style_at(&self, index: usize) -> impl Iterator<Item = (Range<usize>, &StyleProperty<T>)> {
+        self.spans
+            .attributes_at(index)
+            .map(|(range, prop)| (range.as_range(), prop))
+    }
+
     /// Borrow the current selection. The indices returned by functions
     /// such as [`Selection::text_range`] refer to the raw text buffer,
     /// including the IME preedit region, which can be accessed via
-    /// [`PlainEditor::raw_text`].
+    /// [`RichEditor::raw_text`].
     pub fn raw_selection(&self) -> &Selection {
         &self.selection
     }
 
     /// Borrow the current IME preedit range, if any. These indices refer
-    /// to the raw text buffer, which can be accessed via [`PlainEditor::raw_text`].
+    /// to the raw text buffer, which can be accessed via [`RichEditor::raw_text`].
     pub fn raw_compose(&self) -> &Option<Range<usize>> {
         &self.compose
     }
@@ -855,7 +841,7 @@ where
             return None;
         }
         if !self.selection.is_collapsed() {
-            self.buffer.get(self.selection.text_range())
+            self.spans.text().get(self.selection.text_range())
         } else {
             None
         }
@@ -946,13 +932,11 @@ where
     /// The return value is a `SplitString` because it
     /// excludes the IME preedit region.
     pub fn text(&self) -> SplitString<'_> {
+        let text = self.spans.text().as_str();
         if let Some(preedit_range) = &self.compose {
-            SplitString([
-                &self.buffer[..preedit_range.start],
-                &self.buffer[preedit_range.end..],
-            ])
+            SplitString::new([&text[..preedit_range.start], &text[preedit_range.end..]])
         } else {
-            SplitString([&self.buffer, ""])
+            SplitString::new([text, ""])
         }
     }
 
@@ -963,7 +947,7 @@ where
     /// IME preedit contents, which are not meaningful for applications to access; the
     /// in-progress IME content is not itself what the user intends to write.
     pub fn raw_text(&self) -> &str {
-        &self.buffer
+        self.spans.text().as_str()
     }
 
     /// Get the current `Generation` of the layout, to decide whether to draw.
@@ -975,9 +959,10 @@ where
     }
 
     /// Replace the whole text buffer.
+    ///
+    /// This clears all styles applied via [`set_style`](Self::set_style).
     pub fn set_text(&mut self, is: &str) {
-        self.buffer.clear();
-        self.buffer.push_str(is);
+        self.spans.set_text(String::from(is));
         self.layout_dirty = true;
         self.compose = None;
     }
@@ -1011,29 +996,15 @@ where
 
     /// Set whether to quantize the layout coordinates.
     ///
-    /// Set `quantize` as `true` to have the layout coordinates aligned to pixel boundaries.
-    /// That is the easiest way to avoid blurry text and to receive ready-to-paint layout metrics.
-    ///
-    /// For advanced rendering use cases you can set `quantize` as `false` and receive
-    /// fractional coordinates. This ensures the most accurate results if you want to perform
-    /// some post-processing on the coordinates before painting. To avoid blurry text you will
-    /// still need to quantize the coordinates just before painting.
-    ///
-    /// Your should round at least the following:
-    /// * Glyph run baseline
-    /// * Inline box baseline
-    ///   - `box.y = (box.y + box.height).round() - box.height`
-    /// * Selection geometry's `y0` & `y1`
-    /// * Cursor geometry's `y0` & `y1`
-    ///
-    /// Keep in mind that for the simple `f32::round` to be effective,
-    /// you need to first ensure the coordinates are in physical pixel space.
+    /// See [`PlainEditor::set_quantize`](crate::editing::PlainEditor::set_quantize) for details.
     pub fn set_quantize(&mut self, quantize: bool) {
         self.quantize = quantize;
         self.layout_dirty = true;
     }
 
-    /// Modify the styles provided for this editor.
+    /// Modify the default styles provided for this editor.
+    ///
+    /// These apply to any text not otherwise styled via [`set_style`](Self::set_style).
     pub fn edit_styles(&mut self) -> &mut StyleSet<T> {
         self.layout_dirty = true;
         &mut self.default_style
@@ -1086,7 +1057,7 @@ where
     /// Returns `None` if the layout is not up-to-date.
     /// You can call [`refresh_layout`](Self::refresh_layout) before using this method,
     /// to ensure that the layout is up-to-date.
-    /// The [`accessibility`](PlainEditorDriver::accessibility) method on the driver type
+    /// The [`accessibility`](RichEditorDriver::accessibility) method on the driver type
     /// should be preferred if the contexts are available, which will do this automatically.
     pub fn try_accessibility(
         &mut self,
@@ -1125,42 +1096,40 @@ where
     // --- MARK: Internal Helpers ---
     /// Make a cursor at a given byte index.
     fn cursor_at(&self, index: usize) -> Cursor {
-        // TODO: Do we need to be non-dirty?
-        // FIXME: `Selection` should make this easier
-        if index >= self.buffer.len() {
-            Cursor::from_byte_index(&self.layout, self.buffer.len(), Affinity::Upstream)
+        if index >= self.spans.len() {
+            Cursor::from_byte_index(&self.layout, self.spans.len(), Affinity::Upstream)
         } else {
             Cursor::from_byte_index(&self.layout, index, Affinity::Downstream)
         }
     }
 
-    fn update_compose_for_replaced_range(&mut self, old_range: Range<usize>, new_len: usize) {
-        if new_len == old_range.len() {
-            return;
+    /// Replace `old_range` of the text buffer with `s`, keeping style spans and the IME
+    /// compose range consistent with the edit.
+    fn replace_text(&mut self, old_range: Range<usize>, s: &str) {
+        let new_len = s.len();
+        let mut text = self.spans.text().clone();
+        if old_range.is_empty() {
+            text.insert_str(old_range.start, s);
+        } else {
+            text.replace_range(old_range.clone(), s);
         }
-        let Some(compose) = &mut self.compose else {
-            return;
-        };
-        if compose.end <= old_range.start {
-            return;
+        let shifted: Vec<_> = self
+            .spans
+            .attributes_iter()
+            .filter_map(|(range, attr)| {
+                shift_span_range(range.as_range(), old_range.clone(), new_len)
+                    .map(|range| (range, attr.clone()))
+            })
+            .collect();
+        self.spans.set_text(text);
+        for (range, attr) in shifted {
+            self.spans
+                .apply_attribute(TextRange::new_unchecked(range.start, range.end), attr);
         }
-        if compose.start >= old_range.end {
-            if new_len > old_range.len() {
-                let diff = new_len - old_range.len();
-                *compose = compose.start + diff..compose.end + diff;
-            } else {
-                let diff = old_range.len() - new_len;
-                *compose = compose.start - diff..compose.end - diff;
-            }
-            return;
-        }
-        if new_len < old_range.len() {
-            if compose.start >= (old_range.start + new_len) {
-                self.compose = None;
-                return;
-            }
-            compose.end = compose.end.min(old_range.start + new_len);
-        }
+        self.compose = self
+            .compose
+            .take()
+            .and_then(|range| shift_span_range(range, old_range.clone(), new_len));
     }
 
     fn replace_selection(
@@ -1171,12 +1140,7 @@ where
     ) {
         let range = self.selection.text_range();
         let start = range.start;
-        if self.selection.is_collapsed() {
-            self.buffer.insert_str(start, s);
-        } else {
-            self.buffer.replace_range(range.clone(), s);
-        }
-        self.update_compose_for_replaced_range(range, s.len());
+        self.replace_text(range, s);
 
         self.update_layout(font_cx, layout_cx);
         let new_index = start.saturating_add(s.len());
@@ -1194,52 +1158,23 @@ where
         {
             self.generation.nudge();
         }
-
-        // This debug code is quite useful when diagnosing selection problems.
-        #[cfg(feature = "std")]
-        #[allow(clippy::print_stderr)] // reason = "unreachable debug code"
-        if false {
-            use std::{eprint, eprintln};
-
-            let focus = new_sel.focus();
-            let cluster = focus.logical_clusters(&self.layout);
-            let dbg = (
-                cluster[0].as_ref().map(|c| &self.buffer[c.text_range()]),
-                focus.index(),
-                focus.affinity(),
-                cluster[1].as_ref().map(|c| &self.buffer[c.text_range()]),
-            );
-            eprint!("{dbg:?}");
-            let cluster = focus.visual_clusters(&self.layout);
-            let dbg = (
-                cluster[0].as_ref().map(|c| &self.buffer[c.text_range()]),
-                cluster[0]
-                    .as_ref()
-                    .map(|c| if c.is_word_boundary() { " W" } else { "" })
-                    .unwrap_or_default(),
-                focus.index(),
-                focus.affinity(),
-                cluster[1].as_ref().map(|c| &self.buffer[c.text_range()]),
-                cluster[1]
-                    .as_ref()
-                    .map(|c| if c.is_word_boundary() { " W" } else { "" })
-                    .unwrap_or_default(),
-            );
-            eprintln!(" | visual: {dbg:?}");
-        }
         self.selection = new_sel;
     }
+
     /// Update the layout.
     fn update_layout(&mut self, font_cx: &mut FontContext, layout_cx: &mut LayoutContext<T>) {
         let mut builder =
-            layout_cx.ranged_builder(font_cx, &self.buffer, self.scale, self.quantize);
+            layout_cx.ranged_builder(font_cx, self.spans.text(), self.scale, self.quantize);
         for prop in self.default_style.inner().values() {
-            builder.push_default(prop.to_owned());
+            builder.push_default(prop.clone());
+        }
+        for (range, prop) in self.spans.attributes_iter() {
+            builder.push(prop.clone(), range.as_range());
         }
         if let Some(preedit_range) = &self.compose {
-            builder.push(StyleProperty::Underline(true), preedit_range.clone());
+            builder.push(crate::StyleProperty::Underline(true), preedit_range.clone());
         }
-        self.layout = builder.build(&self.buffer);
+        self.layout = builder.build(self.spans.text());
         self.layout.break_all_lines(self.width);
         self.layout
             .align(self.alignment, AlignmentOptions::default());
@@ -1251,7 +1186,7 @@ where
     #[cfg(feature = "accesskit")]
     /// Perform an accessibility update, assuming that the layout is valid.
     ///
-    /// The wrapper [`accessibility`](PlainEditorDriver::accessibility) on the driver type should
+    /// The wrapper [`accessibility`](RichEditorDriver::accessibility) on the driver type should
     /// be preferred.
     ///
     /// You should always call [`refresh_layout`](Self::refresh_layout) before using this method,
@@ -1266,7 +1201,7 @@ where
         set_brush_properties: impl Fn(&mut Node, &crate::Style<T>),
     ) {
         self.layout_access.build_nodes(
-            &self.buffer,
+            self.spans.text(),
             &self.layout,
             update,
             node,

--- a/parley/src/editing/rich_editor.rs
+++ b/parley/src/editing/rich_editor.rs
@@ -814,7 +814,10 @@ where
     }
 
     /// Iterate over the styles applied at a given byte `index`, in application order.
-    pub fn style_at(&self, index: usize) -> impl Iterator<Item = (Range<usize>, &StyleProperty<T>)> {
+    pub fn style_at(
+        &self,
+        index: usize,
+    ) -> impl Iterator<Item = (Range<usize>, &StyleProperty<T>)> {
         self.spans
             .attributes_at(index)
             .map(|(range, prop)| (range.as_range(), prop))


### PR DESCRIPTION
LLM Contributions: LLM used to generate the example (based on previous editor example) and some parts of the `RichEditor` (thoroughly checked by comparison with `PlainEditor`).

Adds a new `RichEditor`, the rich text counterpart to `PlainEditor`, and an example demonstrating its use (based on the editor example).


**Changelog**

> ### Added
>
> - New `RichEditor` and `RichEditorDriver`.
