### PR TITLE
Expand `Whitespace` variants

### DIFF
--- a/parley_engine/src/shape/atom.rs
+++ b/parley_engine/src/shape/atom.rs
@@ -765,9 +765,12 @@ impl GraphemeFlags {
             0 => Whitespace::None,
             1 => Whitespace::Space,
             2 => Whitespace::NoBreakSpace,
-            3 => Whitespace::Tab,
-            4 => Whitespace::Newline,
-            _ => unreachable!("0..5 are the only valid values"),
+            3 => Whitespace::IdeographicSpace,
+            4 => Whitespace::OtherSpaceSeparator,
+            5 => Whitespace::Tab,
+            6 => Whitespace::Newline,
+            7 => Whitespace::ControlWhitespace,
+            _ => unreachable!("0..8 are the only valid values"),
         }
     }
 

--- a/parley_engine/src/shape/cluster.rs
+++ b/parley_engine/src/shape/cluster.rs
@@ -624,7 +624,7 @@ mod tests {
 
     #[test]
     fn whitespace() {
-        // These all code points from `NUL` up to the last `White_Space` character as defined in
+        // Test all code points from `NUL` up to the last `White_Space` character as defined in
         // https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt.
         for c in '\u{0000}'..='\u{3000}' {
             let ws = Whitespace::from_char(c);

--- a/parley_engine/src/shape/cluster.rs
+++ b/parley_engine/src/shape/cluster.rs
@@ -130,7 +130,6 @@ impl Whitespace {
             '\u{1680}' | '\u{2000}'..='\u{200A}' | '\u{202F}' | '\u{205F}' => {
                 Self::OtherSpaceSeparator
             }
-
             '\t' => Self::Tab,
             // Newline, carriage return, line separator, paragraph separator.
             '\n' | '\r' | '\u{2028}' | '\u{2029}' => Self::Newline,

--- a/parley_engine/src/shape/cluster.rs
+++ b/parley_engine/src/shape/cluster.rs
@@ -120,9 +120,6 @@ pub enum Whitespace {
 impl Whitespace {
     #[inline]
     pub(crate) const fn from_char(c: char) -> Self {
-        const LINE_SEPARATOR: char = '\u{2028}';
-        const PARAGRAPH_SEPARATOR: char = '\u{2029}';
-
         // See https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt.
         match c {
             ' ' => Self::Space,
@@ -135,7 +132,8 @@ impl Whitespace {
             }
 
             '\t' => Self::Tab,
-            '\n' | '\r' | LINE_SEPARATOR | PARAGRAPH_SEPARATOR => Self::Newline,
+            // Newline, carriage return, line separator, paragraph separator.
+            '\n' | '\r' | '\u{2028}' | '\u{2029}' => Self::Newline,
             // Vertical tab, form feed, next line. These are `White_Space` that CSS says to render
             // as control characters.
             '\u{000b}' | '\u{000c}' | '\u{0085}' => Self::ControlWhitespace,

--- a/parley_engine/src/shape/cluster.rs
+++ b/parley_engine/src/shape/cluster.rs
@@ -113,7 +113,6 @@ pub enum Whitespace {
     /// There are also `Cc` characters that aren't `White_Space` (those would be
     /// [`Whitespace::None`]).
     ControlWhitespace = 7,
-
     // NOTE: if you grow these variants more than eight, ensure you also update the encoding in
     // `GraphemeFlags`.
 }
@@ -125,7 +124,7 @@ impl Whitespace {
         const PARAGRAPH_SEPARATOR: char = '\u{2029}';
 
         // See https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt.
-        let whitespace = match c {
+        match c {
             ' ' => Self::Space,
             '\u{00A0}' => Self::NoBreakSpace,
             '\u{3000}' => Self::IdeographicSpace,
@@ -141,9 +140,7 @@ impl Whitespace {
             // as control characters.
             '\u{000b}' | '\u{000c}' | '\u{0085}' => Self::ControlWhitespace,
             _ => Self::None,
-        };
-
-        whitespace
+        }
     }
 
     /// Returns true for space or no break space.

--- a/parley_engine/src/shape/cluster.rs
+++ b/parley_engine/src/shape/cluster.rs
@@ -63,23 +63,89 @@ pub struct Char {
     pub style_index: u16,
 }
 
-/// Whitespace content of a cluster.
+/// Whitespace class of a character.
+///
+/// All white space characters as defined
+/// [by Unicode](https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt) map to a variant of
+/// this enum. The variants are based on the various sets of white space as in
+/// [CSS Text 4][css-text-4].
+///
+/// A character maps to [`Whitespace::None`] if and only if that character's [`char::is_whitespace`]
+/// is `false`.
+///
+/// [css-text-4]: https://www.w3.org/TR/css-text-4/
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug)]
 #[repr(u8)]
 pub enum Whitespace {
-    /// Not a space.
+    /// Not white space.
     None = 0,
+
     /// Standard space.
     Space = 1,
+
     /// Non-breaking space (U+00A0).
     NoBreakSpace = 2,
+
+    /// Ideographic space (U+3000).
+    ///
+    /// Note CSS Text 4 doesn't treat this space any differently from [`Self::OtherSpaceSeparator`],
+    /// but some applications do.
+    IdeographicSpace = 3,
+
+    /// The Unicode "space separators" (category `Zs`), except for the standard space, non-breaking
+    /// space and ideographic space.
+    ///
+    /// Applications may want to treat those three space separators differently from the general
+    /// class of space separators.
+    OtherSpaceSeparator = 4,
+
     /// Horizontal tab.
-    Tab = 3,
+    Tab = 5,
+
     /// Newline (CR, LF, CRLF, LS, or PS).
-    Newline = 4,
+    Newline = 6,
+
+    /// Vertical tab, form feed and next line.
+    ///
+    /// These are Unicode `White_Space`, but CSS Text 4 § 4 says to treat them as visible glyphs.
+    ///
+    /// Note [`Self::Tab`] and some of [`Self::Newline`] are also in the Unicode `Cc` category.
+    /// There are also `Cc` characters that aren't `White_Space` (those would be
+    /// [`Whitespace::None`]).
+    ControlWhitespace = 7,
+
+    // NOTE: if you grow these variants more than eight, ensure you also update the encoding in
+    // `GraphemeFlags`.
 }
 
 impl Whitespace {
+    #[inline]
+    pub(crate) const fn from_char(c: char) -> Self {
+        const LINE_SEPARATOR: char = '\u{2028}';
+        const PARAGRAPH_SEPARATOR: char = '\u{2029}';
+
+        // See https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt.
+        let whitespace = match c {
+            ' ' => Self::Space,
+            '\u{00A0}' => Self::NoBreakSpace,
+            '\u{3000}' => Self::IdeographicSpace,
+            // Ogham space mark, en quad through hair space, narrow no-break space, medium
+            // mathematical space.
+            '\u{1680}' | '\u{2000}'..='\u{200A}' | '\u{202F}' | '\u{205F}' => {
+                Self::OtherSpaceSeparator
+            }
+
+            '\t' => Self::Tab,
+            '\n' | '\r' | LINE_SEPARATOR | PARAGRAPH_SEPARATOR => Self::Newline,
+            // Vertical tab, form feed, next line. These are `White_Space` that CSS says to render
+            // as control characters.
+            '\u{000b}' | '\u{000c}' | '\u{0085}' => Self::ControlWhitespace,
+            _ => Self::None,
+        };
+
+        whitespace
+    }
+
     /// Returns true for space or no break space.
     #[inline]
     pub fn is_space_or_nbsp(self) -> bool {
@@ -490,6 +556,8 @@ impl<'a> Mapper<'a> {
 
 #[cfg(test)]
 mod tests {
+    use crate::shape::Whitespace;
+
     use super::Coverage;
 
     #[test]
@@ -552,5 +620,19 @@ mod tests {
                 total: 255,
             } < Coverage::COMPLETE
         );
+    }
+
+    #[test]
+    fn whitespace() {
+        // These all code points from `NUL` up to the last `White_Space` character as defined in
+        // https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt.
+        for c in '\u{0000}'..='\u{3000}' {
+            let ws = Whitespace::from_char(c);
+            assert!(
+                c.is_whitespace() && ws != Whitespace::None
+                    || !c.is_whitespace() && ws == Whitespace::None,
+                "`Whitespace` should encode exactly all of Unicode's `White_Space` characters."
+            );
+        }
     }
 }

--- a/parley_engine/src/shape/data.rs
+++ b/parley_engine/src/shape/data.rs
@@ -205,7 +205,7 @@ impl ClusterInfo {
     // Returns the whitespace type of the cluster.
     #[inline(always)]
     pub fn whitespace(self) -> Whitespace {
-        to_whitespace(self.source_char)
+        Whitespace::from_char(self.source_char)
     }
 
     /// Returns if the cluster is a line boundary.
@@ -224,27 +224,12 @@ impl ClusterInfo {
     /// Returns if the cluster is any whitespace.
     #[inline(always)]
     pub fn is_whitespace(self) -> bool {
-        self.source_char.is_whitespace()
+        self.whitespace() != Whitespace::None
     }
 
     /// Returns the cluster's original character.
     #[inline(always)]
     pub fn source_char(self) -> char {
         self.source_char
-    }
-}
-
-// TODO: should become private when more of `parley`'s shaping is in `parley_engine`
-#[inline]
-pub const fn to_whitespace(c: char) -> Whitespace {
-    const LINE_SEPARATOR: char = '\u{2028}';
-    const PARAGRAPH_SEPARATOR: char = '\u{2029}';
-
-    match c {
-        ' ' => Whitespace::Space,
-        '\t' => Whitespace::Tab,
-        '\n' | '\r' | LINE_SEPARATOR | PARAGRAPH_SEPARATOR => Whitespace::Newline,
-        '\u{00A0}' => Whitespace::NoBreakSpace,
-        _ => Whitespace::None,
     }
 }

--- a/parley_engine/src/shape/mod.rs
+++ b/parley_engine/src/shape/mod.rs
@@ -11,6 +11,6 @@ pub(crate) mod shaped_text;
 pub(crate) mod shaper;
 
 pub use cluster::{Char, CharCluster, Coverage, SourceRange, Whitespace};
-pub use data::{Character, ClusterInfo, ShapedCluster, to_whitespace};
+pub use data::{Character, ClusterInfo, ShapedCluster};
 
 pub(crate) use data::ShapedClusterFlags;


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Investigation, review.

This proposes letting the enum cover all of Unicode `White_Space`, with the variants based on the sets that CSS Text 4 defines. Follow-up to https://github.com/linebender/parley/pull/762#discussion_r3923722770.

According the CSS Text 4, the set of collapsible white space is `Space | Tab | Newline`,  and according to the spec hangable is effectively `collapsible ∪ (space separator \ {non-breaking space})`; but note both Gecko and Blink only hang `collapsible ∪ {ideographic space}` (also note space, non-breaking space, and ideographic space are all part of the space separators `Zs` category).

`ControlWhitespace` are those that CSS Text 4 says should just be rendered as glyphs.

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**

(No changelog, as while `Whitespace` was migrated from `parley`, it wasn't `pub` and so hasn't been in a release yet.)