### PR TITLE
Drop boundary check in `calculate_content_widths`

### DIFF
--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -362,10 +362,9 @@ impl<B: Brush> LayoutData<B> {
                         let style = &self.styles[character.style_index as usize];
                         let prev_text_wrap_mode = text_wrap_mode;
                         text_wrap_mode = style.text_wrap_mode;
-                        if boundary == Boundary::Mandatory
-                            || (prev_text_wrap_mode == TextWrapMode::Wrap
-                                && (boundary == Boundary::Line
-                                    || style.overflow_wrap == OverflowWrap::Anywhere))
+                        if prev_text_wrap_mode == TextWrapMode::Wrap
+                            && (boundary == Boundary::Line
+                                || style.overflow_wrap == OverflowWrap::Anywhere)
                         {
                             let trailing_whitespace = whitespace_advance(prev_atom);
                             min_width = min_width.max(running_min_width - trailing_whitespace);


### PR DESCRIPTION

<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: review.

Quick follow-up to #746, giving the same treatment to `min_width` as #746 did to the `max_width`. So, if there's an inline box immediately following a newline, that box's width is now correctly assigned to the new line's `min_width`.

(Separately, I'm thinking about a nicer form for this function in general, plus perhaps a good way to test it to actually catch this stuff in CI.)

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog**

> ### Fixed
>
> - **Note to the editor:** this PR's entry should be merged with #746's.
