### PR TITLE
Restructure layout generation in the benchmarks

### DIFF
--- a/parley_bench/src/benches.rs
+++ b/parley_bench/src/benches.rs
@@ -8,7 +8,7 @@
 use crate::{ColorBrush, FONT_FAMILY_LIST, get_samples, with_contexts};
 use parley::{
     Alignment, AlignmentOptions, FontFamily, FontStyle, FontWeight, Layout, PositionedLayoutItem,
-    RangedBuilder, StyleProperty,
+    StyleProperty,
 };
 use std::hint::black_box;
 use std::ops::Range;
@@ -142,57 +142,62 @@ pub fn repeated_justification() -> [Benchmark; 1] {
     )]
 }
 
+/// Get the byte ranges of each consecutive chunk of `char_len` characters.
+///
+/// The last chunk holds the characters remaining.
+fn chunks(text: &str, char_len: usize) -> impl Iterator<Item = Range<usize>> {
+    let mut starts = text
+        .char_indices()
+        .map(|(byte_idx, _)| byte_idx)
+        .step_by(char_len)
+        .peekable();
+    std::iter::from_fn(move || {
+        let start = starts.next()?;
+        let end = starts.peek().copied().unwrap_or(text.len());
+        Some(start..end)
+    })
+}
+
+/// Create style spans changing style every few characters.
+fn styled_spans(
+    text: &str,
+) -> impl Iterator<Item = (StyleProperty<'static, ColorBrush>, Range<usize>)> {
+    let style_interval = (text.len() / 5).min(10);
+    chunks(text, style_interval)
+        .enumerate()
+        .filter_map(|(style_idx, range)| {
+            let style = match style_idx % 5 {
+                0 => StyleProperty::FontStyle(FontStyle::Italic),
+                1 => StyleProperty::FontWeight(FontWeight::BOLD),
+                2 => StyleProperty::Underline(true),
+                3 => StyleProperty::Strikethrough(true),
+                4 => return None, // Default style
+                _ => unreachable!(),
+            };
+            Some((style, range))
+        })
+}
+
+/// Apply `style` to every other chunk of `chunk_char_len` characters of `text`.
+fn alternating_spans<'s>(
+    text: &str,
+    chunk_char_len: usize,
+    style: &StyleProperty<'s, ColorBrush>,
+) -> impl Iterator<Item = (StyleProperty<'s, ColorBrush>, Range<usize>)> {
+    chunks(text, chunk_char_len)
+        .step_by(2)
+        .map(move |range| (style.clone(), range))
+}
+
 /// Build a styled layout for `text`, changing style every few characters.
 fn build_styled_layout(text: &str) -> Layout<ColorBrush> {
     const DISPLAY_SCALE: f32 = 1.0;
-    const QUANTIZE: bool = true;
     const MAX_ADVANCE: f32 = 200.0 * DISPLAY_SCALE;
 
-    fn apply_style(
-        builder: &mut RangedBuilder<'_, ColorBrush>,
-        style_idx: usize,
-        range: Range<usize>,
-    ) {
-        // Cycle through 5 different styles
-        match style_idx % 5 {
-            0 => builder.push(StyleProperty::FontStyle(FontStyle::Italic), range),
-            1 => builder.push(StyleProperty::FontWeight(FontWeight::BOLD), range),
-            2 => builder.push(StyleProperty::Underline(true), range),
-            3 => builder.push(StyleProperty::Strikethrough(true), range),
-            4 => {} // Default style
-            _ => unreachable!(),
-        }
-    }
-
-    with_contexts(|font_cx, layout_cx| {
-        let mut builder = layout_cx.ranged_builder(font_cx, text, DISPLAY_SCALE, QUANTIZE);
-        builder.push_default(FontFamily::from(FONT_FAMILY_LIST));
-
-        // Apply different styles every `style_interval` characters
-        let style_interval = (text.len() / 5).min(10);
-        {
-            let mut chunk_start = 0;
-            let mut style_idx = 0;
-
-            for (char_count, (byte_idx, _)) in text.char_indices().enumerate() {
-                if char_count != 0 && char_count % style_interval == 0 {
-                    apply_style(&mut builder, style_idx, chunk_start..byte_idx);
-                    chunk_start = byte_idx;
-                    style_idx += 1;
-                }
-            }
-
-            // Apply style to the last chunk if there's remaining text
-            if chunk_start < text.len() {
-                apply_style(&mut builder, style_idx, chunk_start..text.len());
-            }
-        }
-
-        let mut layout: Layout<ColorBrush> = builder.build(text);
-        layout.break_all_lines(Some(MAX_ADVANCE));
-        layout.align(Alignment::Start, AlignmentOptions::default());
-        layout
-    })
+    let mut layout = build_layout(text, styled_spans(text));
+    layout.break_all_lines(Some(MAX_ADVANCE));
+    layout.align(Alignment::Start, AlignmentOptions::default());
+    layout
 }
 
 /// Benchmark for styled text.
@@ -255,7 +260,10 @@ pub fn iterate_glyph_runs() -> Vec<Benchmark> {
                 latin.name, latin.modification
             ),
             move |b| {
-                let layout = build_alternating_layout(&latin.text, chunk_len, &style);
+                let layout = build_unwrapped_layout(
+                    &latin.text,
+                    alternating_spans(&latin.text, chunk_len, &style),
+                );
                 b.iter(move || black_box(walk_items(&layout)))
             },
         ));
@@ -302,13 +310,10 @@ fn walk_items(layout: &Layout<ColorBrush>) -> (usize, f32) {
     (glyph_count, advance)
 }
 
-/// Build `text` without line wrapping, applying each style of `styles` to its byte range.
+/// Build `text` into a layout. Each style of `styles` is applied to its given byte range.
 ///
-/// The layout is a single long line. Depending on the styles used, the proportion of glyphs per
-/// shaped run or style span varies. E.g., switching between bold and non-bold, the font changes, so
-/// the styles split the text into separately shaped items. Switching between underline and
-/// non-underline, there's no impact on shaping, and only the style spans change.
-fn build_unwrapped_layout<'a>(
+/// This doesn't break the layout into lines.
+fn build_layout<'a>(
     text: &str,
     styles: impl IntoIterator<Item = (StyleProperty<'a, ColorBrush>, Range<usize>)>,
 ) -> Layout<ColorBrush> {
@@ -322,36 +327,25 @@ fn build_unwrapped_layout<'a>(
             builder.push(style, range);
         }
 
-        let mut layout: Layout<ColorBrush> = builder.build(text);
-        layout.break_all_lines(None);
-        layout.align(Alignment::Start, AlignmentOptions::default());
-        layout
+        builder.build(text)
     })
 }
 
-/// Build `text` without line wrapping, applying `style` to every other chunk of `chunk_len`
-/// characters.
+/// Build `text` and line break without a maximum advance, i.e., lines are not wrapped. Each style
+/// of `styles` is applied to its given byte range.
 ///
-/// See [`build_unwrapped_layout`] for an explanation of the impact of varying styles.
-fn build_alternating_layout(
+/// The layout is a single long line. Depending on the styles used, the proportion of glyphs per
+/// shaped run or style span varies. E.g., switching between bold and non-bold, the font changes, so
+/// the styles split the text into separately shaped items. Switching between underline and
+/// non-underline, there's no impact on shaping, and only the style spans change.
+fn build_unwrapped_layout<'a>(
     text: &str,
-    chunk_len: usize,
-    style: &StyleProperty<'_, ColorBrush>,
+    styles: impl IntoIterator<Item = (StyleProperty<'a, ColorBrush>, Range<usize>)>,
 ) -> Layout<ColorBrush> {
-    // The byte offset of every `chunk_len`-th character, plus the end of the text.
-    let bounds = text
-        .char_indices()
-        .step_by(chunk_len)
-        .map(|(byte_idx, _)| byte_idx)
-        .chain([text.len()])
-        .collect::<Vec<_>>();
-    build_unwrapped_layout(
-        text,
-        bounds
-            .windows(2)
-            .step_by(2)
-            .map(|chunk| (style.clone(), chunk[0]..chunk[1])),
-    )
+    let mut layout = build_layout(text, styles);
+    layout.break_all_lines(None);
+    layout.align(Alignment::Start, AlignmentOptions::default());
+    layout
 }
 
 /// Benchmark for a single very long line (no wrapping) with and without justification.


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Review.

This restructures layout generation in the benchmarks a bit, so the styles are generated by helpers and the same layout helpers can be reused more easily.

Motivated by a follow-up that introduces yet another benchmark needing to build layouts (and specifically, needing styled layouts that have not been line broken).

<details>
<summary>Has no discernible impact on the benchmark timings</summary>

```
thomas@castor (nix) ~/code/linebender/parley
$ cargo bench --bench main -- compare ../target/benchmarks/main -t 4.
Default Style - arabic 20 characters               [   9.1 us ...   9.1 us ]      -0.24%
Default Style - latin 20 characters                [   4.3 us ...   4.4 us ]      +0.60%
Default Style - japanese 20 characters             [   7.8 us ...   7.8 us ]      -0.64%
Default Style - arabic 1 paragraph                 [  49.9 us ...  49.8 us ]      -0.16%
Default Style - latin 1 paragraph                  [  17.9 us ...  17.8 us ]      -0.91%
Default Style - japanese 1 paragraph               [  64.8 us ...  64.3 us ]      -0.82%
Default Style - arabic 4 paragraph                 [ 211.6 us ... 217.0 us ]      +2.54%*
Default Style - latin 4 paragraph                  [  67.7 us ...  67.3 us ]      -0.59%
Default Style - japanese 4 paragraph               [  91.7 us ...  90.8 us ]      -1.08%*
Styled - arabic 20 characters                      [  10.3 us ...  10.3 us ]      +0.03%
Styled - latin 20 characters                       [   5.6 us ...   5.6 us ]      +0.00%
Styled - japanese 20 characters                    [   8.4 us ...   8.4 us ]      +0.10%
Styled - arabic 1 paragraph                        [  52.1 us ...  52.5 us ]      +0.63%
Styled - latin 1 paragraph                         [  22.4 us ...  22.4 us ]      -0.20%
Styled - japanese 1 paragraph                      [  72.2 us ...  71.3 us ]      -1.22%*
Styled - arabic 4 paragraph                        [ 236.9 us ... 242.1 us ]      +2.19%*
Styled - latin 4 paragraph                         [  87.3 us ...  87.0 us ]      -0.37%
Styled - japanese 4 paragraph                      [ 102.5 us ... 101.1 us ]      -1.31%*
Glyph Runs - latin 4 paragraph, uniform            [   5.7 us ...   5.8 us ]      +0.16%
Glyph Runs - latin 4 paragraph, non-splitting every 1 chars [  61.2 us ...  61.7 us ]      +0.71%
Glyph Runs - latin 4 paragraph, non-splitting every 16 chars [   9.5 us ...   9.5 us ]      -0.00%
Glyph Runs - latin 4 paragraph, splitting every 1 chars [  27.8 us ...  28.1 us ]      +1.12%*
Glyph Runs - latin 4 paragraph, splitting every 16 chars [   7.1 us ...   7.1 us ]      +0.53%
Glyph Runs - arabic 4 paragraph, mixed             [  14.5 us ...  14.8 us ]      +2.12%*
Glyph Runs - latin 4 paragraph, mixed              [   8.9 us ...   9.0 us ]      +0.73%
Glyph Runs - japanese 4 paragraph, mixed           [   9.2 us ...   9.3 us ]      +1.20%*
Word + Letter Spacing - arabic 20 characters       [   9.1 us ...   9.1 us ]      -0.11%
Word + Letter Spacing - latin 20 characters        [   4.5 us ...   4.5 us ]      +0.05%
Word + Letter Spacing - japanese 20 characters     [   7.9 us ...   7.8 us ]      -0.89%
Word + Letter Spacing - arabic 1 paragraph         [  49.8 us ...  49.9 us ]      +0.15%
Word + Letter Spacing - latin 1 paragraph          [  18.3 us ...  18.1 us ]      -0.77%
Word + Letter Spacing - japanese 1 paragraph       [  66.4 us ...  65.8 us ]      -0.92%
Word + Letter Spacing - arabic 4 paragraph         [ 212.8 us ... 216.5 us ]      +1.75%*
Word + Letter Spacing - latin 4 paragraph          [  67.9 us ...  67.4 us ]      -0.75%
Word + Letter Spacing - japanese 4 paragraph       [  93.3 us ...  92.7 us ]      -0.67%
Repeated Justification - latin 4 paragraph         [ 833.6 ns ... 851.4 ns ]      +2.12%*
Long Line - arabic                                 [ 928.9 us ... 937.6 us ]      +0.94%
Long Line Justify - arabic                         [ 930.1 us ... 947.6 us ]      +1.89%*
Long Line - latin                                  [ 255.7 us ... 254.8 us ]      -0.34%
Long Line Justify - latin                          [ 255.8 us ... 253.5 us ]      -0.89%
Long Line - japanese                               [ 358.8 us ... 354.1 us ]      -1.30%*
Long Line Justify - japanese                       [ 359.1 us ... 354.7 us ]      -1.22%*
```

</details>


<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**