### PR TITLE
Fix LineHeight not forcing a new itemizer item

### DIFF
--- a/parley/src/shape/mod.rs
+++ b/parley/src/shape/mod.rs
@@ -155,7 +155,8 @@ pub(crate) fn shape_text<'a, B: Brush>(
                         || style.font_variations != item_style.font_variations
                         || style.font_features != item_style.font_features
                         || !nearly_eq(style.letter_spacing, item_style.letter_spacing)
-                        || !nearly_eq(style.word_spacing, item_style.word_spacing);
+                        || !nearly_eq(style.word_spacing, item_style.word_spacing)
+                        || !style.line_height.nearly_eq(item_style.line_height);
                 }
 
                 if split {

--- a/parley/src/tests/test_builders.rs
+++ b/parley/src/tests/test_builders.rs
@@ -685,3 +685,30 @@ fn builders_crlf_across_run_boundary_counts_as_single_line_break() {
         "styled CRLF should match styled LF line count"
     );
 }
+
+/// Test that a `LineHeight` difference alone forces a new itemizer item.
+#[test]
+fn line_height_alone_forces_a_new_item() {
+    let text = "Hello world";
+    let mut fcx = create_font_context();
+    let mut lcx: LayoutContext<ColorBrush> = LayoutContext::new();
+
+    let mut rb = lcx.ranged_builder(&mut fcx, text, 1.0, true);
+    rb.push_default(FontFamily::from(FONT_FAMILY_LIST));
+    rb.push_default(StyleProperty::FontSize(16.));
+    rb.push_default(LineHeight::Absolute(20.));
+    rb.push(StyleProperty::LineHeight(LineHeight::Absolute(40.)), 6..11);
+    let mut layout = rb.build(text);
+    layout.break_all_lines(None);
+
+    let runs: Vec<_> = layout.lines().flat_map(|line| line.runs()).collect();
+    assert_eq!(
+        runs.len(),
+        2,
+        "a LineHeight-only change should split into its own run"
+    );
+    assert_eq!(runs[0].text_range(), 0..6);
+    assert_eq!(runs[0].line_height(), 20.);
+    assert_eq!(runs[1].text_range(), 6..11);
+    assert_eq!(runs[1].line_height(), 40.);
+}


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: None.

For ranges with only the `StyleProperty::LineHeight` being different from the "current" style during `shape_text` shape-relevant style properties change splitting a new itemizer item wasn't created so line height change was being lost in the shaping result.

I noticed that I can't get "spans" of text with the line height that is different from the base style to actually have that line height. It was actually worse in the current published version (there seems to be an off by one bug concerning the line heights that prevented the correct line height application to spans even when accompanied by other style properties change). I looked through the codebase and through documentation/comments and couldn't find anything that can hint at why line height wasn't in "shaping-relevant style properties" set. I checked how it works in CSS just to make sure I'm not going crazy and it works as I'd expected it to work.

It's a tiny change. I added a test to make sure it works the way I think it should. The `builders_style_runs_match_ranged` can't capture this because it compares builders outputs and all builders ultimately use the same item-splitting code.

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog**

> ### Added
>
> - LineHeight change is now respected as shaping-relevant style property change.
