### PR TITLE
Parley v0.11.1 release (upgrade to read-fonts 0.41, skrifa 0.44, harfrust 0.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV] of 1.88.
 
+## [0.11.1] - 2026-08-16
+
+This release has an [MSRV] of 1.88.
+
+### Changed
+
+#### Parley
+
+- Upgrade to `read-fonts` 0.41, `skrifa` 0.44, `harfrust` 0.12 (by [@nicoburns][])
+
 ## [0.11.0] - 2026-06-24
 
 This release has an [MSRV] of 1.88.
@@ -682,7 +692,8 @@ This release has an [MSRV][] of 1.70.
 [#643]: https://github.com/linebender/parley/pull/643
 [#650]: https://github.com/linebender/parley/pull/650
 
-[Unreleased]: https://github.com/linebender/parley/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/linebender/parley/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/linebender/parley/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/linebender/parley/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/linebender/parley/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/linebender/parley/compare/v0.8.0...v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -1224,7 +1224,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts 0.40.2",
+ "read-fonts 0.41.0",
  "roxmltree",
  "smallvec",
  "windows 0.62.2",
@@ -1513,14 +1513,14 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0589ddd0d2935dd2845827ac606b4081c266225d613b268ed2910f832889cab"
+checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
- "read-fonts 0.40.2",
+ "read-fonts 0.41.0",
  "smallvec",
 ]
 
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "parley"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "accesskit",
  "core_maths",
@@ -2907,7 +2907,7 @@ dependencies = [
  "parley_data",
  "parley_dev",
  "peniko",
- "skrifa 0.43.2",
+ "skrifa 0.44.0",
 ]
 
 [[package]]
@@ -2917,7 +2917,7 @@ dependencies = [
  "glifo",
  "parley",
  "parley_dev",
- "skrifa 0.43.2",
+ "skrifa 0.44.0",
  "tango-bench",
  "vello_cpu",
 ]
@@ -2928,7 +2928,7 @@ version = "0.0.0"
 
 [[package]]
 name = "parley_data"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "icu_properties",
 ]
@@ -3399,9 +3399,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.40.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487889119a5f19ff7c0a20637196bdc76b9f54ebec17e3588b5d75e4999f8773"
+checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -3715,13 +3715,13 @@ dependencies = [
 
 [[package]]
 name = "skrifa"
-version = "0.43.2"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbe997d0f2480442d727488fbe2150779114cbe480ecdbadef58b33e0318ffb"
+checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
 dependencies = [
  "bytemuck",
  "core_maths",
- "read-fonts 0.40.2",
+ "read-fonts 0.41.0",
 ]
 
 [[package]]
@@ -3854,7 +3854,7 @@ version = "0.1.0"
 dependencies = [
  "image",
  "parley",
- "skrifa 0.43.2",
+ "skrifa 0.44.0",
  "swash",
 ]
 
@@ -4032,7 +4032,7 @@ name = "tiny_skia_render"
 version = "0.1.0"
 dependencies = [
  "parley",
- "skrifa 0.43.2",
+ "skrifa 0.44.0",
  "tiny-skia",
 ]
 
@@ -4306,7 +4306,7 @@ dependencies = [
  "parley",
  "parley_examples_common",
  "peniko",
- "skrifa 0.43.2",
+ "skrifa 0.44.0",
  "vello_cpu",
 ]
 
@@ -4367,7 +4367,7 @@ dependencies = [
  "peniko",
  "png 0.17.16",
  "pollster",
- "skrifa 0.43.2",
+ "skrifa 0.44.0",
  "vello_common",
  "vello_hybrid",
  "wgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.11.0"
+version = "0.11.1"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
 # Until MSRV is bumped to 1.96+, use `core::ops::Range*` rather than `core::range::Range*`.
@@ -35,9 +35,9 @@ repository = "https://github.com/linebender/parley"
 [workspace.dependencies]
 # Local crates
 parlance = { version = "0.1.0", default-features = false, path = "parlance" }
-fontique = { version = "0.11.0", default-features = false, path = "fontique" }
-parley = { version = "0.11.0", default-features = false, path = "parley" }
-parley_data = { version = "0.11.0", path = "parley_data", default-features = false }
+fontique = { version = "0.11.1", default-features = false, path = "fontique" }
+parley = { version = "0.11.1", default-features = false, path = "parley" }
+parley_data = { version = "0.11.1", path = "parley_data", default-features = false }
 parley_data_gen = { path = "parley_data_gen" }
 parley_dev = { default-features = false, path = "parley_dev" }
 parley_linebreaking_cases = { path = "parley_tests/linebreaking_cases" }
@@ -45,7 +45,7 @@ parley_linebreaking_cases = { path = "parley_tests/linebreaking_cases" }
 # External dependencies
 accesskit = "0.24.0"
 bytemuck = { version = "1.25.0", default-features = false }
-harfrust = { version = "0.10.0", default-features = false }
+harfrust = { version = "0.12.0", default-features = false }
 hashbrown = { version = "0.17.0", default-features = false, features = [
     "default-hasher",
     "raw-entry",
@@ -60,8 +60,8 @@ glifo = { git = "https://github.com/linebender/vello", rev = "5796226", default-
 rand = { version = "0.10.1", default-features = false, features = ["std", "std_rng"] }
 rand_chacha = { version = "0.10.0", default-features = false }
 peniko = { version = "0.6.0", default-features = false }
-read-fonts = { version = "0.40.0", default-features = false }
-skrifa = { version = "0.43.2", default-features = false }
+read-fonts = { version = "0.41.0", default-features = false }
+skrifa = { version = "0.44.0", default-features = false }
 smallvec = "1.15.1"
 swash = { version = "0.2.6", default-features = false }
 vello_common = { version = "0.0.7", default-features = false }


### PR DESCRIPTION
Parley 0.11.1 release with Fontations bump: `read-fonts` 0.41, `skrifa` 0.44, and `harfrust` 0.12.

This moves Parley to a Fontations version that matches:

- Vello Sparse Strips 0.1
- Vello Classic 0.10
- Resvg 0.48

LLM Contributions: All changes generated with Devin Ultra

