### PR TITLE
Fix infinite loop in `break_remaining` with `CustomOutOfFlow` inline boxes

### DIFF
--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -1085,10 +1085,12 @@ impl<'a, B: Brush> BreakLines<'a, B> {
         self.state.layout_max_advance = max_advance;
         self.state.line_max_advance = max_advance;
         while let Some(yield_data) = self.break_next() {
-            // `break_next` yields on `CustomOutOfFlow` boxes without advancing past them,
-            // leaving placement (and advancing the breaker state) to the caller. Here there
-            // is no custom placement logic, so treat the box as zero-sized out-of-flow
-            // content and advance past it to guarantee progress.
+            // When `break_next` encounters a `CustomOutOfFlow`, it yields a `YieldData::InlineBoxBreak`
+            // without advancing the item iteration past the box. This allows embedders to implement custom
+            // placement logic to place the box. However, it means that we must also handle placing the box
+            // and advancing the iteration here to avoid an infinite loop.
+            //
+            // So we place the box as a zero-sized out-of-flow box to guarantee progress.
             if let YieldData::InlineBoxBreak(_) = yield_data {
                 self.state.append_inline_box_to_line(
                     self.state.line.x,

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -1084,7 +1084,20 @@ impl<'a, B: Brush> BreakLines<'a, B> {
         // println!("\nBREAK ALL");
         self.state.layout_max_advance = max_advance;
         self.state.line_max_advance = max_advance;
-        while self.break_next().is_some() {}
+        while let Some(yield_data) = self.break_next() {
+            // `break_next` yields on `CustomOutOfFlow` boxes without advancing past them,
+            // leaving placement (and advancing the breaker state) to the caller. Here there
+            // is no custom placement logic, so treat the box as zero-sized out-of-flow
+            // content and advance past it to guarantee progress.
+            if let YieldData::InlineBoxBreak(_) = yield_data {
+                self.state.append_inline_box_to_line(
+                    self.state.line.x,
+                    0.0,
+                    0.0,
+                    self.layout.data.quantize,
+                );
+            }
+        }
         self.finish();
     }
 

--- a/parley_tests/tests/issues.rs
+++ b/parley_tests/tests/issues.rs
@@ -121,9 +121,7 @@ Third line that ends with newlines\n\n";
 /// Test that `break_all_lines` terminates when the layout contains a
 /// `CustomOutOfFlow` inline box.
 ///
-/// `break_next` yields on `CustomOutOfFlow` boxes without advancing past them,
-/// so `break_remaining` must advance past the box itself or it will loop forever.
-/// See <https://github.com/linebender/parley/issues/752>.
+/// Regression test for <https://github.com/linebender/parley/issues/752>.
 #[test]
 fn issue_752() {
     let mut env = TestEnv::new(test_name!(), None);

--- a/parley_tests/tests/issues.rs
+++ b/parley_tests/tests/issues.rs
@@ -5,7 +5,10 @@
 
 use crate::test_name;
 use crate::util::TestEnv;
-use parley::{Alignment, AlignmentOptions, PositionedLayoutItem, StyleProperty, TextWrapMode};
+use parley::{
+    Alignment, AlignmentOptions, InlineBox, InlineBoxKind, PositionedLayoutItem, StyleProperty,
+    TextWrapMode,
+};
 
 /// Test that rendering RTL text doesn't affect subsequent LTR layouts.
 /// See <https://github.com/linebender/parley/issues/489>.
@@ -113,4 +116,31 @@ Third line that ends with newlines\n\n";
     layout.align(Alignment::Start, AlignmentOptions::default());
     env.with_name("max_context_with_mandatory_breaks")
         .check_layout_snapshot(&layout);
+}
+
+/// Test that `break_all_lines` terminates when the layout contains a
+/// `CustomOutOfFlow` inline box.
+///
+/// `break_next` yields on `CustomOutOfFlow` boxes without advancing past them,
+/// so `break_remaining` must advance past the box itself or it will loop forever.
+/// See <https://github.com/linebender/parley/issues/752>.
+#[test]
+fn issue_752() {
+    let mut env = TestEnv::new(test_name!(), None);
+
+    let text = "Hello world this is some text";
+
+    let mut builder = env.ranged_builder(text);
+    builder.push_inline_box(InlineBox {
+        id: 0,
+        kind: InlineBoxKind::CustomOutOfFlow,
+        index: 5,
+        width: 10.0,
+        height: 10.0,
+        baseline: None,
+    });
+    let mut layout = builder.build(text);
+    layout.break_all_lines(Some(100.0));
+
+    assert!(!layout.is_empty());
 }


### PR DESCRIPTION
Fix infinite loop in `break_remaining` with `CustomOutOfFlow` inline boxes. `break_next` yields on `CustomOutOfFlow`, boxes without advancing past them, so if `break_remaining` ignores these yields (as it currently does), it will loop forever with `break_next` continually returning the same box.

Fix: Advance past the box as zero-sized out-of-flow content instead.

Fixes #752

LLM Contributions: Fix generated with Devin Ultra.

No changelog entry because this will get backported as 0.11.2. Changelog added on v0.11.x branch and then forward-ported to `main`.