### PR TITLE
Add debug assertion in the glyph run builder

### DIFF
--- a/parley/src/layout/line.rs
+++ b/parley/src/layout/line.rs
@@ -447,6 +447,11 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                     }
 
                     if let Some((style_index, shaped_clusters)) = glyph_run {
+                        debug_assert_eq!(
+                            run.glyphs_in(shaped_clusters.clone()).count(),
+                            glyph_count,
+                            "The calculated shaped cluster range of this glyph run must hold exactly the number of glyphs we counted above."
+                        );
                         let offset = self.offset;
                         self.offset += advance;
                         return Some(PositionedLayoutItem::GlyphRun(GlyphRun {


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Review.

Follow-up to https://github.com/linebender/parley/pull/770#discussion_r3946928929.

This asserts the calculated shaped cluster range of the glyph run must hold exactly the number of glyphs that was counted when building the glyph run.

Note that we can't quite assert there are no gaps in the shaped cluster range (as discussed in the thread I linked), because elsewhere we special-case `\n` clusters and remove their glyphs, and the loop just above this assertion then skips over those atoms/shaped clusters.



<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**