### PR TITLE
perf: Remove redundant `.take(glyph_count)` in glyph run iteration

### DIFF
--- a/parley/src/layout/line.rs
+++ b/parley/src/layout/line.rs
@@ -243,8 +243,6 @@ pub struct GlyphRun<'a, B: Brush> {
     ///
     /// Both bounds are atom boundaries, as glyph runs must span full ligatures.
     shaped_clusters: Range<u32>,
-    /// The number of glyphs in [`Self::shaped_clusters`].
-    glyph_count: usize,
     offset: f32,
     baseline: f32,
     advance: f32,
@@ -287,9 +285,7 @@ impl<'a, B: Brush> GlyphRun<'a, B> {
 
     /// Returns an iterator over the glyphs in the run.
     pub fn glyphs(&'a self) -> impl Iterator<Item = Glyph> + 'a + Clone {
-        self.run
-            .glyphs_in(self.shaped_clusters.clone())
-            .take(self.glyph_count)
+        self.run.glyphs_in(self.shaped_clusters.clone())
     }
 
     /// Returns an iterator over the fully positioned glyphs in the run.
@@ -458,7 +454,6 @@ impl<'a, B: Brush> Iterator for GlyphRunIter<'a, B> {
                             run,
                             style_index,
                             shaped_clusters,
-                            glyph_count,
                             offset: offset
                                 + self.line.data.metrics.inline_min_coord
                                 + self.line.data.metrics.offset,


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Spotted and implemented by an LLM.

Based on #778.

Following https://github.com/linebender/parley/pull/770, the range spanned holds exactly the glyph run's glyphs (and in particular, is known to hold exactly `glyph_count` glyphs. (And https://github.com/linebender/parley/pull/778 asserts that fact.)

# Performance

This is a nice little performance improvement on all but one case, but there's no real reason for it to regress, so that's just a compilation artifact I think.

```
$ cargo bench --bench main -- compare ../target/benchmarks/main -t 4. --filter "*Glyph*"
Glyph Runs - latin 4 paragraph, uniform                      [   2.3 us ...   2.1 us ]      -7.91%*
Glyph Runs - latin 4 paragraph, non-splitting every 1 chars  [   7.0 us ...   6.3 us ]     -10.26%*
Glyph Runs - latin 4 paragraph, non-splitting every 16 chars [   2.7 us ...   2.5 us ]      -5.80%*
Glyph Runs - latin 4 paragraph, splitting every 1 chars      [  10.5 us ...  10.7 us ]      +1.72%*
Glyph Runs - latin 4 paragraph, splitting every 16 chars     [   2.8 us ...   2.6 us ]      -5.63%*
Glyph Runs - arabic 4 paragraph, mixed                       [   5.4 us ...   5.4 us ]      -0.77%
Glyph Runs - latin 4 paragraph, mixed                        [   3.2 us ...   3.0 us ]      -4.82%*
Glyph Runs - japanese 4 paragraph, mixed                     [   3.3 us ...   3.4 us ]      +0.57%
```

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**
