### PR TITLE
perf: Store glyph runs' cluster ranges instead of `.skip(glyph_start)`

### DIFF
--- a/parley/src/layout/line.rs
+++ b/parley/src/layout/line.rs
@@ -109,7 +109,6 @@ impl<'a, B: Brush> Line<'a, B> {
             line: self.clone(),
             item_index: 0,
             atoms: None,
-            glyph_start: 0,
             offset: 0.,
         }
     }
@@ -234,7 +233,12 @@ pub struct PositionedInlineBox {
 pub struct GlyphRun<'a, B: Brush> {
     run: Run<'a, B>,
     style_index: u16,
-    glyph_start: usize,
+    /// The glyph run's shaped clusters, indexing into the shaped run this [`Run`] belongs to.
+    ///
+    /// Both bounds are atom boundaries (as of writing, the line breaker doesn't break ligated
+    /// shaped clusters, and if in the future it does, it would reshape).
+    shaped_clusters: Range<u32>,
+    /// The number of glyphs in [`Self::shaped_clusters`].
     glyph_count: usize,
     offset: f32,
     baseline: f32,
@@ -278,10 +282,8 @@ impl<'a, B: Brush> GlyphRun<'a, B> {
 
     /// Returns an iterator over the glyphs in the run.
     pub fn glyphs(&'a self) -> impl Iterator<Item = Glyph> + 'a + Clone {
-        let clusters = self.run.line_slice().shaped_clusters_range();
         self.run
-            .glyphs_in(clusters)
-            .skip(self.glyph_start)
+            .glyphs_in(self.shaped_clusters.clone())
             .take(self.glyph_count)
     }
 
@@ -371,7 +373,6 @@ struct GlyphRunIter<'a, B: Brush> {
     /// Iterator over the visual atoms of the run at `item_index`, positioned at the first atom
     /// not yet yielded as part of a glyph run. `None` before entering a run.
     atoms: Option<AtomIter<'a>>,
-    glyph_start: usize,
     offset: f32,
 }
 
@@ -388,7 +389,6 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                         + self.line.data.metrics.offset;
 
                     self.item_index += 1;
-                    self.glyph_start = 0;
                     if inline_box.kind == InlineBoxKind::InFlow {
                         self.offset += inline_box.width;
                     }
@@ -414,30 +414,40 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                     // Atoms without glyphs don't take part.
                     let mut advance = 0.0;
                     let mut glyph_count = 0;
-                    let mut style_index: Option<u16> = None;
+                    // The style index and shaped cluster range of the glyph run being accumulated.
+                    let mut glyph_run: Option<(u16, Range<u32>)> = None;
                     while let Some(atom) = atoms.peek() {
                         let (atom_glyph_count, atom_advance) = atoms.measure(&atom);
                         if atom_glyph_count != 0 {
                             let atom_style_index = atom.characters()[0].style_index;
-                            if style_index.is_some_and(|s| s != atom_style_index) {
-                                break;
+                            let atom_clusters = atom.shaped_clusters_range();
+                            match &mut glyph_run {
+                                Some((style_index, shaped_clusters)) => {
+                                    if *style_index != atom_style_index {
+                                        break;
+                                    }
+                                    // In case the run is RTL, atoms are visited in reverse logical
+                                    // order, so just grow both sides of the range.
+                                    shaped_clusters.start =
+                                        shaped_clusters.start.min(atom_clusters.start);
+                                    shaped_clusters.end =
+                                        shaped_clusters.end.max(atom_clusters.end);
+                                }
+                                None => glyph_run = Some((atom_style_index, atom_clusters)),
                             }
-                            style_index = Some(atom_style_index);
                             glyph_count += atom_glyph_count;
                             advance += atom_advance;
                         }
                         atoms.consume();
                     }
 
-                    if let Some(first_style_index) = style_index {
-                        let glyph_start = self.glyph_start;
-                        self.glyph_start += glyph_count;
+                    if let Some((style_index, shaped_clusters)) = glyph_run {
                         let offset = self.offset;
                         self.offset += advance;
                         return Some(PositionedLayoutItem::GlyphRun(GlyphRun {
                             run,
-                            style_index: first_style_index,
-                            glyph_start,
+                            style_index,
+                            shaped_clusters,
                             glyph_count,
                             offset: offset
                                 + self.line.data.metrics.inline_min_coord
@@ -449,7 +459,6 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                     // Any atoms left have no glyphs and thus nothing to yield.
                     self.atoms = None;
                     self.item_index += 1;
-                    self.glyph_start = 0;
                 }
             }
         }

--- a/parley/src/layout/line.rs
+++ b/parley/src/layout/line.rs
@@ -235,8 +235,7 @@ pub struct GlyphRun<'a, B: Brush> {
     style_index: u16,
     /// The glyph run's shaped clusters, indexing into the shaped run this [`Run`] belongs to.
     ///
-    /// Both bounds are atom boundaries (as of writing, the line breaker doesn't break ligated
-    /// shaped clusters, and if in the future it does, it would reshape).
+    /// Both bounds are atom boundaries, as glyph runs must span full ligatures.
     shaped_clusters: Range<u32>,
     /// The number of glyphs in [`Self::shaped_clusters`].
     glyph_count: usize,


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: review.

Nico's #764 got me looking at glyph iteration, and there are a few more opportunities for optimization.

This change together with #771 appears to be quite a bit faster than v0.11.0, see https://github.com/linebender/parley/pull/770#pullrequestreview-5113133743. 

Previously, `GlyphRun::glyphs` skipped `glyph_start` of the run's line slice, which makes iterating glyphs with spans of non-itemizing styles quadratic (styles like underline). Instead, we can store the exact range of shaped clusters a `GlyphRun` holds, and just iterate that.

# Performance

On it's own, it's a good performance win for text with many style spans without those splitting into separately shaped runs, *but* it's intended to be combined with #771. These two together are better than either alone.

These two PRs taken together, against main, bench (using #769) as follows.

```
Glyph Runs - latin 4 paragraph, uniform                      [   5.7 us ...   2.2 us ]     -61.12%*
Glyph Runs - latin 4 paragraph, non-splitting every 1 chars  [  61.2 us ...   7.2 us ]     -88.28%*
Glyph Runs - latin 4 paragraph, non-splitting every 16 chars [   9.5 us ...   2.6 us ]     -72.42%*
Glyph Runs - latin 4 paragraph, splitting every 1 chars      [  27.8 us ...  10.7 us ]     -61.59%*
Glyph Runs - latin 4 paragraph, splitting every 16 chars     [   7.1 us ...   2.7 us ]     -62.01%*
Glyph Runs - arabic 4 paragraph, mixed                       [  14.5 us ...   5.4 us ]     -62.61%*
Glyph Runs - latin 4 paragraph, mixed                        [   8.9 us ...   3.1 us ]     -64.90%*
Glyph Runs - japanese 4 paragraph, mixed                     [   9.1 us ...   3.4 us ]     -63.23%*
```

This PR compared against #771, i.e., with that PR as base, results in the following.

```
Glyph Runs - latin 4 paragraph, uniform                      [   3.6 us ...   2.2 us ]     -38.99%*
Glyph Runs - latin 4 paragraph, non-splitting every 1 chars  [  92.3 us ...   7.3 us ]     -92.13%*
Glyph Runs - latin 4 paragraph, non-splitting every 16 chars [   9.5 us ...   2.6 us ]     -72.65%*
Glyph Runs - latin 4 paragraph, splitting every 1 chars      [  13.4 us ...  10.6 us ]     -20.97%*
Glyph Runs - latin 4 paragraph, splitting every 16 chars     [   4.3 us ...   2.7 us ]     -38.09%*
Glyph Runs - arabic 4 paragraph, mixed                       [   8.2 us ...   5.4 us ]     -33.77%*
Glyph Runs - latin 4 paragraph, mixed                        [   5.7 us ...   3.1 us ]     -45.46%*
Glyph Runs - japanese 4 paragraph, mixed                     [   4.8 us ...   3.3 us ]     -30.03%*`
```

And for completeness, just this PR against `main` (and note this PR on its own has some slight regressions in the non-splitting case, but is strictly better on top of/together with #771).

```
Glyph Runs - latin 4 paragraph, uniform                      [   5.7 us ...   5.9 us ]      +3.01%*
Glyph Runs - latin 4 paragraph, non-splitting every 1 chars  [  61.3 us ...  26.6 us ]     -56.54%*
Glyph Runs - latin 4 paragraph, non-splitting every 16 chars [   9.5 us ...   7.1 us ]     -24.77%*
Glyph Runs - latin 4 paragraph, splitting every 1 chars      [  27.8 us ...  30.1 us ]      +8.48%*
Glyph Runs - latin 4 paragraph, splitting every 16 chars     [   7.1 us ...   7.3 us ]      +3.42%*
Glyph Runs - arabic 4 paragraph, mixed                       [  14.5 us ...  15.3 us ]      +5.71%*
Glyph Runs - latin 4 paragraph, mixed                        [   8.9 us ...   8.9 us ]      +0.30%
Glyph Runs - japanese 4 paragraph, mixed                     [   9.1 us ...   9.9 us ]      +8.32%*
```

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**
