### PR TITLE
Add `Layout::calculate_content_widths` benchmarks 

### DIFF
--- a/parley_bench/benches/main.rs
+++ b/parley_bench/benches/main.rs
@@ -6,7 +6,8 @@
 use tango_bench::tango_benchmarks;
 
 use parley_bench::benches::{
-    defaults, iterate_glyph_runs, long_line, repeated_justification, spacing, styled,
+    content_widths, defaults, iterate_glyph_runs, long_line, repeated_justification, spacing,
+    styled,
 };
 use parley_bench::fontique_benches::system_fonts_init;
 
@@ -14,6 +15,7 @@ tango_benchmarks!(
     defaults(),
     styled(),
     iterate_glyph_runs(),
+    content_widths(),
     spacing(),
     repeated_justification(),
     long_line(),

--- a/parley_bench/src/benches.rs
+++ b/parley_bench/src/benches.rs
@@ -310,6 +310,45 @@ fn walk_items(layout: &Layout<ColorBrush>) -> (usize, f32) {
     (glyph_count, advance)
 }
 
+/// Benchmark for computing content widths.
+///
+/// Note this benches the calculation on layouts before line breaking is performed; that's the
+/// sequencing that'll likely be used by clients (i.e., measure possible sizes, and later on line
+/// break once the target size is known).
+pub fn content_widths() -> Vec<Benchmark> {
+    let samples = get_samples();
+
+    let mut benchmarks = Vec::new();
+
+    for sample in samples.iter() {
+        benchmarks.push(benchmark_fn(
+            format!(
+                "Content Widths - {} {}, uniform",
+                sample.name, sample.modification
+            ),
+            |b| {
+                let layout = build_layout(&sample.text, []);
+                b.iter(move || black_box(layout.calculate_content_widths()))
+            },
+        ));
+    }
+
+    for sample in samples.iter() {
+        benchmarks.push(benchmark_fn(
+            format!(
+                "Content Widths - {} {}, mixed",
+                sample.name, sample.modification
+            ),
+            |b| {
+                let layout = build_layout(&sample.text, styled_spans(&sample.text));
+                b.iter(move || black_box(layout.calculate_content_widths()))
+            },
+        ));
+    }
+
+    benchmarks
+}
+
 /// Build `text` into a layout. Each style of `styles` is applied to its given byte range.
 ///
 /// This doesn't break the layout into lines.


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Review.

The content widths function will need some work to correctly match line breaking (see, e.g., https://github.com/linebender/parley/pull/762), so let's start measuring its performance.

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**