### PR TITLE
perf: Remove reverse line walk

### DIFF
--- a/parley/src/layout/alignment.rs
+++ b/parley/src/layout/alignment.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use super::BreakReason;
-use crate::data::LayoutData;
+use crate::layout::data::{LayoutData, LayoutItemKind, LineData, LineItemData};
+use crate::layout::spacing::is_word_separator;
 use crate::style::Brush;
+use parley_engine::ShapedText;
 
 /// Alignment of a layout.
 #[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
@@ -111,18 +113,68 @@ pub(crate) fn align<B: Brush>(
                 // (`BreakReason::None`), (`BreakReason::Explicit`) or if there are no whitespace
                 // gaps to adjust. In that case, start-align, i.e., left-align for LTR text and
                 // right-align for RTL text.
-                if matches!(line.break_reason, BreakReason::None | BreakReason::Explicit)
-                    || line.num_justification_opportunities == 0
-                {
+                if matches!(line.break_reason, BreakReason::None | BreakReason::Explicit) {
                     if is_rtl {
                         line.metrics.offset += free_space;
                     }
                     continue;
                 }
 
-                line.justification.amount_per_opportunity =
-                    free_space / line.num_justification_opportunities as f32;
+                // Count the line's justification opportunities, and cache.
+                let opportunities = match line.num_justification_opportunities {
+                    Some(opportunities) => opportunities,
+                    None => {
+                        let opportunities = justification_opportunities(
+                            line,
+                            &layout.line_items,
+                            &layout.shaped_text,
+                        );
+                        line.num_justification_opportunities = Some(opportunities);
+                        opportunities
+                    }
+                };
+
+                if opportunities == 0 {
+                    if is_rtl {
+                        line.metrics.offset += free_space;
+                    }
+                    continue;
+                }
+
+                line.justification.amount_per_opportunity = free_space / opportunities as f32;
             }
         }
     }
+}
+
+/// The number of justification opportunities on the line.
+///
+/// An opportunity is a [word separator](`is_word_separator`) that lies before
+/// [`Justification::justification_end_cluster`](crate::layout::spacing::Justification).
+fn justification_opportunities(
+    line: &LineData,
+    line_items: &[LineItemData],
+    shaped_text: &ShapedText,
+) -> u32 {
+    let end_cluster = line.justification.justification_end_cluster;
+
+    let mut opportunities = 0;
+    for line_item in &line_items[line.item_range.clone()] {
+        if line_item.kind != LayoutItemKind::TextRun {
+            continue;
+        }
+        let slice = shaped_text
+            .run_slice(line_item.index as u32)
+            .narrow(line_item.shaped_cluster_range.clone());
+        for atom in slice.atoms_start() {
+            if atom.shaped_clusters_range().end > end_cluster {
+                break;
+            }
+            if is_word_separator(atom.characters()[0].info.whitespace()) {
+                opportunities += 1;
+            }
+        }
+    }
+
+    opportunities
 }

--- a/parley/src/layout/alignment.rs
+++ b/parley/src/layout/alignment.rs
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use super::BreakReason;
-use crate::layout::data::{LayoutData, LayoutItemKind, LineData, LineItemData};
-use crate::layout::spacing::is_word_separator;
+use crate::data::LayoutData;
 use crate::style::Brush;
-use parley_engine::ShapedText;
 
 /// Alignment of a layout.
 #[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
@@ -113,68 +111,18 @@ pub(crate) fn align<B: Brush>(
                 // (`BreakReason::None`), (`BreakReason::Explicit`) or if there are no whitespace
                 // gaps to adjust. In that case, start-align, i.e., left-align for LTR text and
                 // right-align for RTL text.
-                if matches!(line.break_reason, BreakReason::None | BreakReason::Explicit) {
+                if matches!(line.break_reason, BreakReason::None | BreakReason::Explicit)
+                    || line.num_justification_opportunities == 0
+                {
                     if is_rtl {
                         line.metrics.offset += free_space;
                     }
                     continue;
                 }
 
-                // Count the line's justification opportunities, and cache.
-                let opportunities = match line.num_justification_opportunities {
-                    Some(opportunities) => opportunities,
-                    None => {
-                        let opportunities = justification_opportunities(
-                            line,
-                            &layout.line_items,
-                            &layout.shaped_text,
-                        );
-                        line.num_justification_opportunities = Some(opportunities);
-                        opportunities
-                    }
-                };
-
-                if opportunities == 0 {
-                    if is_rtl {
-                        line.metrics.offset += free_space;
-                    }
-                    continue;
-                }
-
-                line.justification.amount_per_opportunity = free_space / opportunities as f32;
+                line.justification.amount_per_opportunity =
+                    free_space / line.num_justification_opportunities as f32;
             }
         }
     }
-}
-
-/// The number of justification opportunities on the line.
-///
-/// An opportunity is a [word separator](`is_word_separator`) that lies before
-/// [`Justification::justification_end_cluster`](crate::layout::spacing::Justification).
-fn justification_opportunities(
-    line: &LineData,
-    line_items: &[LineItemData],
-    shaped_text: &ShapedText,
-) -> u32 {
-    let end_cluster = line.justification.justification_end_cluster;
-
-    let mut opportunities = 0;
-    for line_item in &line_items[line.item_range.clone()] {
-        if line_item.kind != LayoutItemKind::TextRun {
-            continue;
-        }
-        let slice = shaped_text
-            .run_slice(line_item.index as u32)
-            .narrow(line_item.shaped_cluster_range.clone());
-        for atom in slice.atoms_start() {
-            if atom.shaped_clusters_range().end > end_cluster {
-                break;
-            }
-            if is_word_separator(atom.characters()[0].info.whitespace()) {
-                opportunities += 1;
-            }
-        }
-    }
-
-    opportunities
 }

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -54,9 +54,8 @@ pub(crate) struct LineData {
     pub(crate) break_reason: BreakReason,
     /// Maximum advance for the line.
     pub(crate) max_advance: f32,
-    /// The number of justification opportunities on the line, or `None` if they haven't been
-    /// counted yet.
-    pub(crate) num_justification_opportunities: Option<u32>,
+    /// The number of justification opportunities on the line.
+    pub(crate) num_justification_opportunities: u32,
     pub(crate) justification: Justification,
     /// Text indent applied to this line.
     pub(crate) indent: f32,

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -54,8 +54,9 @@ pub(crate) struct LineData {
     pub(crate) break_reason: BreakReason,
     /// Maximum advance for the line.
     pub(crate) max_advance: f32,
-    /// Number of justified clusters on the line.
-    pub(crate) num_justification_opportunities: usize,
+    /// The number of justification opportunities on the line, or `None` if they haven't been
+    /// counted yet.
+    pub(crate) num_justification_opportunities: Option<u32>,
     pub(crate) justification: Justification,
     /// Text indent applied to this line.
     pub(crate) indent: f32,

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -11,7 +11,7 @@ use core_maths::CoreFloat;
 use parlance::BidiLevel;
 
 use crate::layout::data::count_graphemes;
-use crate::layout::spacing::{EffectiveSpacing, Justification};
+use crate::layout::spacing::{EffectiveSpacing, Justification, is_word_separator};
 use crate::layout::whitespace::{atom_hanging_advance, whitespace_can_hang};
 use crate::layout::{
     BreakReason, Layout, LayoutData, LayoutItem, LayoutItemKind, LineData, LineItemData,
@@ -55,6 +55,12 @@ struct LineState {
     /// We lag the text-wrap-mode by one cluster due to line-breaking boundaries only
     /// being triggered on the cluster after the linebreak.
     text_wrap_mode: TextWrapMode,
+
+    /// The number of word separators appended to the line so far.
+    ///
+    /// These are the line's justification opportunities, before subtracting those that end up in
+    /// the line's hanging whitespace.
+    num_word_separators: u32,
 }
 
 impl LineState {
@@ -62,6 +68,7 @@ impl LineState {
     fn reset(&mut self) {
         self.x = 0.0;
         self.box_metrics = LineBoxMetrics::default();
+        self.num_word_separators = 0;
     }
 }
 
@@ -338,12 +345,21 @@ impl BreakerState {
     /// Add the atom currently being evaluated to the current line.
     ///
     /// `text_metrics` are the line box metrics contributed by the atom's text.
+    /// `is_word_separator` is `true` iff the atom is a [word separator](`is_word_separator`), i.e.,
+    /// a justification opportunity.
     #[inline]
-    fn append_atom_to_line(&mut self, atom: &Atom<'_>, next_x: f32, text_metrics: LineBoxMetrics) {
+    fn append_atom_to_line(
+        &mut self,
+        atom: &Atom<'_>,
+        next_x: f32,
+        text_metrics: LineBoxMetrics,
+        is_word_separator: bool,
+    ) {
         self.line.items.end = self.item_idx + 1;
         self.line.clusters.end = atom.shaped_clusters_range().end;
         self.cluster_idx = atom.shaped_clusters_range().end;
         self.line.x = next_x;
+        self.line.num_word_separators += u32::from(is_word_separator);
         self.line.box_metrics.add(text_metrics);
         self.update_max_height_exceeded();
     }
@@ -772,6 +788,8 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                         let is_newline = whitespace == Whitespace::Newline;
                         // Whether this is a space that is allowed to hang past the line.
                         let is_space = whitespace_can_hang(whitespace);
+                        // Whether this atom is a justification opportunity.
+                        let is_separator = is_word_separator(whitespace);
                         let boundary = first_character.info.boundary();
                         let max_height_exceeded = self.state.line.max_height_exceeded;
                         let style = &self.layout.data.styles[first_character.style_index as usize];
@@ -818,8 +836,12 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                                         && next.info.source_char() == '\n'
                                 });
 
-                            self.state
-                                .append_atom_to_line(&atom, self.state.line.x, text_metrics);
+                            self.state.append_atom_to_line(
+                                &atom,
+                                self.state.line.x,
+                                text_metrics,
+                                is_separator,
+                            );
 
                             if is_cr_before_lf {
                                 continue;
@@ -864,7 +886,12 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                             if max_height_exceeded {
                                 return self.max_height_break_data(line_height);
                             }
-                            self.state.append_atom_to_line(&atom, next_x, text_metrics);
+                            self.state.append_atom_to_line(
+                                &atom,
+                                next_x,
+                                text_metrics,
+                                is_separator,
+                            );
                         }
                         // Else we attempt to line break:
                         //
@@ -879,7 +906,12 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                                 if max_height_exceeded {
                                     return self.max_height_break_data(line_height);
                                 }
-                                self.state.append_atom_to_line(&atom, next_x, text_metrics);
+                                self.state.append_atom_to_line(
+                                    &atom,
+                                    next_x,
+                                    text_metrics,
+                                    is_separator,
+                                );
                                 return self.start_new_line(
                                     BreakReason::Regular,
                                     max_advance,
@@ -922,7 +954,12 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                                 if max_height_exceeded {
                                     return self.max_height_break_data(line_height);
                                 }
-                                self.state.append_atom_to_line(&atom, next_x, text_metrics);
+                                self.state.append_atom_to_line(
+                                    &atom,
+                                    next_x,
+                                    text_metrics,
+                                    is_separator,
+                                );
                             }
                         }
                     }
@@ -1041,6 +1078,7 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                         let first_character = &atom.characters()[0];
                         let whitespace = first_character.info.whitespace();
                         let is_newline = whitespace == Whitespace::Newline;
+                        let is_separator = is_word_separator(whitespace);
                         let advance = spacing.atom_advance(&atom);
 
                         // Compute the x position.
@@ -1050,7 +1088,8 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                         } else {
                             self.state.line.x + advance
                         };
-                        self.state.append_atom_to_line(&atom, next_x, text_metrics);
+                        self.state
+                            .append_atom_to_line(&atom, next_x, text_metrics, is_separator);
                         char_count += atom.char_range().len() as u32;
 
                         // Check if we've reached the limit after adding this atom
@@ -1456,8 +1495,11 @@ fn commit_line<B: Brush>(
     // let end_run_idx = lines.line_items.last().map(|item| item.index).unwrap_or(0);
     let end_item_idx = lines.line_items.len();
 
-    let (hanging_advance, justification_end_cluster) =
+    let (hanging_advance, justification_end_cluster, hanging_opportunities) =
         hanging_whitespace(layout, &lines.line_items[start_item_idx..end_item_idx]);
+    // The word separators counted as the line was built include the line's hanging whitespace, and
+    // hanging whitespace is not stretched by justification.
+    let num_justification_opportunities = state.num_word_separators - hanging_opportunities;
 
     // Reorder the items within the line (if required). Reordering is required if the line contains
     // a mix of bidi levels (a mix of LTR and RTL text)
@@ -1470,8 +1512,7 @@ fn commit_line<B: Brush>(
         text_range: text_start..text_end,
         max_advance,
         break_reason,
-        // Justification opportunities are counted lazily.
-        num_justification_opportunities: None,
+        num_justification_opportunities,
         justification: Justification {
             justification_end_cluster,
             ..Justification::NONE
@@ -1505,14 +1546,19 @@ fn commit_line<B: Brush>(
 }
 
 /// Returns the advance of the whitespace hanging past the end of the line made up of `line_items`,
-/// plus the index one past its logically last shaped cluster that's eligible for justification (see
-/// [`Justification::justification_end_cluster`]).
+/// the index one past its logically last shaped cluster that's eligible for justification (see
+/// [`Justification::justification_end_cluster`]), and the number of justification opportunities
+/// that are no longer eligible, as they are at or beyond that cluster.
 ///
 /// `line_items` must be in logical order.
-fn hanging_whitespace<B: Brush>(layout: &Layout<B>, line_items: &[LineItemData]) -> (f32, u32) {
+fn hanging_whitespace<B: Brush>(
+    layout: &Layout<B>,
+    line_items: &[LineItemData],
+) -> (f32, u32, u32) {
     let mut hanging_whitespace_advance = 0.;
     // Atoms with shaped clusters before this index may be stretched by justification.
     let mut justification_end_cluster = u32::MAX;
+    let mut hanging_opportunities = 0;
 
     for line_item in line_items.iter().rev() {
         match line_item.kind {
@@ -1555,15 +1601,26 @@ fn hanging_whitespace<B: Brush>(layout: &Layout<B>, line_items: &[LineItemData])
                     // Justification can't stretch within an atom, so it stops at the start of the
                     // last atom that hangs atom hangs in its entirety or only partially.
                     justification_end_cluster = atom.shaped_clusters_range().start;
+                    if is_word_separator(atom.characters()[0].info.whitespace()) {
+                        hanging_opportunities += 1;
+                    }
                     if !all_hang {
-                        return (hanging_whitespace_advance, justification_end_cluster);
+                        return (
+                            hanging_whitespace_advance,
+                            justification_end_cluster,
+                            hanging_opportunities,
+                        );
                     }
                 }
             }
         }
     }
 
-    (hanging_whitespace_advance, justification_end_cluster)
+    (
+        hanging_whitespace_advance,
+        justification_end_cluster,
+        hanging_opportunities,
+    )
 }
 
 /// Reorder items within line according to the bidi levels of the items

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -11,7 +11,7 @@ use core_maths::CoreFloat;
 use parlance::BidiLevel;
 
 use crate::layout::data::count_graphemes;
-use crate::layout::spacing::{EffectiveSpacing, Justification, is_word_separator};
+use crate::layout::spacing::{EffectiveSpacing, Justification};
 use crate::layout::whitespace::{atom_hanging_advance, whitespace_can_hang};
 use crate::layout::{
     BreakReason, Layout, LayoutData, LayoutItem, LayoutItemKind, LineData, LineItemData,
@@ -1168,109 +1168,11 @@ impl<'a, B: Brush> BreakLines<'a, B> {
 
         // Reset metrics for line
         line.metrics.offset = 0.;
-        line.text_range.start = usize::MAX;
 
         line.metrics.line_height = line_height;
 
         if line.item_range.is_empty() {
             line.text_range = self.layout.data.text_len..self.layout.data.text_len;
-        }
-
-        // Walk the line's items to compute text ranges, per-run advances, bidi ordering, and
-        // hanging whitespace. The vertical metrics (ascent/descent/line-height and inline box
-        // extents) are *not* computed here: they were already accumulated into `self.state.line` as
-        // the line was built and are read from there below.
-        let mut needs_reorder = false;
-        let mut hanging_whitespace_advance = 0.;
-        let mut num_justification_opportunities = 0;
-        // One past the justified region: atoms with shaped clusters before this index may be
-        // stretched by justification.
-        let mut justification_end_cluster = u32::MAX;
-
-        let mut hanging = true; // Whether we've seen any line item that stops hanging.
-        for line_item in self.lines.line_items[line.item_range.clone()]
-            .iter_mut()
-            .rev()
-        {
-            match line_item.kind {
-                LayoutItemKind::InlineBox => {
-                    let item = &self.layout.data.inline_boxes[line_item.index];
-
-                    // Advance is already computed in "commit line" for items
-                    if item.kind == InlineBoxKind::InFlow {
-                        // Inline boxes don't hang.
-                        hanging = false;
-                    }
-                }
-                LayoutItemKind::TextRun => {
-                    // Trailing whitespace can only hang if it ends up at the line's end edge after
-                    // bidi reordering. We don't currently apply UAX #9 L1 (resetting trailing
-                    // whitespace to paragraph level), so only logically-last items that match the
-                    // paragraph level are guaranteed to be at that edge.
-                    if hanging && line_item.bidi_level != self.layout.data.base_level {
-                        hanging = false;
-                    }
-
-                    // Compute the text range for the line
-                    // Q: Can we not simplify this computation by assuming that items are in order?
-                    line.text_range.end = line.text_range.end.max(line_item.text_range.end);
-                    line.text_range.start = line.text_range.start.min(line_item.text_range.start);
-
-                    // Mark line as needing bidi re-ordering if it contains any runs with non-zero bidi level
-                    // (zero is the default level, so this is equivalent to marking lines that have multiple levels)
-                    if line_item.bidi_level != BidiLevel::new(0) {
-                        needs_reorder = true;
-                    }
-
-                    let slice = self
-                        .layout
-                        .data
-                        .shaped_text
-                        .run_slice(line_item.index as u32)
-                        .narrow(line_item.shaped_cluster_range.clone());
-
-                    // Calculate the run's advance including any word/letter spacing. This doesn't
-                    // include justification, as that's applied after lines are broken.
-                    let effective_spacing = EffectiveSpacing::new(
-                        self.layout.data.runs[line_item.index].spacing,
-                        Justification::NONE,
-                    );
-                    line_item.advance = effective_spacing.slice_advance(slice);
-
-                    // Ignore trailing whitespace for the line's content advance calculation
-                    // (we are iterating backwards so trailing whitespace comes first).
-                    for atom in slice.atoms_end().rev() {
-                        if hanging {
-                            let (atom_hanging, all_hang) = atom_hanging_advance(
-                                slice,
-                                &atom,
-                                &self.layout.data.styles,
-                                effective_spacing,
-                                line_item.is_rtl(),
-                            );
-                            hanging_whitespace_advance += atom_hanging;
-                            // Justification can't stretch within an atom, so it stops at the start
-                            // of the last atom that hangs, whether in its entirety or only
-                            // partially.
-                            justification_end_cluster = atom.shaped_clusters_range().start;
-                            hanging = all_hang;
-                        } else if is_word_separator(atom.characters()[0].info.whitespace()) {
-                            num_justification_opportunities += 1;
-                        }
-                    }
-                }
-            }
-        }
-
-        line.metrics.hanging_advance = hanging_whitespace_advance;
-        line.num_justification_opportunities = num_justification_opportunities;
-        line.justification.justification_end_cluster = justification_end_cluster;
-
-        // Reorder the items within the line (if required). Reordering is required if the line contains
-        // a mix of bidi levels (a mix of LTR and RTL text)
-        let item_count = line.item_range.end - line.item_range.start;
-        if needs_reorder && item_count > 1 {
-            reorder_line_items(&mut self.lines.line_items[line.item_range.clone()]);
         }
 
         // Whether metrics should be quantized to pixel boundaries
@@ -1431,6 +1333,12 @@ fn commit_line<B: Brush>(
     // println!("\nCOMMIT LINE");
     let mut last_item_kind = LayoutItemKind::TextRun;
     let mut committed_text_run = false;
+    // The line's source text range, as the union of the ranges of the text runs committed to it.
+    let mut text_start = usize::MAX;
+    let mut text_end = 0;
+    // Mark line as needing bidi re-ordering if it contains any runs with non-zero bidi level
+    // (zero is the default level, so this is equivalent to marking lines that have multiple levels)
+    let mut needs_reorder = false;
     for (i, item) in items_to_commit.iter().enumerate() {
         // println!("i = {} index = {} {:?}", i, item.index, item.kind);
 
@@ -1501,7 +1409,7 @@ fn commit_line<B: Brush>(
                                 shaped_run.shaped_clusters_range.start..cluster_range.start,
                             ))
                         });
-                let (text_range, grapheme_range) = if cluster_range.is_empty() {
+                let (item_text_range, grapheme_range) = if cluster_range.is_empty() {
                     let char_pos = shaped_clusters[cluster_range.start as usize]
                         .chars_range()
                         .start;
@@ -1519,14 +1427,28 @@ fn commit_line<B: Brush>(
                     (text_range, grapheme_start..grapheme_start + grapheme_len)
                 };
 
+                // Compute the text range for the line
+                // Q: Can we not simplify this computation by assuming that items are in order?
+                text_start = text_start.min(item_text_range.start);
+                text_end = text_end.max(item_text_range.end);
+                needs_reorder |= shaped_run.bidi_level != BidiLevel::new(0);
+
+                // Calculate the run's advance including any word/letter spacing. This doesn't
+                // include justification, as that's applied after lines are broken.
+                let effective_spacing = EffectiveSpacing::new(
+                    layout.data.runs[item.index].spacing,
+                    Justification::NONE,
+                );
+                let advance = effective_spacing.slice_advance(slice.narrow(cluster_range.clone()));
+
                 lines.line_items.push(LineItemData {
                     kind: LayoutItemKind::TextRun,
                     index: item.index,
                     bidi_level: shaped_run.bidi_level,
-                    advance: 0.,
+                    advance,
                     shaped_cluster_range: cluster_range,
                     grapheme_range,
-                    text_range,
+                    text_range: item_text_range,
                 });
             }
         }
@@ -1534,18 +1456,32 @@ fn commit_line<B: Brush>(
     // let end_run_idx = lines.line_items.last().map(|item| item.index).unwrap_or(0);
     let end_item_idx = lines.line_items.len();
 
+    let (hanging_advance, justification_end_cluster) =
+        hanging_whitespace(layout, &lines.line_items[start_item_idx..end_item_idx]);
+
+    // Reorder the items within the line (if required). Reordering is required if the line contains
+    // a mix of bidi levels (a mix of LTR and RTL text)
+    if needs_reorder && end_item_idx - start_item_idx > 1 {
+        reorder_line_items(&mut lines.line_items[start_item_idx..end_item_idx]);
+    }
+
     lines.lines.push(LineData {
         item_range: start_item_idx..end_item_idx,
+        text_range: text_start..text_end,
         max_advance,
         break_reason,
-        num_justification_opportunities: 0,
-        justification: Justification::NONE,
+        // Justification opportunities are counted lazily.
+        num_justification_opportunities: None,
+        justification: Justification {
+            justification_end_cluster,
+            ..Justification::NONE
+        },
         indent: line_indent,
         metrics: LineMetrics {
             advance: state.x,
+            hanging_advance,
             ..Default::default()
         },
-        ..Default::default()
     });
 
     // Reset state for the new line
@@ -1566,6 +1502,68 @@ fn commit_line<B: Brush>(
     };
 
     true
+}
+
+/// Returns the advance of the whitespace hanging past the end of the line made up of `line_items`,
+/// plus the index one past its logically last shaped cluster that's eligible for justification (see
+/// [`Justification::justification_end_cluster`]).
+///
+/// `line_items` must be in logical order.
+fn hanging_whitespace<B: Brush>(layout: &Layout<B>, line_items: &[LineItemData]) -> (f32, u32) {
+    let mut hanging_whitespace_advance = 0.;
+    // Atoms with shaped clusters before this index may be stretched by justification.
+    let mut justification_end_cluster = u32::MAX;
+
+    for line_item in line_items.iter().rev() {
+        match line_item.kind {
+            LayoutItemKind::InlineBox => {
+                let item = &layout.data.inline_boxes[line_item.index];
+
+                // Inline boxes don't hang.
+                if item.kind == InlineBoxKind::InFlow {
+                    break;
+                }
+            }
+            LayoutItemKind::TextRun => {
+                // Trailing whitespace can only hang if it ends up at the line's end edge after bidi
+                // reordering. We don't currently apply UAX #9 L1 (resetting trailing whitespace to
+                // paragraph level), so only logically-last items that match the paragraph level are
+                // guaranteed to be at that edge.
+                if line_item.bidi_level != layout.data.base_level {
+                    break;
+                }
+
+                let effective_spacing = EffectiveSpacing::new(
+                    layout.data.runs[line_item.index].spacing,
+                    Justification::NONE,
+                );
+                let slice = layout
+                    .data
+                    .shaped_text
+                    .run_slice(line_item.index as u32)
+                    .narrow(line_item.shaped_cluster_range.clone());
+
+                for atom in slice.atoms_end().rev() {
+                    let (hanging, all_hang) = atom_hanging_advance(
+                        slice,
+                        &atom,
+                        &layout.data.styles,
+                        effective_spacing,
+                        line_item.is_rtl(),
+                    );
+                    hanging_whitespace_advance += hanging;
+                    // Justification can't stretch within an atom, so it stops at the start of the
+                    // last atom that hangs atom hangs in its entirety or only partially.
+                    justification_end_cluster = atom.shaped_clusters_range().start;
+                    if !all_hang {
+                        return (hanging_whitespace_advance, justification_end_cluster);
+                    }
+                }
+            }
+        }
+    }
+
+    (hanging_whitespace_advance, justification_end_cluster)
 }
 
 /// Reorder items within line according to the bidi levels of the items


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Mostly generated.

Most of the code is just moved around.

Motivated by https://github.com/linebender/parley/pull/762#issuecomment-5588545755, and see [#parley > Parley perf 0.11 vs main (2026-09-08)](https://xi.zulipchat.com/#narrow/channel/205635-parley/topic/Parley.20perf.200.2E11.20vs.20main.20.282026-09-08.29/with/622668594).

This removes the reverse line walk the line breaker performed in `finish_line`; this now determines those facts in the forward walk during `commit_line`, plus there's once again a (usually small) walk backwards, only over the line's hanging whitespace.

The justification opportunities are no longer counted during line breaking, but are calculated (and cached) by `Layout::align(Alignment::Justify, ..)`.

# Performance

This is a tidy little performance improvement.

```
Line Breaking - arabic 4 paragraph, narrow              [   9.0 us ...   8.4 us ]      -7.04%*
Line Breaking - arabic 4 paragraph, wider               [   6.8 us ...   6.1 us ]     -10.38%*
Line Breaking - arabic 4 paragraph, unwrapped           [   6.2 us ...   5.5 us ]     -10.52%*
Line Breaking - latin 4 paragraph, narrow               [   7.2 us ...   6.5 us ]     -10.19%*
Line Breaking - latin 4 paragraph, wider                [   5.2 us ...   4.5 us ]     -13.51%*
Line Breaking - latin 4 paragraph, unwrapped            [   4.5 us ...   3.9 us ]     -13.90%*
Line Breaking - japanese 4 paragraph, narrow            [   5.1 us ...   4.6 us ]     -10.48%*
Line Breaking - japanese 4 paragraph, wider             [   4.1 us ...   3.6 us ]     -11.28%*
Line Breaking - japanese 4 paragraph, unwrapped         [   3.8 us ...   3.3 us ]     -11.73%*
Line Breaking - arabic 4 paragraph, wrapped + spacing   [   7.7 us ...   7.0 us ]      -9.37%*
Line Breaking - latin 4 paragraph, wrapped + spacing    [   5.9 us ...   5.2 us ]     -11.50%*
Line Breaking - japanese 4 paragraph, wrapped + spacing [   4.5 us ...   4.0 us ]     -11.23%*
```

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**