### PR TITLE
Move segmentation out of Parley Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ This release has an [MSRV] of 1.88.
 
 #### Parley
 
+- Line and word segmentation now runs in Parley rather than `parley_engine`, preserving existing
+  layout behavior while allowing the engine to accept host-provided line break opportunities.
 - Breaking change: the `Glyph::style_index` field was removed. Use `Cluster::{style, style_index}` or `GlyphRun::{style, style_index}` instead. ([#661][] by [@tomcur][])
 - Breaking change: `Cluster` now spans a full grapheme cluster instead of a single character. ([#715][] by [@tomcur][])  
   Shaped clusters that cross grapheme boundaries are represented using the existing `Cluster::is_ligature_start` and `Cluster::is_ligature_continuation`; note these methods previously encoded graphemes as well.
@@ -40,6 +42,12 @@ This release has an [MSRV] of 1.88.
   Note glyphs overflow these content bounds as well, for example when many combining marks are stacked.
   The union of the line-box and content bounds is close to the old `LineMetrics::block_{min,max}_coord` fields.
 - `parley::editing::Cursor::{previous,next}_logical_word` now land at the previous/next logical start of a word and skip over whitespace. ([#215][] by [@tomcur][])
+
+#### Parley Engine
+
+- Breaking change: `AnalysisOptions` now accepts caller-provided UTF-8 line break offsets. The
+  engine no longer performs line or word segmentation, and `Boundary` no longer has a `Word`
+  variant.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,6 +2966,7 @@ dependencies = [
  "fontique",
  "hashbrown 0.17.1",
  "icu_properties",
+ "icu_segmenter",
  "linebender_resource_handle",
  "oxipng",
  "parlance",

--- a/doc/user-provided-line-breaks.md
+++ b/doc/user-provided-line-breaks.md
@@ -1,0 +1,148 @@
+# Plan: caller-provided line break opportunities in `parley_engine`
+
+## Goal
+
+`parley_engine` stops performing line and word segmentation. Callers supply
+soft line break opportunities as input; word boundaries become something only
+`parley` computes and stores. The engine keeps grapheme segmentation
+(dictionary-free, needed internally for cluster formation) and mandatory-break
+detection (a cheap Unicode property lookup, not policy).
+
+Motivations, in order:
+
+1. The segmentation dictionaries (`complex-scripts`: Thai, Khmer, Lao, Burmese)
+   leave the engine's dependency tree. Hosts that load segmentation data
+   separately, or use a platform segmenter such as the web's `Intl.Segmenter`,
+   no longer link them twice. The dictionaries are shared between
+   `LineSegmenter` and `WordSegmenter`, so both must leave the engine for this
+   to land — moving only line segmentation achieves nothing.
+2. Layering: the engine's contract becomes "break opportunities in, shaped text
+   and line-break decisions out". Segmentation policy (word-break strength,
+   browser-parity overrides) is a host concern. External engine users (Servo,
+   Typst, Blink, ...) all have their own segmenters.
+
+A future public extension point in `parley` for user-provided segmentation is a
+separate task. This change only needs to leave an internal seam shaped so that
+task can extract a trait from it, rather than design around it.
+
+## Engine API changes (`parley_engine`)
+
+- `AnalysisOptions` becomes `{ base_direction, line_break_opportunities: &[usize] }`.
+  - `line_break_opportunities`: sorted UTF-8 byte offsets, each meaning "a soft
+    break opportunity exists before the character starting at this offset".
+    `usize` matches the existing byte-offset convention (`u32` is reserved for
+    char indices in the shape API).
+  - A slice, not an iterator: producers (ICU, `Intl.Segmenter`) materialize
+    eagerly anyway, and the current code already collects into a `Vec`.
+  - The `word_break` ranges field and `line_break_override` field are deleted.
+- Validation: panic on unsorted offsets, offsets not on `char` boundaries, and
+  offsets that fall mid-grapheme-cluster. The grapheme check is one branch in
+  the existing merge loop (`is_grapheme_start` is computed there). No silent
+  repair.
+- `Boundary` shrinks to `{ None, Line, Mandatory }`. It continues to flow
+  through `CharInfo` and `ClusterInfo` unchanged otherwise.
+- Moved (not deleted) out of the engine, into `parley`: the `break_overrides`
+  module (`LineBreakContext`, `AsciiLineBreakTable`,
+  `CHROMIUM_LINE_BREAK_OVERRIDE`), the `DenseWordBreaks`/`WordBreakSegmentIter`
+  substring plumbing in `analysis.rs`, the `LineSegmenter` and `WordSegmenter`
+  construction, and the single-word-break-style fast path (a bookkeeping bypass
+  of the substring machinery for the common no-`word-break`-spans case — it
+  belongs wherever ICU runs, so it migrates verbatim).
+- Kept: `GraphemeClusterSegmenter` (a slim, `const`, dictionary-free
+  `icu_segmenter` dependency remains) and `Properties::is_mandatory_linebreak`.
+- The `complex-scripts` feature moves from `parley_engine`'s Cargo.toml to
+  `parley`'s.
+- New/changed public items get documentation which does not refer to the prior state.
+
+## `parley` changes
+
+All evicted machinery lands in `parley` as `pub(crate)` code (suggested module:
+`parley/src/segmentation.rs`). Public API and observable behavior are unchanged
+in this task; the existing knobs (`word_break` style ranges,
+`line_break_override`, the Chromium table re-export if any) keep their surface.
+
+At layout-build time, before calling `Analyzer::analyze`:
+
+1. Line breaks: split text into contiguous word-break-strength substrings
+   (migrated `DenseWordBreaks`/`WordBreakSegmentIter`, including the
+   single-word-break-style fast path), run the ICU `LineSegmenter` per
+   substring, apply the `line_break_override` callback as a post-pass over
+   adjacent char pairs, and collect the offsets `Vec` passed to the engine.
+   Keep this behind one internal function with the shape
+   `(text, word-break config) -> offsets` — the future extraction seam.
+
+   Allocation note: the engine previously applied the override just-in-time
+   inside its merge loop, materializing only raw ICU offsets. Post-override
+   offsets must now be materialized instead, but it is still exactly one
+   `Vec`, held as reusable scratch on `LayoutContext`, and of roughly the same
+   length (the Chromium table mostly suppresses; its forced break after a
+   space targets positions ICU already emits). The real cost is one extra
+   traversal of the text for the override pair-walk; the override closure is
+   called the same number of times as before. The bench comparison sizes this.
+2. Word boundaries: run the ICU `WordSegmenter` over the full text and store its
+   output as-is: `LayoutData::word_boundary_bytes: Vec<usize>`, sorted byte
+   offsets of UAX-29 word-segment boundaries. `parley` has no existing per-cluster
+   arrays (`Cluster::info()` reads engine-owned data), so this is a new side
+   array; `Cluster::is_word_boundary()` binary-searches it via the cluster's
+   text range. Word boundaries are sparse and the query sites are
+   editing/selection/accessibility paths, so `O(log n)` is fine. Whether
+   `parley` later packs this with line boundary data into its own
+   `Boundary`-like (e.g. bitvec) representation is deliberately deferred.
+
+`Cluster::is_word_boundary()` currently means "any boundary" (`boundary !=
+None`), which is wrong (not all line opportunities are word boundaries) but is the
+behavior selection/cursor/editing/accessibility ship on. This task keeps it
+bug-compatible: the read site computes `word_boundary || line || mandatory`,
+marked `// HACK(follow-up):` so review sees the storage is correct and only the
+merge is legacy. Fixing the semantics is a hyper-local follow-up.
+
+## Suggested implementation order
+
+Single PR, reviewed commit-by-commit (the workspace must compile at every
+commit, so engine and `parley` changes cannot be split into separate PRs):
+
+1. Add `line_break_opportunities` to `AnalysisOptions` alongside the existing
+   fields; engine prefers it when non-empty. Wire `parley` to compute and pass
+   it (machinery still duplicated at this point). Validate: snapshot tests
+   byte-identical.
+2. Add `parley`-side word-boundary storage; switch `is_word_boundary()` to the
+   marked hack expression. Validate: snapshot tests byte-identical.
+3. Delete the engine-side segmentation, `word_break`/`line_break_override`
+   options, `break_overrides` module; shrink `Boundary`; add the panics; move
+   the `complex-scripts` feature. Port tests.
+4. Changelog entries for both crates; bench comparison.
+
+## Test and validation strategy
+
+- The full snapshot/golden suites must pass byte-identical — this refactor is
+  behavior-preserving by construction, which is the main correctness gate.
+- `parley/src/tests/test_analysis.rs`: boundary-list tests that exercise
+  word-break strength and overrides become tests of `parley`'s segmentation
+  stage. Engine-level analysis tests supply hand-written offset slices.
+- New engine tests: panic cases (unsorted, non-char-boundary, mid-grapheme
+  offsets), empty-offsets input (no soft wrapping — a valid configuration).
+- `parley_bench` before/after: analysis loses its fused fast path and `parley`
+  gains passes; the word/letter-spacing and justification benches cover the
+  affected paths.
+
+## Consequences
+
+- Breaking change for direct `parley_engine` users: they must bring a
+  segmenter. The offsets contract is deliberately simple (sorted byte offsets)
+  so any UAX-14 implementation or platform API can feed it. Note that
+  `Intl.Segmenter` reports UTF-16 code-unit indices; converting to UTF-8 byte
+  offsets is the caller's job and must be prominent in the docs.
+- Engine and provider can disagree about grapheme boundaries across Unicode
+  versions; the mid-grapheme panic surfaces that skew rather than hiding it.
+- `parlance::WordBreak` stays in `parlance`; only `parley` consumes it now.
+- With no offsets supplied, text simply never soft-wraps (mandatory breaks
+  still apply). This is valid, not an error.
+
+## Future work (separate tasks)
+
+- Public `Segmenter` extension point in `parley`, extracted from the internal
+  `(text, word-break config) -> offsets` seam, with the ICU default behind a
+  feature so hosts can exclude the dictionaries entirely.
+- Fix `Cluster::is_word_boundary()` to exclude line-only and mandatory-only
+  boundaries (removing the marked hack); a documented behavior change for
+  selection/cursor/double-click around hyphens, CJK, etc.

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -25,7 +25,7 @@ system = ["std", "fontique/system"]
 accesskit = ["dep:accesskit", "dep:skrifa"]
 # Enables dictionary-based line and word breaking for complex scripts (CJK, Thai, Khmer, Lao, Myanmar).
 # When disabled, a lightweight segmenter is used that falls back to character-level breaks for those scripts.
-complex-scripts = ["parley_engine/complex-scripts"]
+complex-scripts = []
 
 [dependencies]
 skrifa = { workspace = true, optional = true }
@@ -37,6 +37,7 @@ parley_engine = { workspace = true }
 core_maths = { version = "0.1.1", optional = true }
 accesskit = { workspace = true, optional = true }
 hashbrown = { workspace = true }
+icu_segmenter = { workspace = true, features = ["compiled_data"] }
 
 [dev-dependencies]
 parlance = { workspace = true, features = ["bytemuck"] }

--- a/parley/src/analysis.rs
+++ b/parley/src/analysis.rs
@@ -3,7 +3,7 @@
 
 use crate::{Brush, LayoutContext};
 
-use parley_engine::break_overrides::LineBreakOverrideFn;
+use crate::LineBreakOverrideFn;
 
 use parley_engine::AnalysisOptions;
 
@@ -26,10 +26,17 @@ pub(crate) fn analyze_text<B: Brush>(
             (word_break != WordBreak::Normal).then(|| (sr.range.clone(), word_break))
         }));
 
+    crate::segmentation::line_break_opportunities(
+        text,
+        &lcx.word_break,
+        line_break_override,
+        &mut lcx.line_break_opportunities,
+    );
+    crate::segmentation::word_boundaries(text, &mut lcx.word_boundary_bytes);
+
     let options = AnalysisOptions {
         base_direction,
-        word_break: &lcx.word_break,
-        line_break_override,
+        line_break_opportunities: &lcx.line_break_opportunities,
     };
     lcx.analyzer.analyze(text, &options, &mut lcx.analysis);
 }

--- a/parley/src/break_overrides.rs
+++ b/parley/src/break_overrides.rs
@@ -114,17 +114,11 @@ static CHROMIUM_LINE_BREAK_TABLE: AsciiLineBreakTable<5> =
 /// # Example
 ///
 /// ```
-/// # use parley_engine::break_overrides::CHROMIUM_LINE_BREAK_OVERRIDE;
-/// # use parley_engine::{Analysis, AnalysisOptions, Analyzer};
-/// # let mut analyzer = Analyzer::new();
-/// # let mut analysis = Analysis::new();
+/// # use parley::CHROMIUM_LINE_BREAK_OVERRIDE;
 /// let text = "Hello there!";
-/// let options = AnalysisOptions {
-///     // Emulate Chromium:
-///     line_break_override: Some(CHROMIUM_LINE_BREAK_OVERRIDE),
-///     ..AnalysisOptions::default()
-/// };
-/// analyzer.analyze(text, &options, &mut analysis);
+/// # let _ = text;
+/// // Pass `CHROMIUM_LINE_BREAK_OVERRIDE` to a layout builder's
+/// // `set_line_break_override` method to emulate Chromium.
 /// ```
 #[derive(Clone, Debug)]
 pub struct AsciiLineBreakTable<const N: usize> {

--- a/parley/src/builder.rs
+++ b/parley/src/builder.rs
@@ -9,10 +9,10 @@ use super::style::{Brush, StyleProperty, TextStyle, WhiteSpaceCollapse};
 
 use super::layout::Layout;
 
+use crate::LineBreakOverrideFn;
 use alloc::string::String;
 use core::ops::{Bound, Range, RangeBounds};
 use parlance::BaseDirection;
-use parley_engine::break_overrides::LineBreakOverrideFn;
 
 use crate::InlineBoxKind;
 use crate::inline_box::InlineBox;
@@ -341,6 +341,10 @@ fn build_into_layout<B: Brush>(
     layout.data.quantize = options.quantize;
     layout.data.base_level = lcx.analysis.paragraph_level();
     layout.data.text_len = text.len();
+    layout
+        .data
+        .word_boundary_bytes
+        .extend_from_slice(&lcx.word_boundary_bytes);
 
     lcx.char_style_indices
         .resize(lcx.analysis.char_info().len(), 0);

--- a/parley/src/context.rs
+++ b/parley/src/context.rs
@@ -32,6 +32,8 @@ pub struct LayoutContext<B: Brush = [u8; 4]> {
     pub(crate) analyzer: Analyzer,
     pub(crate) analysis: Analysis,
     pub(crate) word_break: Vec<(Range<usize>, WordBreak)>,
+    pub(crate) line_break_opportunities: Vec<usize>,
+    pub(crate) word_boundary_bytes: Vec<usize>,
 
     // Reusable style builders (to amortise allocations)
     pub(crate) ranged_style_builder: RangedStyleBuilder<B>,
@@ -55,6 +57,8 @@ impl<B: Brush> LayoutContext<B> {
             analyzer: Analyzer::new(),
             analysis: Analysis::new(),
             word_break: Vec::new(),
+            line_break_opportunities: Vec::new(),
+            word_boundary_bytes: Vec::new(),
             ranged_style_builder: RangedStyleBuilder::default(),
             tree_style_builder: TreeStyleBuilder::default(),
             char_style_indices: vec![],

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -216,7 +216,24 @@ impl<'a, B: Brush> Cluster<'a, B> {
 
     /// Returns `true` if the cluster is a word boundary.
     pub fn is_word_boundary(&self) -> bool {
-        self.info().is_boundary()
+        let range = self.text_range();
+        let word_boundary = self
+            .run
+            .layout
+            .data
+            .word_boundary_bytes
+            .binary_search_by(|offset| {
+                if *offset < range.start {
+                    core::cmp::Ordering::Less
+                } else if *offset >= range.end {
+                    core::cmp::Ordering::Greater
+                } else {
+                    core::cmp::Ordering::Equal
+                }
+            });
+        // HACK(follow-up): Preserve the legacy inclusion of line and mandatory
+        // boundaries until callers can migrate to word-segment boundaries only.
+        word_boundary.is_ok() || self.info().is_boundary()
     }
 
     /// Returns `true` if the cluster is a soft line break.

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -181,6 +181,8 @@ pub(crate) struct LayoutData<B: Brush> {
     pub(crate) base_level: BidiLevel,
     /// The length of the text in the layout
     pub(crate) text_len: usize,
+    /// Ordered byte offsets of word-segment boundaries in the source text.
+    pub(crate) word_boundary_bytes: Vec<usize>,
 
     // Output of style resolution (input to line breaking)
     pub(crate) styles: Vec<Style<B>>,
@@ -225,6 +227,7 @@ impl<B: Brush> Default for LayoutData<B> {
             quantize: true,
             base_level: BidiLevel::new(0),
             text_len: 0,
+            word_boundary_bytes: Vec::new(),
             width: 0.,
             full_width: 0.,
             height: 0.,
@@ -251,6 +254,7 @@ impl<B: Brush> LayoutData<B> {
         self.quantize = true;
         self.base_level = BidiLevel::new(0);
         self.text_len = 0;
+        self.word_boundary_bytes.clear();
         self.width = 0.;
         self.full_width = 0.;
         self.height = 0.;

--- a/parley/src/lib.rs
+++ b/parley/src/lib.rs
@@ -109,11 +109,13 @@ extern crate std;
 pub use fontique;
 
 mod analysis;
+mod break_overrides;
 mod builder;
 mod context;
 mod font;
 mod inline_box;
 mod resolve;
+mod segmentation;
 mod shape;
 mod util;
 
@@ -125,12 +127,12 @@ pub mod style;
 #[cfg(test)]
 mod tests;
 
-pub use linebender_resource_handle::FontData;
-pub use parlance::BaseDirection;
-pub use parley_engine::break_overrides::{
+pub use break_overrides::{
     AsciiLineBreakTable, AsciiLineBreakTableBuilder, CHROMIUM_LINE_BREAK_OVERRIDE,
     LineBreakContext, LineBreakOverrideFn,
 };
+pub use linebender_resource_handle::FontData;
+pub use parlance::BaseDirection;
 
 pub use builder::{RangedBuilder, StyleRunBuilder, TreeBuilder};
 pub use context::LayoutContext;

--- a/parley/src/segmentation.rs
+++ b/parley/src/segmentation.rs
@@ -1,0 +1,241 @@
+// Copyright 2026 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Text segmentation using [`icu_segmenter`] for word and line break boundaries.
+
+use alloc::vec::Vec;
+use core::ops::Range;
+
+use icu_segmenter::options::{LineBreakOptions, LineBreakWordOption, WordBreakInvariantOptions};
+use icu_segmenter::{LineSegmenter, LineSegmenterBorrowed, WordSegmenter};
+use parlance::WordBreak;
+
+use crate::{LineBreakContext, LineBreakOverrideFn};
+
+/// Turns the sparse, sorted, non-overlapping `options.word_break` into a contiguous sequence of
+/// `(range, word-break)` segments covering all of `text`.
+///
+/// Any region not covered by an override takes the default `WordBreak::Normal`.
+struct DenseWordBreaks<'a> {
+    word_break: &'a [(Range<usize>, WordBreak)],
+    next: usize,
+    cursor: usize,
+    text_len: usize,
+}
+
+impl<'a> DenseWordBreaks<'a> {
+    fn new(word_break: &'a [(Range<usize>, WordBreak)], text_len: usize) -> Self {
+        Self {
+            word_break,
+            next: 0,
+            cursor: 0,
+            text_len,
+        }
+    }
+}
+
+impl Iterator for DenseWordBreaks<'_> {
+    type Item = (Range<usize>, WordBreak);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor >= self.text_len {
+            return None;
+        }
+        while self
+            .word_break
+            .get(self.next)
+            .is_some_and(|(range, _)| range.is_empty())
+        {
+            self.next += 1;
+        }
+        match self.word_break.get(self.next) {
+            Some((range, _)) if self.cursor < range.start => {
+                let segment = self.cursor..range.start;
+                self.cursor = range.start;
+                Some((segment, WordBreak::Normal))
+            }
+            Some((range, word_break)) => {
+                self.cursor = range.end;
+                self.next += 1;
+                Some((range.clone(), *word_break))
+            }
+            None => {
+                let segment = self.cursor..self.text_len;
+                self.cursor = self.text_len;
+                Some((segment, WordBreak::Normal))
+            }
+        }
+    }
+}
+
+/// Produces overlapping substrings for contiguous runs of one word-break style.
+struct WordBreakSegmentIter<'a, I: Iterator> {
+    text: &'a str,
+    segments: I,
+    char_indices: core::str::CharIndices<'a>,
+    current_char: (usize, char),
+    building_range_start: usize,
+    previous_word_break_style: WordBreak,
+    done: bool,
+}
+
+impl<'a, I> WordBreakSegmentIter<'a, I>
+where
+    I: Iterator<Item = (Range<usize>, WordBreak)>,
+{
+    fn new(text: &'a str, segments: I, first_segment: (Range<usize>, WordBreak)) -> Self {
+        let mut char_indices = text.char_indices();
+        let current_char = char_indices.next().unwrap();
+        Self {
+            text,
+            segments,
+            char_indices,
+            current_char,
+            building_range_start: first_segment.0.start,
+            previous_word_break_style: first_segment.1,
+            done: false,
+        }
+    }
+}
+
+impl<'a, I> Iterator for WordBreakSegmentIter<'a, I>
+where
+    I: Iterator<Item = (Range<usize>, WordBreak)>,
+{
+    type Item = (&'a str, WordBreak, bool);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        for (range, word_break) in self.segments.by_ref() {
+            assert!(range.start < range.end, "segments must not be empty");
+            let mut previous_char = self.current_char;
+            while self.current_char.0 < range.start {
+                previous_char = self.current_char;
+                self.current_char = self.char_indices.next().unwrap();
+            }
+            if self.previous_word_break_style == word_break {
+                continue;
+            }
+            let substring =
+                &self.text[self.building_range_start..range.start + self.current_char.1.len_utf8()];
+            let result_style = self.previous_word_break_style;
+            self.building_range_start = range.start - previous_char.1.len_utf8();
+            self.previous_word_break_style = word_break;
+            return Some((substring, result_style, false));
+        }
+        self.done = true;
+        Some((
+            &self.text[self.building_range_start..],
+            self.previous_word_break_style,
+            true,
+        ))
+    }
+}
+
+#[cfg(feature = "complex-scripts")]
+fn line_segmenter(options: LineBreakOptions<'_>) -> LineSegmenterBorrowed<'static> {
+    LineSegmenter::new_dictionary(options)
+}
+
+#[cfg(not(feature = "complex-scripts"))]
+fn line_segmenter(options: LineBreakOptions<'_>) -> LineSegmenterBorrowed<'static> {
+    LineSegmenter::new_for_non_complex_scripts(options)
+}
+
+fn line_segmenter_for(word_break: WordBreak) -> LineSegmenterBorrowed<'static> {
+    let mut options = LineBreakOptions::default();
+    options.word_option = Some(match word_break {
+        WordBreak::Normal => LineBreakWordOption::Normal,
+        WordBreak::BreakAll => LineBreakWordOption::BreakAll,
+        WordBreak::KeepAll => LineBreakWordOption::KeepAll,
+    });
+    line_segmenter(options)
+}
+
+/// Computes soft line-break opportunities for `text` into reusable storage.
+pub(crate) fn line_break_opportunities(
+    text: &str,
+    word_break: &[(Range<usize>, WordBreak)],
+    line_break_override: Option<&LineBreakOverrideFn>,
+    output: &mut Vec<usize>,
+) {
+    output.clear();
+    if text.is_empty() {
+        return;
+    }
+
+    let mut segments = DenseWordBreaks::new(word_break, text.len());
+    let first_segment = segments.next().unwrap();
+    let substrings = WordBreakSegmentIter::new(text, segments, first_segment);
+    let mut global_offset = 0;
+
+    for (substring_index, (substring, word_break_strength, last)) in substrings.enumerate() {
+        if substring_index == 0 && last {
+            output.extend(
+                line_segmenter_for(word_break_strength)
+                    .segment_str(substring)
+                    .skip(1),
+            );
+            output.pop();
+            break;
+        }
+
+        let mut substring_chars = substring.chars();
+        if substring_index != 0 {
+            global_offset -= substring_chars.next().unwrap().len_utf8();
+        }
+        let last_len = substring_chars.next_back().unwrap().len_utf8();
+        for (index, position) in line_segmenter_for(word_break_strength)
+            .segment_str(substring)
+            .enumerate()
+        {
+            if index == 0 || position == substring.len() {
+                continue;
+            }
+            if !last && position == substring.len() - last_len {
+                continue;
+            }
+            output.push(position + global_offset);
+        }
+        if !last {
+            global_offset += substring.len() - last_len;
+        }
+    }
+
+    if let Some(line_break_override) = line_break_override {
+        let mut previous = None;
+        let mut previous_previous = None;
+        for (position, character) in text.char_indices() {
+            if let Some(before) = previous
+                && let Some(forced) = line_break_override(LineBreakContext {
+                    before_before: previous_previous,
+                    before,
+                    after: character,
+                })
+            {
+                match (output.binary_search(&position), forced) {
+                    (Err(index), true) => output.insert(index, position),
+                    (Ok(index), false) => {
+                        output.remove(index);
+                    }
+                    _ => {}
+                }
+            }
+            previous_previous = previous;
+            previous = Some(character);
+        }
+    }
+}
+
+/// Computes UAX-29 word-segment boundaries for `text` into reusable storage.
+pub(crate) fn word_boundaries(text: &str, output: &mut Vec<usize>) {
+    output.clear();
+    #[cfg(feature = "complex-scripts")]
+    let segmenter = WordSegmenter::new_dictionary(WordBreakInvariantOptions::default());
+    #[cfg(not(feature = "complex-scripts"))]
+    let segmenter =
+        const { WordSegmenter::new_for_non_complex_scripts(WordBreakInvariantOptions::default()) };
+    output.extend(segmenter.segment_str(text));
+}

--- a/parley/src/tests/test_analysis.rs
+++ b/parley/src/tests/test_analysis.rs
@@ -5,24 +5,35 @@ use crate::{FontContext, LayoutContext, RangedBuilder, StyleProperty, WordBreak}
 use alloc::{vec, vec::Vec};
 use fontique::FontWeight;
 use icu_properties::props::{GraphemeClusterBreak, Script};
-use parley_engine::Boundary;
+use parley_engine::Boundary as EngineBoundary;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Boundary {
+    None,
+    Word,
+    Line,
+    Mandatory,
+}
 
 #[derive(Default)]
 struct TestContext {
     pub layout_context: LayoutContext,
     pub font_context: FontContext,
+    text: alloc::string::String,
 }
 
 impl TestContext {
     fn expect_boundary_list(self, expected: Vec<Boundary>) -> Self {
-        let actual: Vec<_> = self
-            .layout_context
-            .analysis
-            .char_info()
-            .iter()
-            .map(|info| info.boundary)
-            .collect();
+        let actual = self.legacy_boundary_list();
         assert_eq!(actual, expected, "Boundary list mismatch");
+        self
+    }
+
+    fn expect_word_boundary_bytes(self, expected: &[usize]) -> Self {
+        assert_eq!(
+            self.layout_context.word_boundary_bytes, expected,
+            "Word boundary byte list mismatch"
+        );
         self
     }
 
@@ -132,12 +143,30 @@ impl TestContext {
         self
     }
 
-    fn boundary_list(&self) -> Vec<Boundary> {
-        self.layout_context
-            .analysis
-            .char_info()
-            .iter()
-            .map(|info| info.boundary)
+    /// Reconstructs the combined boundary representation used before word
+    /// segmentation moved out of `parley_engine`.
+    fn legacy_boundary_list(&self) -> Vec<Boundary> {
+        let text = if self.text.is_empty() {
+            " "
+        } else {
+            &self.text
+        };
+        text.char_indices()
+            .zip(self.layout_context.analysis.char_info().iter())
+            .map(|((byte_offset, _), info)| match info.boundary {
+                EngineBoundary::Mandatory => Boundary::Mandatory,
+                EngineBoundary::Line => Boundary::Line,
+                EngineBoundary::None
+                    if self
+                        .layout_context
+                        .word_boundary_bytes
+                        .binary_search(&byte_offset)
+                        .is_ok() =>
+                {
+                    Boundary::Word
+                }
+                EngineBoundary::None => Boundary::None,
+            })
             .collect()
     }
 }
@@ -146,7 +175,10 @@ fn verify_analysis(
     text: &str,
     configure_builder: impl for<'a> FnOnce(&mut RangedBuilder<'a, [u8; 4]>),
 ) -> TestContext {
-    let mut test_context = TestContext::default();
+    let mut test_context = TestContext {
+        text: text.into(),
+        ..TestContext::default()
+    };
 
     {
         let mut builder = test_context.layout_context.ranged_builder(
@@ -169,7 +201,10 @@ fn verify_analysis_with_override(
     text: &str,
     line_break_override: &crate::LineBreakOverrideFn,
 ) -> TestContext {
-    let mut test_context = TestContext::default();
+    let mut test_context = TestContext {
+        text: text.into(),
+        ..TestContext::default()
+    };
 
     {
         let mut builder = test_context.layout_context.ranged_builder(
@@ -188,28 +223,28 @@ fn verify_analysis_with_override(
 #[test]
 fn test_line_break_override_none_matches_default() {
     let text = "ab/cd ef";
-    let default = verify_analysis(text, |_| {}).boundary_list();
-    let overridden = verify_analysis_with_override(text, &|_| None).boundary_list();
+    let default = verify_analysis(text, |_| {}).legacy_boundary_list();
+    let overridden = verify_analysis_with_override(text, &|_| None).legacy_boundary_list();
     assert_eq!(default, overridden);
 }
 
 #[test]
 fn test_line_break_override_suppresses_break_after_slash() {
     let text = "ab/cd";
-    let default = verify_analysis(text, |_| {}).boundary_list();
+    let default = verify_analysis(text, |_| {}).legacy_boundary_list();
     assert!(default.contains(&Boundary::Line),);
 
     let overridden = verify_analysis_with_override(text, &|cx| {
         if cx.before == '/' { Some(false) } else { None }
     })
-    .boundary_list();
+    .legacy_boundary_list();
 
     assert!(!overridden.contains(&Boundary::Line),);
 }
 
 #[test]
 fn test_line_break_override_does_not_suppress_mandatory_break() {
-    let overridden = verify_analysis_with_override("a\nb", &|_| Some(false)).boundary_list();
+    let overridden = verify_analysis_with_override("a\nb", &|_| Some(false)).legacy_boundary_list();
 
     assert_eq!(
         overridden,
@@ -219,13 +254,18 @@ fn test_line_break_override_does_not_suppress_mandatory_break() {
 
 #[test]
 fn test_line_break_override_mandatory_break_takes_precedence() {
-    let overridden = verify_analysis_with_override("a\nb", &|_| Some(true)).boundary_list();
+    let overridden = verify_analysis_with_override("a\nb", &|_| Some(true)).legacy_boundary_list();
 
     assert_eq!(
         overridden,
         // A mandatory break (e.g. `\n`) takes precedence over a forced line break override.
         vec![Boundary::Word, Boundary::Line, Boundary::Mandatory]
     );
+}
+
+#[test]
+fn test_word_boundaries_are_stored_as_utf8_byte_offsets() {
+    verify_analysis("é ok", |_| {}).expect_word_boundary_bytes(&[0, 2, 3, 5]);
 }
 
 #[test]

--- a/parley_engine/Cargo.toml
+++ b/parley_engine/Cargo.toml
@@ -16,10 +16,6 @@ all-features = true
 default = ["std"]
 std = ["fontique/std", "harfrust/std", "parlance/std", "skrifa/std"]
 libm = ["fontique/libm", "harfrust/libm", "skrifa/libm"]
-# Enables dictionary-based line and word breaking for complex scripts (CJK, Thai, Khmer, Lao, Myanmar).
-# When disabled, a lightweight segmenter is used that falls back to character-level breaks for those scripts.
-complex-scripts = []
-
 [dependencies]
 fontique = { workspace = true }
 parlance = { workspace = true }

--- a/parley_engine/src/analysis.rs
+++ b/parley_engine/src/analysis.rs
@@ -7,8 +7,6 @@
 //! [`Analysis`].
 
 use alloc::vec::Vec;
-use core::ops::Range;
-
 use icu_normalizer::properties::{
     CanonicalComposition, CanonicalCompositionBorrowed, CanonicalDecomposition,
     CanonicalDecompositionBorrowed,
@@ -17,16 +15,11 @@ use icu_properties::props::{BidiMirroringGlyph, GeneralCategory, GraphemeCluster
 use icu_properties::{
     CodePointMapData, CodePointMapDataBorrowed, PropertyNamesShort, PropertyNamesShortBorrowed,
 };
-use icu_segmenter::options::{LineBreakOptions, LineBreakWordOption, WordBreakInvariantOptions};
-use icu_segmenter::{
-    GraphemeClusterSegmenter, GraphemeClusterSegmenterBorrowed, LineSegmenter,
-    LineSegmenterBorrowed, WordSegmenter, WordSegmenterBorrowed,
-};
-use parlance::{BaseDirection, BidiLevel, WordBreak};
+use icu_segmenter::{GraphemeClusterSegmenter, GraphemeClusterSegmenterBorrowed};
+use parlance::{BaseDirection, BidiLevel};
 use parley_data::Properties;
 
 use crate::bidi;
-use crate::break_overrides::LineBreakContext;
 use crate::{AnalysisOptions, Analyzer};
 
 /// The result of [`Analyzer::analyze`].
@@ -103,39 +96,6 @@ impl AnalysisDataSources {
     }
 
     #[inline(always)]
-    fn word_segmenter(&self) -> WordSegmenterBorrowed<'static> {
-        #[cfg(feature = "complex-scripts")]
-        {
-            WordSegmenter::new_dictionary(WordBreakInvariantOptions::default())
-        }
-        #[cfg(not(feature = "complex-scripts"))]
-        {
-            const { WordSegmenter::new_for_non_complex_scripts(WordBreakInvariantOptions::default()) }
-        }
-    }
-
-    #[inline(always)]
-    fn line_segmenter(&self, word_break_strength: WordBreak) -> LineSegmenterBorrowed<'static> {
-        match word_break_strength {
-            WordBreak::Normal => {
-                let mut opt = LineBreakOptions::default();
-                opt.word_option = Some(LineBreakWordOption::Normal);
-                line_segmenter_impl(opt)
-            }
-            WordBreak::BreakAll => {
-                let mut opt = LineBreakOptions::default();
-                opt.word_option = Some(LineBreakWordOption::BreakAll);
-                line_segmenter_impl(opt)
-            }
-            WordBreak::KeepAll => {
-                let mut opt = LineBreakOptions::default();
-                opt.word_option = Some(LineBreakWordOption::KeepAll);
-                line_segmenter_impl(opt)
-            }
-        }
-    }
-
-    #[inline(always)]
     pub fn composing_normalizer(&self) -> CanonicalCompositionBorrowed<'_> {
         const { CanonicalComposition::new() }
     }
@@ -154,18 +114,6 @@ impl AnalysisDataSources {
     fn brackets(&self) -> CodePointMapDataBorrowed<'_, BidiMirroringGlyph> {
         const { CodePointMapData::new() }
     }
-}
-
-#[cfg(feature = "complex-scripts")]
-#[inline(always)]
-fn line_segmenter_impl(opt: LineBreakOptions<'_>) -> LineSegmenterBorrowed<'static> {
-    LineSegmenter::new_dictionary(opt)
-}
-
-#[cfg(not(feature = "complex-scripts"))]
-#[inline(always)]
-fn line_segmenter_impl(opt: LineBreakOptions<'_>) -> LineSegmenterBorrowed<'static> {
-    LineSegmenter::new_for_non_complex_scripts(opt)
 }
 
 /// Per-character analysis info.
@@ -292,12 +240,10 @@ impl CharInfo {
 pub enum Boundary {
     /// Not a boundary.
     None = 0,
-    /// Start of a word.
-    Word = 1,
     /// Potential line break.
-    Line = 2,
+    Line = 1,
     /// Mandatory line break.
-    Mandatory = 3,
+    Mandatory = 2,
 }
 
 pub(crate) fn analyze_text(
@@ -306,147 +252,20 @@ pub(crate) fn analyze_text(
     options: &AnalysisOptions<'_>,
     analysis: &mut Analysis,
 ) {
-    /// Turns the sparse, sorted, non-overlapping `options.word_break` into a contiguous sequence of
-    /// `(range, word-break)` segments covering all of `text`.
-    ///
-    /// Any region not covered by an override takes the default `WordBreak::Normal`.
-    struct DenseWordBreaks<'a> {
-        word_break: &'a [(Range<usize>, WordBreak)],
-        /// Index of the next word break to emit.
-        next: usize,
-        /// Start of the next segment to emit.
-        cursor: usize,
-        text_len: usize,
-    }
-
-    impl<'a> DenseWordBreaks<'a> {
-        fn new(word_break: &'a [(Range<usize>, WordBreak)], text_len: usize) -> Self {
-            Self {
-                word_break,
-                next: 0,
-                cursor: 0,
-                text_len,
-            }
-        }
-    }
-
-    impl Iterator for DenseWordBreaks<'_> {
-        type Item = (Range<usize>, WordBreak);
-
-        fn next(&mut self) -> Option<Self::Item> {
-            if self.cursor >= self.text_len {
-                return None;
-            }
-
-            // Ignore empty ranges.
-            while self
-                .word_break
-                .get(self.next)
-                .is_some_and(|(range, _)| range.is_empty())
-            {
-                self.next += 1;
-            }
-
-            match self.word_break.get(self.next) {
-                // A gap before the next override: fill it with the default up to its start.
-                Some((range, _)) if self.cursor < range.start => {
-                    let segment = self.cursor..range.start;
-                    self.cursor = range.start;
-                    Some((segment, WordBreak::Normal))
-                }
-                // At the next override: emit it.
-                Some((range, word_break)) => {
-                    self.cursor = range.end;
-                    self.next += 1;
-                    Some((range.start..range.end, *word_break))
-                }
-                // No overrides remain: fill the default to the end.
-                None => {
-                    let segment = self.cursor..self.text_len;
-                    self.cursor = self.text_len;
-                    Some((segment, WordBreak::Normal))
-                }
-            }
-        }
-    }
-
-    struct WordBreakSegmentIter<'a, I: Iterator> {
-        text: &'a str,
-        segments: I,
-        char_indices: core::str::CharIndices<'a>,
-        current_char: (usize, char),
-        building_range_start: usize,
-        previous_word_break_style: WordBreak,
-        done: bool,
-    }
-
-    impl<'a, I> WordBreakSegmentIter<'a, I>
-    where
-        I: Iterator<Item = (Range<usize>, WordBreak)>,
-    {
-        fn new(text: &'a str, segments: I, first_segment: (Range<usize>, WordBreak)) -> Self {
-            let mut char_indices = text.char_indices();
-            let current_char_len = char_indices.next().unwrap();
-
-            Self {
-                text,
-                segments,
-                char_indices,
-                current_char: current_char_len,
-                building_range_start: first_segment.0.start,
-                previous_word_break_style: first_segment.1,
-                done: false,
-            }
-        }
-    }
-
-    impl<'a, I> Iterator for WordBreakSegmentIter<'a, I>
-    where
-        I: Iterator<Item = (Range<usize>, WordBreak)>,
-    {
-        type Item = (&'a str, WordBreak, bool);
-
-        fn next(&mut self) -> Option<Self::Item> {
-            if self.done {
-                return None;
-            }
-
-            for (range, word_break) in self.segments.by_ref() {
-                assert!(range.start < range.end, "Segments must not be empty");
-
-                let style_start_index = range.start;
-                let mut prev_char_index = self.current_char;
-
-                // Find the character at the style boundary.
-                while self.current_char.0 < style_start_index {
-                    prev_char_index = self.current_char;
-                    self.current_char = self.char_indices.next().unwrap();
-                }
-
-                let current_word_break_style = word_break;
-                if self.previous_word_break_style == current_word_break_style {
-                    continue;
-                }
-
-                // Produce one substring for each different word break style run
-                let prev_size = prev_char_index.1.len_utf8();
-                let size = self.current_char.1.len_utf8();
-
-                let substring = &self.text[self.building_range_start..style_start_index + size];
-                let result_style = self.previous_word_break_style;
-
-                self.building_range_start = style_start_index - prev_size;
-                self.previous_word_break_style = current_word_break_style;
-
-                return Some((substring, result_style, false));
-            }
-
-            // Final segment
-            self.done = true;
-            let last_substring = &self.text[self.building_range_start..self.text.len()];
-            Some((last_substring, self.previous_word_break_style, true))
-        }
-    }
+    assert!(
+        options
+            .line_break_opportunities
+            .windows(2)
+            .all(|pair| pair[0] <= pair[1]),
+        "line break opportunities must be sorted"
+    );
+    assert!(
+        options
+            .line_break_opportunities
+            .iter()
+            .all(|&offset| text.is_char_boundary(offset)),
+        "line break opportunities must be UTF-8 character boundaries"
+    );
 
     if text.is_empty() {
         analyzer
@@ -456,100 +275,15 @@ pub(crate) fn analyze_text(
         return;
     }
 
-    // Line boundaries (word break naming refers to the line boundary determination config).
-    //
-    // This breaks text into sequences with similar line boundary config (part of style
-    // information). If this config is consistent for all text, we use a fast path through this.
-    let mut segments = DenseWordBreaks::new(options.word_break, text.len());
-    // `text` is non-empty (checked above), so there is always at least one segment.
-    let first_segment = segments.next().unwrap();
-    let contiguous_word_break_substrings = WordBreakSegmentIter::new(text, segments, first_segment);
-
-    let mut global_offset = 0;
-    let mut line_boundary_positions: Vec<usize> = Vec::new();
-
     let data_sources = AnalysisDataSources::new();
-
-    for (substring_index, (substring, word_break_strength, last)) in
-        contiguous_word_break_substrings.enumerate()
-    {
-        // Fast path for text with a single word-break option.
-        if substring_index == 0 && last {
-            let mut lb_iter = data_sources
-                .line_segmenter(word_break_strength)
-                .segment_str(substring);
-
-            let _first = lb_iter.next();
-            let second = lb_iter.next();
-            if second.is_none() {
-                continue;
-            }
-            let third = lb_iter.next();
-            if third.is_none() {
-                continue;
-            }
-
-            let iter = [second.unwrap(), third.unwrap()].into_iter().chain(lb_iter);
-
-            line_boundary_positions.extend(iter);
-            // Remove the unnecessary boundary at the end added by ICU4X.
-            line_boundary_positions.pop();
-            break;
-        }
-
-        let line_boundaries_iter = data_sources
-            .line_segmenter(word_break_strength)
-            .segment_str(substring);
-
-        let mut substring_chars = substring.chars();
-        if substring_index != 0 {
-            global_offset -= substring_chars.next().unwrap().len_utf8();
-        }
-        // There will always be at least two characters if we are not taking the fast path for
-        // a single word break style substring.
-        let last_len = substring_chars.next_back().unwrap().len_utf8();
-
-        // Mark line boundaries (overriding word boundaries where present).
-        for (index, pos) in line_boundaries_iter.enumerate() {
-            // icu adds leading and trailing line boundaries, which we don't use.
-            if index == 0 || pos == substring.len() {
-                continue;
-            }
-
-            // For all but the last substring, we ignore line boundaries caused by the last
-            // character, as this character is carried back from the next substring, and will be
-            // accounted for there.
-            if !last && pos == substring.len() - last_len {
-                continue;
-            }
-            line_boundary_positions.push(pos + global_offset);
-        }
-
-        if !last {
-            global_offset += substring.len() - last_len;
-        }
-    }
-
-    // Collect boundary byte positions compactly
-    let mut wb_iter = data_sources.word_segmenter().segment_str(text).peekable();
     let mut gb_iter = data_sources
         .grapheme_segmenter()
         .segment_str(text)
         .peekable();
 
-    // Merge boundaries - line takes precedence over word
-    let mut lb_iter = line_boundary_positions.iter().peekable();
-    let mut prev_char = None;
-    let mut prev_prev_char = None;
+    // Merge caller-provided line opportunities with grapheme boundaries.
+    let mut lb_iter = options.line_break_opportunities.iter().peekable();
     let boundary_iter = text.char_indices().map(|(byte_pos, ch)| {
-        // advance any stale word boundary positions
-        while let Some(&w) = wb_iter.peek() {
-            if w < byte_pos {
-                _ = wb_iter.next();
-            } else {
-                break;
-            }
-        }
         // advance any stale grapheme boundary positions
         while let Some(&g) = gb_iter.peek() {
             if g < byte_pos {
@@ -558,22 +292,6 @@ pub(crate) fn analyze_text(
                 break;
             }
         }
-        // advance any stale line boundary positions
-        while let Some(&l) = lb_iter.peek() {
-            if *l < byte_pos {
-                _ = lb_iter.next();
-            } else {
-                break;
-            }
-        }
-
-        let mut is_word = false;
-        if let Some(&w) = wb_iter.peek()
-            && w == byte_pos
-        {
-            is_word = true;
-            _ = wb_iter.next();
-        }
         let mut is_grapheme_start = false;
         if let Some(&g) = gb_iter.peek()
             && g == byte_pos
@@ -581,32 +299,17 @@ pub(crate) fn analyze_text(
             is_grapheme_start = true;
             _ = gb_iter.next();
         }
-        let mut is_line = false;
-        if let Some(&l) = lb_iter.peek()
-            && *l == byte_pos
-        {
-            is_line = true;
+        let is_line = lb_iter.peek().is_some_and(|&&offset| offset == byte_pos);
+        while lb_iter.peek().is_some_and(|&&offset| offset == byte_pos) {
             _ = lb_iter.next();
         }
-
-        // This leaves word boundaries intact. Consumers can only impact line boundaries.
-        if let (Some(prev), Some(lb_override)) = (prev_char, options.line_break_override) {
-            let forced = lb_override(LineBreakContext {
-                before_before: prev_prev_char,
-                before: prev,
-                after: ch,
-            });
-            if let Some(forced) = forced {
-                is_line = forced;
-            }
-        }
-        prev_prev_char = prev_char;
-        prev_char = Some(ch);
+        assert!(
+            !is_line || is_grapheme_start,
+            "line break opportunities must be grapheme-cluster boundaries"
+        );
 
         let boundary = if is_line {
             Boundary::Line
-        } else if is_word {
-            Boundary::Word
         } else {
             Boundary::None
         };

--- a/parley_engine/src/analyzer.rs
+++ b/parley_engine/src/analyzer.rs
@@ -3,11 +3,9 @@
 
 //! The analyzer API.
 
-use core::ops::Range;
+use parlance::BaseDirection;
 
-use parlance::{BaseDirection, WordBreak};
-
-use crate::{bidi::BidiResolver, break_overrides::LineBreakOverrideFn};
+use crate::bidi::BidiResolver;
 
 use crate::analysis::{Analysis, analyze_text};
 
@@ -45,24 +43,26 @@ pub struct AnalysisOptions<'a> {
     ///
     /// Defaults to [`BaseDirection::Auto`], which infers the direction from the text.
     pub base_direction: BaseDirection,
-
-    /// Word break configuration for ranges of the source text.
+    /// Sorted UTF-8 byte offsets at which a soft line break is allowed.
     ///
-    /// Ranges must be sorted and non-overlapping, and must start and end on character boundaries of
-    /// the text. Empty ranges are ignored. Gaps use [`WordBreak::Normal`].
-    pub word_break: &'a [(Range<usize>, WordBreak)],
-
-    /// The callback which will be called as a first provider of line breaking decisions.
+    /// Each offset is before the character that starts there and must be both a
+    /// character boundary and a grapheme-cluster boundary. An empty slice disables
+    /// soft wrapping; mandatory line breaks are still detected by the analyzer.
+    /// APIs that report UTF-16 indices, such as JavaScript's `Intl.Segmenter`, must
+    /// have their results converted to UTF-8 byte offsets by the caller.
     ///
-    /// See [`LineBreakOverrideFn`] for more details.
-    pub line_break_override: Option<&'a LineBreakOverrideFn>,
+    /// # Panics
+    ///
+    /// [`Analyzer::analyze`] panics if these offsets are not sorted, do not fall on
+    /// UTF-8 character boundaries, or fall within a grapheme cluster.
+    pub line_break_opportunities: &'a [usize],
 }
 
 impl core::fmt::Debug for AnalysisOptions<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("AnalysisOptions")
             .field("base_direction", &self.base_direction)
-            .field("word_break", &self.word_break)
+            .field("line_break_opportunities", &self.line_break_opportunities)
             .finish_non_exhaustive()
     }
 }
@@ -72,7 +72,7 @@ mod tests {
     use parlance::BidiLevel;
 
     use super::{AnalysisOptions, Analyzer};
-    use crate::{Analysis, BaseDirection};
+    use crate::{Analysis, BaseDirection, Boundary};
 
     fn analyze(text: &str, base_direction: BaseDirection) -> Analysis {
         let mut analyzer = Analyzer::new();
@@ -134,5 +134,73 @@ mod tests {
 
         assert!(analysis.paragraph_level().is_rtl());
         assert!(analysis.bidi_levels().is_empty());
+    }
+
+    #[test]
+    fn caller_provided_line_breaks_are_used() {
+        let mut analyzer = Analyzer::new();
+        let mut analysis = Analysis::new();
+        analyzer.analyze(
+            "abc",
+            &AnalysisOptions {
+                line_break_opportunities: &[1],
+                ..AnalysisOptions::default()
+            },
+            &mut analysis,
+        );
+        assert_eq!(analysis.char_info()[1].boundary, Boundary::Line);
+    }
+
+    #[test]
+    fn empty_line_breaks_disable_soft_wrapping() {
+        let analysis = analyze("abc def", BaseDirection::Auto);
+        assert!(
+            analysis
+                .char_info()
+                .iter()
+                .all(|info| info.boundary == Boundary::None)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "must be sorted")]
+    fn rejects_unsorted_line_breaks() {
+        let mut analyzer = Analyzer::new();
+        analyzer.analyze(
+            "abc",
+            &AnalysisOptions {
+                line_break_opportunities: &[2, 1],
+                ..AnalysisOptions::default()
+            },
+            &mut Analysis::new(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "UTF-8 character boundaries")]
+    fn rejects_non_character_line_breaks() {
+        let mut analyzer = Analyzer::new();
+        analyzer.analyze(
+            "aé",
+            &AnalysisOptions {
+                line_break_opportunities: &[2],
+                ..AnalysisOptions::default()
+            },
+            &mut Analysis::new(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "grapheme-cluster boundaries")]
+    fn rejects_mid_grapheme_line_breaks() {
+        let mut analyzer = Analyzer::new();
+        analyzer.analyze(
+            "a\u{301}",
+            &AnalysisOptions {
+                line_break_opportunities: &[1],
+                ..AnalysisOptions::default()
+            },
+            &mut Analysis::new(),
+        );
     }
 }

--- a/parley_engine/src/lib.rs
+++ b/parley_engine/src/lib.rs
@@ -26,7 +26,6 @@ extern crate alloc;
 mod analysis;
 mod analyzer;
 pub mod bidi;
-pub mod break_overrides;
 mod glyph;
 pub mod itemize;
 mod lru_cache;

--- a/parley_engine/src/shape/atom.rs
+++ b/parley_engine/src/shape/atom.rs
@@ -694,10 +694,9 @@ impl GraphemeFlags {
     fn boundary_before(self) -> Boundary {
         match self.0 & Self::BOUNDARY_MASK {
             0 => Boundary::None,
-            1 => Boundary::Word,
-            2 => Boundary::Line,
-            3 => Boundary::Mandatory,
-            _ => unreachable!("0..4 are the only valid values"),
+            1 => Boundary::Line,
+            2 => Boundary::Mandatory,
+            _ => unreachable!("0..3 are the only valid values"),
         }
     }
 
@@ -828,8 +827,7 @@ mod tests {
         Analyzer::new().analyze(
             text,
             &AnalysisOptions {
-                word_break: &[],
-                line_break_override: None,
+                line_break_opportunities: &[],
                 ..AnalysisOptions::default()
             },
             &mut analysis,

--- a/parley_engine/src/shape/shaped_text.rs
+++ b/parley_engine/src/shape/shaped_text.rs
@@ -573,8 +573,7 @@ mod tests {
         Analyzer::new().analyze(
             text,
             &AnalysisOptions {
-                word_break: &[],
-                line_break_override: None,
+                line_break_opportunities: &[],
                 ..AnalysisOptions::default()
             },
             &mut analysis,


### PR DESCRIPTION
LLM Contributions: Fable to write plan, Sol to implement.

> [!WARNING]
>
> This PR's changes are currently fully LLM generated, and the LLMs have made some hard-to-defend choices, which I plan to change.

See [#parley > Moving Segmentation out of Parley Engine](https://xi.zulipchat.com/#narrow/channel/205635-parley/topic/Moving.20Segmentation.20out.20of.20Parley.20Engine/with/619204677).

**Changelog**

> ### Parley Engine
>
> - Breaking change: Parley Engine no longer calculates line breaking opportunities.