### PR TITLE
Simplify template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,25 +1,17 @@
-<!--
-Thanks for opening a PR for this Linebender project!
--->
+<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.
 
-<!-- If you used any LLM ("AI") tools in making this PR, please ensure that you have reviewed our
-LLM policy at https://linebender.org/wiki/llm-policy/.
-Please list how you used it (e.g. writing code, reviewing, fact finding) below.
-We expect you to have fully understood and self-reviewed your contributions to Linebender.
-
-If you did not use any LLM tools, please replace "Unspecified" with 'None'. -->
+If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
 LLM Contributions: Unspecified.
 
-_Describe what problem this is solving, and how it's solved. Use your own words - descriptions authored by LLMs are not allowed._
+_Use your own words - descriptions authored by LLMs are not allowed._
 
 <!--
-If this change has any user facing effects, please describe them in the quote block below.
+If our users need to know about this change, please describe that in the quote block below.
 What you write here will be edited by us later - it doesn't need to be perfect.
-If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**` and delete
-the quote block. Do not use an LLM to write the changelog entry.
+If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
 -->
 **Changelog**
 
 > ### Added
 >
-> - [Breaking change:] Changelog entry.
+> - Breaking change: Changelog entry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog follows the patterns described here: <https://keepachangelog.com/
 
 Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
 
+This changelog is updated based on pull request bodies - see `.github/pull_request_template.md`.
+In general, when submitting a PR, you should generally not manually edit this file.
+Every change to this file must be written by a human.
+
 -->
 
 # Changelog


### PR DESCRIPTION
LLM Contributions: None.

Based on feedback in [#parley > Parley PR template](https://xi.zulipchat.com/#narrow/channel/205635-parley/topic/Parley.20PR.20template/with/616079356), the current template is too long.
People also seem unable to understand the syntax of using square brackets for optional arguments. I had been under the impression that this was common, but I've not observed anyone actually use it correctly. As such, I've removed it from the template.

Additionally, people using LLM tools to open their PRs is currently indistinguishable from people using e.g. IDEs or other tools which don't expose it. I'm hinting towards this template in the CHANGELOG file to at least have a chance for LLMs to follow this (I've observed LLMs having a drive to make CHANGELOG entries).

**Changelog: None**