### PR TITLE
perf: Write an explicit glyph iterator for `Run::glyphs_in` instead of composing

### DIFF
--- a/parley/src/layout/run.rs
+++ b/parley/src/layout/run.rs
@@ -4,14 +4,14 @@
 use crate::layout::cluster::{Cluster, ClusterPath};
 use crate::layout::data::{LineItemData, RunData, count_graphemes};
 use crate::layout::layout::Layout;
-use crate::layout::spacing::{EffectiveSpacing, Justification};
+use crate::layout::spacing::{EffectiveSpacing, Gaps, Justification};
 use crate::style::Brush;
 
 use core::ops::Range;
 use fontique::Synthesis;
 use parley_engine::{
-    Atom, Atoms, FontInstance, FontMetrics, Glyph, Graphemes, NormalizedCoord, ShapedRun,
-    ShapedSlice,
+    Atom, Atoms, FontInstance, FontMetrics, Glyph, Graphemes, NormalizedCoord, ShapedClusterGlyphs,
+    ShapedRun, ShapedSlice,
 };
 
 /// Sequence of clusters with a single font and style.
@@ -230,99 +230,117 @@ impl<'a, B: Brush> Run<'a, B> {
         Clusters::new(*self, self.is_rtl())
     }
 
-    /// An iterator over the glyphs in `clusters` in visual left-to-right order.
+    /// An iterator over the glyphs in `shaped_clusters` in visual left-to-right order.
     ///
     /// This includes additional spacing from [`EffectiveSpacing`].
-    pub(crate) fn glyphs_in(
-        self,
-        clusters: Range<u32>,
-    ) -> impl Iterator<Item = Glyph> + Clone + use<'a, B> {
-        let spacing = self.line_spacing();
+    ///
+    /// `shaped_clusters` indexes into the shaped run this [`Run`] belongs to, and must be
+    /// atom-aligned.
+    pub(crate) fn glyphs_in(self, shaped_clusters: Range<u32>) -> Glyphs<'a> {
+        Glyphs::new(
+            self.full_slice().narrow(shaped_clusters),
+            self.is_rtl(),
+            self.line_spacing(),
+        )
+    }
+}
 
-        return spacing
-            .is_zero()
-            .then(|| glyphs_without_spacing(self, clusters.clone()))
-            .into_iter()
-            .flatten()
-            .chain(
-                (!spacing.is_zero())
-                    .then(|| glyphs_with_spacing(self, clusters, spacing))
-                    .into_iter()
-                    .flatten(),
-            );
+/// An iterator over the glyphs of a range of shaped clusters, in visual left-to-right order.
+///
+/// See [`Run::glyphs_in`].
+#[derive(Clone)]
+pub(crate) struct Glyphs<'a> {
+    /// The slice of shaped text narrowed to the shaped clusters being iterated.
+    slice: ShapedSlice<'a>,
+    is_rtl: bool,
+    /// The spacing to apply, if any. Without spacing, atoms are not tracked.
+    spacing: Option<EffectiveSpacing>,
+    /// The shaped clusters not yet visited: all of `slice`'s clusters without spacing, otherwise
+    /// those of the current atom. Visited in logical order for LTR text and in reverse for RTL.
+    shaped_clusters: Range<u32>,
+    /// The not-yet-yielded glyphs of the current shaped cluster.
+    glyphs: ShapedClusterGlyphs<'a>,
+    /// The gaps around the current atom; only meaningful with `spacing`.
+    gaps: Gaps,
+    /// The index within the current atom of the next glyph to yield. The first one gets
+    /// `gaps.before`.
+    atom_glyph: usize,
+    /// The number of glyphs of the current atom. The last one gets `gaps.after`.
+    atom_glyph_count: usize,
+}
 
-        fn glyphs_without_spacing<'a, B: Brush>(
-            run: Run<'a, B>,
-            clusters: Range<u32>,
-        ) -> impl Iterator<Item = Glyph> + Clone + use<'a, B> {
-            let slice = run
-                .layout
-                .data
-                .shaped_text
-                .run_slice(run.shaped_text_run_index);
-
-            (!run.is_rtl())
-                .then(|| clusters.clone())
-                .into_iter()
-                .flatten()
-                // we chain because `.rev()` wraps the iterator in `Rev` - a different type than the LTR
-                // iterator.
-                .chain((run.is_rtl()).then(|| clusters.rev()).into_iter().flatten())
-                .flat_map(move |cluster_idx| slice.shaped_cluster_glyphs(cluster_idx))
+impl<'a> Glyphs<'a> {
+    fn new(slice: ShapedSlice<'a>, is_rtl: bool, spacing: EffectiveSpacing) -> Self {
+        let clusters = slice.shaped_clusters_range();
+        Self {
+            slice,
+            is_rtl,
+            spacing: (!spacing.is_zero()).then_some(spacing),
+            shaped_clusters: if spacing.is_zero() {
+                clusters
+            } else {
+                // With spacing, clusters are visited atom by atom: start out on no atom, at the
+                // visually leftmost edge of the slice.
+                if is_rtl {
+                    clusters.end..clusters.end
+                } else {
+                    clusters.start..clusters.start
+                }
+            },
+            glyphs: ShapedClusterGlyphs::empty(),
+            gaps: Gaps::ZERO,
+            atom_glyph: 0,
+            atom_glyph_count: 0,
         }
+    }
+}
 
-        fn glyphs_with_spacing<'a, B: Brush>(
-            run: Run<'a, B>,
-            clusters: Range<u32>,
-            spacing: EffectiveSpacing,
-        ) -> impl Iterator<Item = Glyph> + Clone + use<'a, B> {
-            let slice = run
-                .layout
-                .data
-                .shaped_text
-                .run_slice(run.shaped_text_run_index)
-                .narrow(clusters);
+impl Iterator for Glyphs<'_> {
+    type Item = Glyph;
 
-            let is_rtl = run.is_rtl();
-            (!is_rtl)
-                .then(|| slice.atoms_start())
-                .into_iter()
-                .flatten()
-                // we chain because `.rev()` wraps the iterator in `Rev` - a different type than the LTR
-                // iterator.
-                .chain(
-                    is_rtl
-                        .then(|| slice.atoms_end().rev())
-                        .into_iter()
-                        .flatten(),
-                )
-                .flat_map(move |atom| {
-                    let gaps = spacing.gaps(&atom);
-                    let glyph_count: usize = atom
-                        .shaped_clusters()
-                        .iter()
-                        .map(|cluster| usize::from(cluster.glyph_len()))
-                        .sum();
+    #[inline]
+    fn next(&mut self) -> Option<Glyph> {
+        loop {
+            if let Some(mut glyph) = self.glyphs.next() {
+                if self.spacing.is_some() {
+                    if self.atom_glyph == 0 {
+                        glyph.x += self.gaps.before;
+                        glyph.advance += self.gaps.before;
+                    }
+                    self.atom_glyph += 1;
+                    if self.atom_glyph == self.atom_glyph_count {
+                        glyph.advance += self.gaps.after;
+                    }
+                }
+                return Some(glyph);
+            }
 
-                    let atom_clusters = atom.shaped_clusters_range();
-                    (!is_rtl)
-                        .then(|| atom_clusters.clone())
-                        .into_iter()
-                        .flatten()
-                        .chain(is_rtl.then(|| atom_clusters.rev()).into_iter().flatten())
-                        .flat_map(move |cluster_idx| slice.shaped_cluster_glyphs(cluster_idx))
-                        .enumerate()
-                        .map(move |(glyph_idx, mut glyph)| {
-                            if glyph_idx == 0 {
-                                glyph.x += gaps.before;
-                                glyph.advance += gaps.before;
-                            }
-                            if glyph_idx + 1 == glyph_count {
-                                glyph.advance += gaps.after;
-                            }
-                            glyph
-                        })
-                })
+            let cluster = if self.is_rtl {
+                self.shaped_clusters.next_back()
+            } else {
+                self.shaped_clusters.next()
+            };
+            if let Some(cluster) = cluster {
+                self.glyphs = self.slice.shaped_cluster_glyphs(cluster);
+                continue;
+            }
+
+            // Without spacing, that was the last cluster. With spacing, it was the last cluster of
+            // the current atom; move on to the next atom.
+            let spacing = self.spacing?;
+            let atom = if self.is_rtl {
+                self.slice.atoms_from(self.shaped_clusters.start).prev()
+            } else {
+                self.slice.atoms_from(self.shaped_clusters.end).next()
+            }?;
+            self.shaped_clusters = atom.shaped_clusters_range();
+            self.gaps = spacing.gaps(&atom);
+            self.atom_glyph = 0;
+            self.atom_glyph_count = atom
+                .shaped_clusters()
+                .iter()
+                .map(|cluster| usize::from(cluster.glyph_len()))
+                .sum();
         }
     }
 }

--- a/parley_engine/src/lib.rs
+++ b/parley_engine/src/lib.rs
@@ -119,6 +119,6 @@ pub use parlance::BaseDirection;
 pub use analysis::{Analysis, AnalysisDataSources, Boundary, CharInfo};
 pub use analyzer::{AnalysisOptions, Analyzer};
 pub use glyph::Glyph;
-pub use shape::atom::{Atom, Atoms, Grapheme, Graphemes, ShapedSlice};
+pub use shape::atom::{Atom, Atoms, Grapheme, Graphemes, ShapedClusterGlyphs, ShapedSlice};
 pub use shape::shaped_text::{FontMetrics, NormalizedCoord, ShapedRun, ShapedText};
 pub use shape::shaper::{FontInstance, FontSelector, ShapeOptions, Shaper};

--- a/parley_engine/src/shape/atom.rs
+++ b/parley_engine/src/shape/atom.rs
@@ -136,10 +136,7 @@ impl<'a> ShapedSlice<'a> {
     /// Get an iterator over glyphs in visual left-to-right order of the shaped cluster with the
     /// given index.
     #[inline]
-    pub fn shaped_cluster_glyphs(
-        &self,
-        cluster_idx: u32,
-    ) -> impl Iterator<Item = Glyph> + Clone + use<'a> {
+    pub fn shaped_cluster_glyphs(&self, cluster_idx: u32) -> ShapedClusterGlyphs<'a> {
         debug_assert!(
             self.clusters.0 <= cluster_idx && cluster_idx < self.clusters.1,
             "cluster index out of this slice's range"
@@ -147,21 +144,23 @@ impl<'a> ShapedSlice<'a> {
 
         let shaped_cluster = self.shaped_clusters[cluster_idx as usize];
 
-        let inline = shaped_cluster.has_inline_glyph().then_some(Glyph {
-            id: shaped_cluster.glyph_offset,
-            x: 0.,
-            y: 0.,
-            advance: shaped_cluster.advance,
-        });
-
-        let stored: &'a [Glyph] = if shaped_cluster.has_inline_glyph() {
-            &[]
+        if shaped_cluster.has_inline_glyph() {
+            ShapedClusterGlyphs {
+                inline: Some(Glyph {
+                    id: shaped_cluster.glyph_offset,
+                    x: 0.,
+                    y: 0.,
+                    advance: shaped_cluster.advance,
+                }),
+                stored: [].iter(),
+            }
         } else {
             let start = shaped_cluster.glyph_offset as usize;
-            &self.glyphs[start..start + usize::from(shaped_cluster.glyph_len())]
-        };
-
-        inline.into_iter().chain(stored.iter().copied())
+            ShapedClusterGlyphs {
+                inline: None,
+                stored: self.glyphs[start..start + usize::from(shaped_cluster.glyph_len())].iter(),
+            }
+        }
     }
 
     /// Get a cursor to walk atoms from the logical start of this slice.
@@ -333,6 +332,59 @@ impl<'a> ShapedSlice<'a> {
         cluster.advance / cluster.graphemes_overlapped(self.characters) as f32
     }
 }
+
+/// An iterator over the glyphs of a single [`ShapedCluster`], in visual left-to-right order.
+///
+/// See [`ShapedSlice::shaped_cluster_glyphs`]. The default value yields no glyphs.
+#[derive(Clone, Debug)]
+pub struct ShapedClusterGlyphs<'a> {
+    /// The cluster's glyph if it is stored inline.
+    inline: Option<Glyph>,
+    /// The cluster's glyphs in the glyph array.
+    stored: core::slice::Iter<'a, Glyph>,
+}
+
+impl ShapedClusterGlyphs<'static> {
+    /// An empty iterator that does not return any glyphs.
+    ///
+    /// This can be used to store a value of this type before actually having access to any shaped
+    /// clusters.
+    pub fn empty() -> Self {
+        Self {
+            inline: None,
+            stored: [].iter(),
+        }
+    }
+}
+
+impl Iterator for ShapedClusterGlyphs<'_> {
+    type Item = Glyph;
+
+    #[inline]
+    fn next(&mut self) -> Option<Glyph> {
+        if let Some(glyph) = self.inline.take() {
+            return Some(glyph);
+        }
+        self.stored.next().copied()
+    }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Glyph> {
+        match self.inline.take() {
+            Some(glyph) if n == 0 => Some(glyph),
+            Some(_) => self.stored.nth(n - 1).copied(),
+            None => self.stored.nth(n).copied(),
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = usize::from(self.inline.is_some()) + self.stored.len();
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for ShapedClusterGlyphs<'_> {}
 
 /// An [`Atom`] cursor.
 ///


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Mostly generated.

The old `Run::glyphs_in` builds quite the tower of composed iterators. This instead makes the iterator a much smaller type, makes it nameable, and improves performance nicely.

# Performance

Together with the #770, this benches as follows. See #770 for some more detailed numbers, including a comparison against v0.11.0.

```
$ cargo bench --bench main -- compare ../target/benchmarks/main -t 8. --filter "*Glyph*"

Glyph Runs - latin 4 paragraph, uniform                      [   5.7 us ...   2.2 us ]     -61.12%*
Glyph Runs - latin 4 paragraph, non-splitting every 1 chars  [  61.2 us ...   7.2 us ]     -88.28%*
Glyph Runs - latin 4 paragraph, non-splitting every 16 chars [   9.5 us ...   2.6 us ]     -72.42%*
Glyph Runs - latin 4 paragraph, splitting every 1 chars      [  27.8 us ...  10.7 us ]     -61.59%*
Glyph Runs - latin 4 paragraph, splitting every 16 chars     [   7.1 us ...   2.7 us ]     -62.01%*
Glyph Runs - arabic 4 paragraph, mixed                       [  14.5 us ...   5.4 us ]     -62.61%*
Glyph Runs - latin 4 paragraph, mixed                        [   8.9 us ...   3.1 us ]     -64.90%*
Glyph Runs - japanese 4 paragraph, mixed                     [   9.1 us ...   3.4 us ]     -63.23%*
```


<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**
