### PR TITLE
Don't let soft break opportunities shadow mandatory breaks in complex-script runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,6 +2966,7 @@ dependencies = [
  "fontique",
  "hashbrown 0.17.1",
  "icu_properties",
+ "icu_segmenter",
  "linebender_resource_handle",
  "oxipng",
  "parlance",

--- a/parley/Cargo.toml
+++ b/parley/Cargo.toml
@@ -45,6 +45,7 @@ peniko = { workspace = true }
 
 bytemuck = { workspace = true }
 icu_properties = { workspace = true, features = ["compiled_data"] }
+icu_segmenter = { workspace = true, features = ["compiled_data"] }
 
 # We special-case android targets because oxipng doesn't build in Android CI.
 [target.'cfg(not(target_os = "android"))'.dev-dependencies]

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -757,14 +757,9 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                         let text_wrap_mode = self.state.line.text_wrap_mode;
                         self.state.line.text_wrap_mode = style.text_wrap_mode;
 
-                        if boundary == Boundary::Line && text_wrap_mode == TextWrapMode::Wrap {
-                            // We don't record boundaries when the advance is 0. As we do not want overflowing content to cause extra consecutive
-                            // line breaks. We should accept the overflowing fragment in that scenario.
-                            if self.state.line.x != 0.0 {
-                                self.state.mark_line_break_opportunity();
-                                // break_opportunity = true;
-                            }
-                        } else if is_newline {
+                        // A newline always ends the line, regardless of any soft break
+                        // opportunity that analysis may have recorded on it.
+                        if is_newline {
                             if max_height_exceeded {
                                 return self.max_height_break_data(line_height);
                             }
@@ -818,6 +813,14 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                                 max_advance,
                                 line_indent,
                             );
+                        } else if boundary == Boundary::Line && text_wrap_mode == TextWrapMode::Wrap
+                        {
+                            // We don't record boundaries when the advance is 0. As we do not want overflowing content to cause extra consecutive
+                            // line breaks. We should accept the overflowing fragment in that scenario.
+                            if self.state.line.x != 0.0 {
+                                self.state.mark_line_break_opportunity();
+                                // break_opportunity = true;
+                            }
                         } else if
                         // This text can contribute "emergency" line breaks.
                         style.overflow_wrap != OverflowWrap::Normal

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -757,8 +757,7 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                         let text_wrap_mode = self.state.line.text_wrap_mode;
                         self.state.line.text_wrap_mode = style.text_wrap_mode;
 
-                        // A newline always ends the line, regardless of any soft break
-                        // opportunity that analysis may have recorded on it.
+                        // Take mandatory line breaks before checking for line wrapping.
                         if is_newline {
                             if max_height_exceeded {
                                 return self.max_height_break_data(line_height);

--- a/parley/src/tests/test_analysis.rs
+++ b/parley/src/tests/test_analysis.rs
@@ -5,6 +5,7 @@ use crate::{FontContext, LayoutContext, RangedBuilder, StyleProperty, WordBreak}
 use alloc::{vec, vec::Vec};
 use fontique::FontWeight;
 use icu_properties::props::{GraphemeClusterBreak, Script};
+use icu_segmenter::{LineSegmenter, options::LineBreakOptions};
 use parley_engine::Boundary;
 
 #[derive(Default)]
@@ -314,6 +315,15 @@ fn test_paragraph_separator_is_hard_break() {
 /// regular wrap opportunity. See <https://github.com/linebender/parley/issues/768>.
 #[test]
 fn test_mandatory_break_after_complex_script_run() {
+    // Check that the ICU4X bug still reproduces: a break opportunity is reported at byte 6,
+    // between the second Thai character and the `\n`. Once this assertion fails, ICU4X has
+    // been fixed and the `is_line = !properties.is_mandatory_linebreak()` workaround in
+    // `parley_engine::analysis` can be reverted to `is_line = true`.
+    let icu_breaks: Vec<usize> = LineSegmenter::new_dictionary(LineBreakOptions::default())
+        .segment_str("กก\nกก")
+        .collect();
+    assert_eq!(icu_breaks, vec![0, 6, 7, 13]);
+
     // Thai
     verify_analysis("กก\nกก", |_| {}).expect_boundary_list(vec![
         Boundary::Word,

--- a/parley/src/tests/test_analysis.rs
+++ b/parley/src/tests/test_analysis.rs
@@ -308,6 +308,40 @@ fn test_paragraph_separator_is_hard_break() {
         .expect_contributes_to_shaping_list(vec![true, false, true]);
 }
 
+/// ICU4X emits a soft break opportunity at the end of a complex-script run even
+/// when it is directly followed by a mandatory break character (violating UAX #14
+/// LB6). That opportunity must be dropped so the newline is not treated as a
+/// regular wrap opportunity. See <https://github.com/linebender/parley/issues/768>.
+#[test]
+fn test_mandatory_break_after_complex_script_run() {
+    // Thai
+    verify_analysis("กก\nกก", |_| {}).expect_boundary_list(vec![
+        Boundary::Word,
+        Boundary::None,
+        Boundary::Word,
+        Boundary::Mandatory,
+        Boundary::None,
+    ]);
+    // Khmer
+    verify_analysis("ក្ម\nក្ម", |_| {}).expect_boundary_list(vec![
+        Boundary::Word,
+        Boundary::None,
+        Boundary::None,
+        Boundary::Word,
+        Boundary::Mandatory,
+        Boundary::None,
+        Boundary::None,
+    ]);
+    // Lao
+    verify_analysis("ກກ\nກກ", |_| {}).expect_boundary_list(vec![
+        Boundary::Word,
+        Boundary::None,
+        Boundary::Word,
+        Boundary::Mandatory,
+        Boundary::None,
+    ]);
+}
+
 #[test]
 fn test_blank() {
     verify_analysis("", |_| {})

--- a/parley/src/tests/test_builders.rs
+++ b/parley/src/tests/test_builders.rs
@@ -3,7 +3,7 @@
 
 //! Test that the various builders produce the same results.
 
-use std::{borrow::Cow, path::PathBuf, sync::Arc, vec::Vec};
+use std::{borrow::Cow, path::PathBuf, sync::Arc, vec, vec::Vec};
 
 use fontique::{Collection, CollectionOptions, FontStyle, FontWeight, FontWidth, SourceCache};
 use parlance::FontFamilyName;
@@ -11,9 +11,9 @@ use peniko::{Blob, color::palette};
 
 use super::utils::{ColorBrush, asserts::assert_eq_layout_data};
 use crate::{
-    BaseDirection, FontContext, FontFamily, FontFeatures, FontVariations, Layout, LayoutContext,
-    LineHeight, OverflowWrap, RangedBuilder, StyleProperty, StyleRunBuilder, TextStyle,
-    TextWrapMode, TreeBuilder, WordBreak,
+    BaseDirection, BreakReason, FontContext, FontFamily, FontFeatures, FontVariations, Layout,
+    LayoutContext, LineHeight, OverflowWrap, RangedBuilder, StyleProperty, StyleRunBuilder,
+    TextStyle, TextWrapMode, TreeBuilder, WordBreak,
 };
 
 // TODO: `FONT_FAMILY_LIST`, `load_fonts`, and `create_font_context` are
@@ -684,4 +684,41 @@ fn builders_crlf_across_run_boundary_counts_as_single_line_break() {
         split_crlf, split_lf,
         "styled CRLF should match styled LF line count"
     );
+}
+
+/// ICU4X's line segmenter emits a soft break opportunity at the end of a
+/// complex-script (Thai, Khmer, Lao, ...) run even when the next character is a
+/// mandatory break, which must not shadow the hard break.
+/// See <https://github.com/linebender/parley/issues/768>.
+#[test]
+fn builders_newline_inside_complex_script_run_is_hard_break() {
+    let mut fcx = create_font_context();
+    let mut break_reasons = |text: &str| -> Vec<BreakReason> {
+        let mut lcx: LayoutContext<ColorBrush> = LayoutContext::new();
+        let ropts = RangedOptions {
+            scale: 1.0,
+            quantize: false,
+            max_advance: None,
+            text,
+        };
+        let layout = build_layout_with_ranged(&mut fcx, &mut lcx, &ropts, |rb| {
+            set_root_style(rb);
+        });
+        layout.lines().map(|line| line.break_reason()).collect()
+    };
+
+    for text in [
+        "กก\nกก",
+        "ក្ម\nក្ម",
+        "ກກ\nກກ",
+        "กก\r\nกก",
+        "กก\u{2028}กก",
+        "aa\nbb",
+    ] {
+        assert_eq!(
+            break_reasons(text),
+            vec![BreakReason::Explicit, BreakReason::None],
+            "{text:?} should produce exactly two lines with an explicit break",
+        );
+    }
 }

--- a/parley/src/tests/test_builders.rs
+++ b/parley/src/tests/test_builders.rs
@@ -703,6 +703,7 @@ fn builders_newline_inside_complex_script_run_is_hard_break() {
         };
         let layout = build_layout_with_ranged(&mut fcx, &mut lcx, &ropts, |rb| {
             set_root_style(rb);
+            rb.push_default(StyleProperty::WordBreak(WordBreak::Normal));
         });
         layout.lines().map(|line| line.break_reason()).collect()
     };

--- a/parley_engine/src/analysis.rs
+++ b/parley_engine/src/analysis.rs
@@ -581,11 +581,15 @@ pub(crate) fn analyze_text(
             is_grapheme_start = true;
             _ = gb_iter.next();
         }
+        let properties = data_sources.properties(ch);
         let mut is_line = false;
         if let Some(&l) = lb_iter.peek()
             && *l == byte_pos
         {
-            is_line = true;
+            // A soft break opportunity is never valid directly before a mandatory break
+            // character (UAX #14 LB6), but ICU4X's line segmenter emits one at the end of a
+            // complex-script (Thai, Khmer, Lao, ...) run regardless of what follows it.
+            is_line = !properties.is_mandatory_linebreak();
             _ = lb_iter.next();
         }
 
@@ -611,10 +615,8 @@ pub(crate) fn analyze_text(
             Boundary::None
         };
 
-        (boundary, is_grapheme_start, ch)
+        (boundary, is_grapheme_start, ch, properties)
     });
-
-    let properties = |c| data_sources.properties(c);
 
     let mut needs_bidi_resolution = false;
 
@@ -626,8 +628,7 @@ pub(crate) fn analyze_text(
         // character-indexed.
         .fold(
             false,
-            |is_mandatory_linebreak, (boundary, is_grapheme_start, ch)| {
-                let properties = properties(ch);
+            |is_mandatory_linebreak, (boundary, is_grapheme_start, ch, properties)| {
                 let script = properties.script();
                 let grapheme_cluster_break = properties.grapheme_cluster_break();
                 let bidi_class = properties.bidi_class();


### PR DESCRIPTION
Fixes #768

LLM Contributions: Debugged and fix generated by Fable 5.1 Low

## Changes made

- In `line_break.rs`: check the `is_newline` case before the `Boundary::Line` case so a mandatory break takes precedence over a line break opportunity.
- In `analysis.rs`: drop an ICU line boundary that lands on a mandatory-break character, so `\n` always gets `Boundary::Word`. This is applied before `line_break_override`, so overrides are unaffected. 
- Regression tests.

Either fix is sufficient to fix Parley's layout, but both are applied on principle. The analysis one is required for other consumers of Parley Engine.


**Changelog**

> ### Fixed
>
> - Mandatory line breaks (\n, \r\n, U+2028, U+2029) directly following Thai, Khmer or Lao text are no longer dropped.
