### PR TITLE
Make glyph run iteration fast again

### DIFF
--- a/parley/src/layout/line.rs
+++ b/parley/src/layout/line.rs
@@ -11,7 +11,7 @@ use crate::style::Brush;
 use crate::{InlineBox, InlineBoxKind};
 
 use core::ops::Range;
-use parley_engine::{Atom, Atoms, Glyph, ShapedSlice};
+use parley_engine::{Atom, Atoms, Glyph};
 
 /// Line in a text layout.
 #[derive(Copy, Clone)]
@@ -298,14 +298,14 @@ impl<'a, B: Brush> GlyphRun<'a, B> {
     }
 }
 
-/// Cursor over the atoms of a run in visual order, resumable across [`GlyphRunIter::next`] calls.
+/// Peekable iterator over the atoms of a run in visual order, resumable across
+/// [`GlyphRunIter::next`] calls.
 ///
-/// This walks the run's shaped data ([`ShapedSlice`]/[`Atom`]) directly rather than
-/// materialising [`Cluster`](crate::Cluster)s and their composed glyph iterators. It computes
-/// the same glyph counts and advances as [`Run::glyphs_in`] over the same atoms.
+/// This walks the run's shaped data ([`Atom`]s) directly rather than materialising
+/// [`Cluster`](crate::Cluster)s and their composed glyph iterators. It computes the same glyph
+/// counts and advances as [`Run::glyphs_in`] over the same atoms.
 #[derive(Clone)]
-struct AtomCursor<'a> {
-    slice: ShapedSlice<'a>,
+struct AtomIter<'a> {
     atoms: Atoms<'a>,
     spacing: EffectiveSpacing,
     is_rtl: bool,
@@ -313,12 +313,11 @@ struct AtomCursor<'a> {
     peeked: Option<Atom<'a>>,
 }
 
-impl<'a> AtomCursor<'a> {
+impl<'a> AtomIter<'a> {
     fn new<B: Brush>(run: Run<'a, B>) -> Self {
         let slice = run.line_slice();
         let is_rtl = run.is_rtl();
         Self {
-            slice,
             atoms: if is_rtl {
                 slice.atoms_end()
             } else {
@@ -342,23 +341,22 @@ impl<'a> AtomCursor<'a> {
         self.peeked
     }
 
+    /// Consume the atom returned by [`Self::peek`], so the next peek moves on.
     #[inline]
-    fn advance(&mut self) {
+    fn consume(&mut self) {
         self.peeked = None;
     }
 
     /// The number of glyphs in `atom` and the sum of their advances (including spacing gaps),
     /// matching what [`Run::glyphs_in`] yields for the atom's clusters.
     #[inline]
-    fn glyphs(&self, atom: &Atom<'a>) -> (usize, f32) {
-        let mut glyph_count = 0_usize;
-        let mut advance = 0.0_f32;
-        for cluster_idx in atom.shaped_clusters_range() {
-            for glyph in self.slice.shaped_cluster_glyphs(cluster_idx) {
-                glyph_count += 1;
-                advance += glyph.advance;
-            }
-        }
+    fn measure(&self, atom: &Atom<'a>) -> (usize, f32) {
+        let glyph_count: usize = atom
+            .shaped_clusters()
+            .iter()
+            .map(|cluster| usize::from(cluster.glyph_len()))
+            .sum();
+        let mut advance = atom.advance();
         if glyph_count != 0 && !self.spacing.is_zero() {
             advance += self.spacing.gaps(atom).total();
         }
@@ -370,9 +368,9 @@ impl<'a> AtomCursor<'a> {
 struct GlyphRunIter<'a, B: Brush> {
     line: Line<'a, B>,
     item_index: usize,
-    /// Cursor over the visual atoms of the run at `item_index`, positioned at the first atom not
-    /// yet yielded as part of a glyph run. `None` before entering a run.
-    atoms: Option<AtomCursor<'a>>,
+    /// Iterator over the visual atoms of the run at `item_index`, positioned at the first atom
+    /// not yet yielded as part of a glyph run. `None` before entering a run.
+    atoms: Option<AtomIter<'a>>,
     glyph_start: usize,
     offset: f32,
 }
@@ -409,16 +407,16 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                     // TODO: style indices are taken from the atom's first character, matching
                     // `Cluster::style_index`. We could get the style index from `parley_engine`'s
                     // `ShapedCluster` instead, which would be somewhat finer-grained.
-                    let atoms = self.atoms.get_or_insert_with(|| AtomCursor::new(run));
+                    let atoms = self.atoms.get_or_insert_with(|| AtomIter::new(run));
 
                     // Styles are uniform within an atom, so glyph runs always end on atom
-                    // boundaries and the cursor only needs to resume at atom granularity.
+                    // boundaries and the iterator only needs to resume at atom granularity.
                     // Atoms without glyphs don't take part.
                     let mut advance = 0.0;
                     let mut glyph_count = 0;
                     let mut style_index: Option<u16> = None;
                     while let Some(atom) = atoms.peek() {
-                        let (atom_glyph_count, atom_advance) = atoms.glyphs(&atom);
+                        let (atom_glyph_count, atom_advance) = atoms.measure(&atom);
                         if atom_glyph_count != 0 {
                             let atom_style_index = atom.characters()[0].style_index;
                             if style_index.is_some_and(|s| s != atom_style_index) {
@@ -428,7 +426,7 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                             glyph_count += atom_glyph_count;
                             advance += atom_advance;
                         }
-                        atoms.advance();
+                        atoms.consume();
                     }
 
                     if let Some(first_style_index) = style_index {

--- a/parley/src/layout/line.rs
+++ b/parley/src/layout/line.rs
@@ -5,13 +5,13 @@ use crate::layout::Style;
 use crate::layout::data::BreakReason;
 use crate::layout::data::{LayoutItemKind, LineData};
 use crate::layout::layout::Layout;
-use crate::layout::run::{Clusters, Run};
+use crate::layout::run::Run;
+use crate::layout::spacing::EffectiveSpacing;
 use crate::style::Brush;
 use crate::{InlineBox, InlineBoxKind};
 
-use core::iter::Peekable;
 use core::ops::Range;
-use parley_engine::Glyph;
+use parley_engine::{Atom, Atoms, Glyph, ShapedSlice};
 
 /// Line in a text layout.
 #[derive(Copy, Clone)]
@@ -108,7 +108,7 @@ impl<'a, B: Brush> Line<'a, B> {
         GlyphRunIter {
             line: self.clone(),
             item_index: 0,
-            clusters: None,
+            atoms: None,
             glyph_start: 0,
             offset: 0.,
         }
@@ -298,13 +298,81 @@ impl<'a, B: Brush> GlyphRun<'a, B> {
     }
 }
 
+/// Cursor over the atoms of a run in visual order, resumable across [`GlyphRunIter::next`] calls.
+///
+/// This walks the run's shaped data ([`ShapedSlice`]/[`Atom`]) directly rather than
+/// materialising [`Cluster`](crate::Cluster)s and their composed glyph iterators. It computes
+/// the same glyph counts and advances as [`Run::glyphs_in`] over the same atoms.
+#[derive(Clone)]
+struct AtomCursor<'a> {
+    slice: ShapedSlice<'a>,
+    atoms: Atoms<'a>,
+    spacing: EffectiveSpacing,
+    is_rtl: bool,
+    /// The next atom in visual order, if it has been peeked but not yet consumed.
+    peeked: Option<Atom<'a>>,
+}
+
+impl<'a> AtomCursor<'a> {
+    fn new<B: Brush>(run: Run<'a, B>) -> Self {
+        let slice = run.line_slice();
+        let is_rtl = run.is_rtl();
+        Self {
+            slice,
+            atoms: if is_rtl {
+                slice.atoms_end()
+            } else {
+                slice.atoms_start()
+            },
+            spacing: run.line_spacing(),
+            is_rtl,
+            peeked: None,
+        }
+    }
+
+    #[inline]
+    fn peek(&mut self) -> Option<Atom<'a>> {
+        if self.peeked.is_none() {
+            self.peeked = if self.is_rtl {
+                self.atoms.prev()
+            } else {
+                self.atoms.next()
+            };
+        }
+        self.peeked
+    }
+
+    #[inline]
+    fn advance(&mut self) {
+        self.peeked = None;
+    }
+
+    /// The number of glyphs in `atom` and the sum of their advances (including spacing gaps),
+    /// matching what [`Run::glyphs_in`] yields for the atom's clusters.
+    #[inline]
+    fn glyphs(&self, atom: &Atom<'a>) -> (usize, f32) {
+        let mut glyph_count = 0_usize;
+        let mut advance = 0.0_f32;
+        for cluster_idx in atom.shaped_clusters_range() {
+            for glyph in self.slice.shaped_cluster_glyphs(cluster_idx) {
+                glyph_count += 1;
+                advance += glyph.advance;
+            }
+        }
+        if glyph_count != 0 && !self.spacing.is_zero() {
+            advance += self.spacing.gaps(atom).total();
+        }
+        (glyph_count, advance)
+    }
+}
+
 #[derive(Clone)]
 struct GlyphRunIter<'a, B: Brush> {
     line: Line<'a, B>,
     item_index: usize,
-    /// Cursor over the visual clusters of the run at `item_index`, positioned at the first
-    /// cluster not yet yielded as part of a glyph run. `None` before entering a run.
-    clusters: Option<Peekable<Clusters<'a, B>>>,
+    /// Cursor over the visual atoms of the run at `item_index`, positioned at the first atom not
+    /// yet yielded as part of a glyph run. `None` before entering a run.
+    atoms: Option<AtomCursor<'a>>,
     glyph_start: usize,
     offset: f32,
 }
@@ -338,36 +406,29 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                     }));
                 }
                 LineItem::Run(run) => {
-                    // TODO: this is taking the glyphs and style indices from `parley`'s `Cluster`,
-                    // which means style indices are taken from the atom's first character. We could
-                    // get the style index from `parley_engine`'s `ShapedCluster` instead, which
-                    // would be somewhat finer-grained.
-                    let clusters = self
-                        .clusters
-                        .get_or_insert_with(|| Clusters::new(run, run.is_rtl()).peekable());
+                    // TODO: style indices are taken from the atom's first character, matching
+                    // `Cluster::style_index`. We could get the style index from `parley_engine`'s
+                    // `ShapedCluster` instead, which would be somewhat finer-grained.
+                    let atoms = self.atoms.get_or_insert_with(|| AtomCursor::new(run));
 
-                    // Styles are uniform within a cluster, so glyph runs always end on cluster
-                    // boundaries and the cursor only needs to resume at cluster granularity.
-                    // Clusters without glyphs (ligature continuations) don't take part.
+                    // Styles are uniform within an atom, so glyph runs always end on atom
+                    // boundaries and the cursor only needs to resume at atom granularity.
+                    // Atoms without glyphs don't take part.
                     let mut advance = 0.0;
                     let mut glyph_count = 0;
                     let mut style_index: Option<u16> = None;
-                    while let Some(cluster) = clusters.peek() {
-                        let mut glyphs = cluster.glyphs();
-                        if let Some(first_glyph) = glyphs.next() {
-                            let cluster_style_index = cluster.style_index();
-                            if style_index.is_some_and(|s| s != cluster_style_index) {
+                    while let Some(atom) = atoms.peek() {
+                        let (atom_glyph_count, atom_advance) = atoms.glyphs(&atom);
+                        if atom_glyph_count != 0 {
+                            let atom_style_index = atom.characters()[0].style_index;
+                            if style_index.is_some_and(|s| s != atom_style_index) {
                                 break;
                             }
-                            style_index = Some(cluster_style_index);
-                            glyph_count += 1;
-                            advance += first_glyph.advance;
-                            for glyph in glyphs {
-                                glyph_count += 1;
-                                advance += glyph.advance;
-                            }
+                            style_index = Some(atom_style_index);
+                            glyph_count += atom_glyph_count;
+                            advance += atom_advance;
                         }
-                        clusters.next();
+                        atoms.advance();
                     }
 
                     if let Some(first_style_index) = style_index {
@@ -387,8 +448,8 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                             advance,
                         }));
                     }
-                    // Any clusters left have no glyphs and thus nothing to yield.
-                    self.clusters = None;
+                    // Any atoms left have no glyphs and thus nothing to yield.
+                    self.atoms = None;
                     self.item_index += 1;
                     self.glyph_start = 0;
                 }

--- a/parley/src/layout/line.rs
+++ b/parley/src/layout/line.rs
@@ -5,10 +5,11 @@ use crate::layout::Style;
 use crate::layout::data::BreakReason;
 use crate::layout::data::{LayoutItemKind, LineData};
 use crate::layout::layout::Layout;
-use crate::layout::run::Run;
+use crate::layout::run::{Clusters, Run};
 use crate::style::Brush;
 use crate::{InlineBox, InlineBoxKind};
 
+use core::iter::Peekable;
 use core::ops::Range;
 use parley_engine::Glyph;
 
@@ -107,6 +108,7 @@ impl<'a, B: Brush> Line<'a, B> {
         GlyphRunIter {
             line: self.clone(),
             item_index: 0,
+            clusters: None,
             glyph_start: 0,
             offset: 0.,
         }
@@ -300,6 +302,9 @@ impl<'a, B: Brush> GlyphRun<'a, B> {
 struct GlyphRunIter<'a, B: Brush> {
     line: Line<'a, B>,
     item_index: usize,
+    /// Cursor over the visual clusters of the run at `item_index`, positioned at the first
+    /// cluster not yet yielded as part of a glyph run. `None` before entering a run.
+    clusters: Option<Peekable<Clusters<'a, B>>>,
     glyph_start: usize,
     offset: f32,
 }
@@ -337,23 +342,35 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                     // which means style indices are taken from the atom's first character. We could
                     // get the style index from `parley_engine`'s `ShapedCluster` instead, which
                     // would be somewhat finer-grained.
-                    let mut glyphs = run
-                        .visual_clusters()
-                        .flat_map(|c| {
-                            let style_index = c.style_index();
-                            c.glyphs().map(move |glyph| (glyph, style_index))
-                        })
-                        .skip(self.glyph_start);
+                    let clusters = self
+                        .clusters
+                        .get_or_insert_with(|| Clusters::new(run, run.is_rtl()).peekable());
 
-                    if let Some((first_glyph, first_style_index)) = glyphs.next() {
-                        let mut advance = first_glyph.advance;
-                        let mut glyph_count = 1;
-                        for (glyph, _) in
-                            glyphs.take_while(|(_, style_index)| *style_index == first_style_index)
-                        {
+                    // Styles are uniform within a cluster, so glyph runs always end on cluster
+                    // boundaries and the cursor only needs to resume at cluster granularity.
+                    // Clusters without glyphs (ligature continuations) don't take part.
+                    let mut advance = 0.0;
+                    let mut glyph_count = 0;
+                    let mut style_index: Option<u16> = None;
+                    while let Some(cluster) = clusters.peek() {
+                        let mut glyphs = cluster.glyphs();
+                        if let Some(first_glyph) = glyphs.next() {
+                            let cluster_style_index = cluster.style_index();
+                            if style_index.is_some_and(|s| s != cluster_style_index) {
+                                break;
+                            }
+                            style_index = Some(cluster_style_index);
                             glyph_count += 1;
-                            advance += glyph.advance;
+                            advance += first_glyph.advance;
+                            for glyph in glyphs {
+                                glyph_count += 1;
+                                advance += glyph.advance;
+                            }
                         }
+                        clusters.next();
+                    }
+
+                    if let Some(first_style_index) = style_index {
                         let glyph_start = self.glyph_start;
                         self.glyph_start += glyph_count;
                         let offset = self.offset;
@@ -370,6 +387,8 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                             advance,
                         }));
                     }
+                    // Any clusters left have no glyphs and thus nothing to yield.
+                    self.clusters = None;
                     self.item_index += 1;
                     self.glyph_start = 0;
                 }

--- a/parley/src/layout/run.rs
+++ b/parley/src/layout/run.rs
@@ -330,7 +330,7 @@ impl<'a, B: Brush> Run<'a, B> {
 /// An iterator over a [`Run`]'s clusters.
 ///
 /// This walks the run's graphemes. Each grapheme is one [`Cluster`].
-struct Clusters<'a, B: Brush> {
+pub(crate) struct Clusters<'a, B: Brush> {
     run: Run<'a, B>,
     /// Cursor over the run's (line-scoped) atoms.
     atoms: Atoms<'a>,
@@ -346,7 +346,7 @@ struct Clusters<'a, B: Brush> {
 }
 
 impl<'a, B: Brush> Clusters<'a, B> {
-    fn new(run: Run<'a, B>, rev: bool) -> Self {
+    pub(crate) fn new(run: Run<'a, B>, rev: bool) -> Self {
         let slice = run.line_slice();
         Self {
             run,

--- a/parley/src/layout/run.rs
+++ b/parley/src/layout/run.rs
@@ -330,7 +330,7 @@ impl<'a, B: Brush> Run<'a, B> {
 /// An iterator over a [`Run`]'s clusters.
 ///
 /// This walks the run's graphemes. Each grapheme is one [`Cluster`].
-pub(crate) struct Clusters<'a, B: Brush> {
+struct Clusters<'a, B: Brush> {
     run: Run<'a, B>,
     /// Cursor over the run's (line-scoped) atoms.
     atoms: Atoms<'a>,
@@ -346,7 +346,7 @@ pub(crate) struct Clusters<'a, B: Brush> {
 }
 
 impl<'a, B: Brush> Clusters<'a, B> {
-    pub(crate) fn new(run: Run<'a, B>, rev: bool) -> Self {
+    fn new(run: Run<'a, B>, rev: bool) -> Self {
         let slice = run.line_slice();
         Self {
             run,

--- a/parley_bench/benches/main.rs
+++ b/parley_bench/benches/main.rs
@@ -5,12 +5,15 @@
 
 use tango_bench::tango_benchmarks;
 
-use parley_bench::benches::{defaults, long_line, repeated_justification, spacing, styled};
+use parley_bench::benches::{
+    defaults, iterate_styled_items, long_line, repeated_justification, spacing, styled,
+};
 use parley_bench::fontique_benches::system_fonts_init;
 
 tango_benchmarks!(
     defaults(),
     styled(),
+    iterate_styled_items(),
     spacing(),
     repeated_justification(),
     long_line(),

--- a/parley_bench/src/benches.rs
+++ b/parley_bench/src/benches.rs
@@ -7,8 +7,8 @@
 
 use crate::{ColorBrush, FONT_FAMILY_LIST, get_samples, with_contexts};
 use parley::{
-    Alignment, AlignmentOptions, FontFamily, FontStyle, FontWeight, Layout, RangedBuilder,
-    StyleProperty,
+    Alignment, AlignmentOptions, FontFamily, FontStyle, FontWeight, Layout, PositionedLayoutItem,
+    RangedBuilder, StyleProperty,
 };
 use std::hint::black_box;
 use tango_bench::{Benchmark, benchmark_fn};
@@ -141,8 +141,8 @@ pub fn repeated_justification() -> [Benchmark; 1] {
     )]
 }
 
-/// Benchmark for styled text.
-pub fn styled() -> Vec<Benchmark> {
+/// Build a styled layout for `text`, changing style every few characters.
+fn build_styled_layout(text: &str) -> Layout<ColorBrush> {
     const DISPLAY_SCALE: f32 = 1.0;
     const QUANTIZE: bool = true;
     const MAX_ADVANCE: f32 = 200.0 * DISPLAY_SCALE;
@@ -163,6 +163,39 @@ pub fn styled() -> Vec<Benchmark> {
         }
     }
 
+    with_contexts(|font_cx, layout_cx| {
+        let mut builder = layout_cx.ranged_builder(font_cx, text, DISPLAY_SCALE, QUANTIZE);
+        builder.push_default(FontFamily::from(FONT_FAMILY_LIST));
+
+        // Apply different styles every `style_interval` characters
+        let style_interval = (text.len() / 5).min(10);
+        {
+            let mut chunk_start = 0;
+            let mut style_idx = 0;
+
+            for (char_count, (byte_idx, _)) in text.char_indices().enumerate() {
+                if char_count != 0 && char_count % style_interval == 0 {
+                    apply_style(&mut builder, style_idx, chunk_start..byte_idx);
+                    chunk_start = byte_idx;
+                    style_idx += 1;
+                }
+            }
+
+            // Apply style to the last chunk if there's remaining text
+            if chunk_start < text.len() {
+                apply_style(&mut builder, style_idx, chunk_start..text.len());
+            }
+        }
+
+        let mut layout: Layout<ColorBrush> = builder.build(text);
+        layout.break_all_lines(Some(MAX_ADVANCE));
+        layout.align(Alignment::Start, AlignmentOptions::default());
+        layout
+    })
+}
+
+/// Benchmark for styled text.
+pub fn styled() -> Vec<Benchmark> {
     let samples = get_samples();
 
     samples
@@ -172,39 +205,45 @@ pub fn styled() -> Vec<Benchmark> {
                 format!("Styled - {} {}", sample.name, sample.modification),
                 |b| {
                     b.iter(|| {
-                        let text = &sample.text;
+                        black_box(build_styled_layout(&sample.text));
+                    })
+                },
+            )
+        })
+        .collect()
+}
 
-                        with_contexts(|font_cx, layout_cx| {
-                            let mut builder =
-                                layout_cx.ranged_builder(font_cx, text, DISPLAY_SCALE, QUANTIZE);
-                            builder.push_default(FontFamily::from(FONT_FAMILY_LIST));
+/// Benchmark for iterating the positioned glyph runs and glyphs of a styled layout, as a renderer
+/// would.
+pub fn iterate_styled_items() -> Vec<Benchmark> {
+    let samples = get_samples();
 
-                            // Apply different styles every `style_interval` characters
-                            let style_interval = (text.len() / 5).min(10);
-                            {
-                                let mut chunk_start = 0;
-                                let mut style_idx = 0;
-
-                                for (char_count, (byte_idx, _)) in text.char_indices().enumerate() {
-                                    if char_count != 0 && char_count % style_interval == 0 {
-                                        apply_style(&mut builder, style_idx, chunk_start..byte_idx);
-                                        chunk_start = byte_idx;
-                                        style_idx += 1;
+    samples
+        .iter()
+        .map(|sample| {
+            benchmark_fn(
+                format!("Styled Items - {} {}", sample.name, sample.modification),
+                |b| {
+                    let layout = build_styled_layout(&sample.text);
+                    b.iter(move || {
+                        let mut glyph_count = 0_usize;
+                        let mut advance = 0.0_f32;
+                        for line in layout.lines() {
+                            for item in line.items() {
+                                match item {
+                                    PositionedLayoutItem::GlyphRun(glyph_run) => {
+                                        for glyph in glyph_run.positioned_glyphs() {
+                                            glyph_count += 1;
+                                            advance += glyph.advance;
+                                        }
+                                    }
+                                    PositionedLayoutItem::InlineBox(inline_box) => {
+                                        advance += inline_box.width;
                                     }
                                 }
-
-                                // Apply style to the last chunk if there's remaining text
-                                if chunk_start < text.len() {
-                                    apply_style(&mut builder, style_idx, chunk_start..text.len());
-                                }
                             }
-
-                            let mut layout: Layout<ColorBrush> = builder.build(text);
-                            layout.break_all_lines(Some(MAX_ADVANCE));
-                            layout.align(Alignment::Start, AlignmentOptions::default());
-
-                            black_box(layout);
-                        });
+                        }
+                        black_box((glyph_count, advance))
                     })
                 },
             )


### PR DESCRIPTION
Fixes: https://github.com/linebender/parley/issues/763 (20x regression in glyph iteration performance)

- Replaces `.flatMap().skip()` iteration with a custom iterator
- The new iterator:
   - Iterates over atoms, keeping 1 peeked atom in state so it can compare runs between the current and next atom
   - Internally handles ltr vs rtl iteration (benchmarked as being faster due to less code bloat)
   - Iterates by reference to avoid excessive memory copies

**LLM Contributions**: Generated with Fable 5.1 Low (which also identified the issue and benchmarked)

**Changelog**: None (fixes a regression that has never been published)
