### PR TITLE
Store derived `Whitespace`

### DIFF
--- a/parley_engine/src/shape/data.rs
+++ b/parley_engine/src/shape/data.rs
@@ -184,6 +184,7 @@ impl ShapedCluster {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ClusterInfo {
     boundary: Boundary,
+    whitespace: Whitespace,
     source_char: char,
 }
 
@@ -192,6 +193,7 @@ impl ClusterInfo {
     pub fn new(boundary: Boundary, source_char: char) -> Self {
         Self {
             boundary,
+            whitespace: Whitespace::from_char(source_char),
             source_char,
         }
     }
@@ -205,7 +207,7 @@ impl ClusterInfo {
     // Returns the whitespace type of the cluster.
     #[inline(always)]
     pub fn whitespace(self) -> Whitespace {
-        Whitespace::from_char(self.source_char)
+        self.whitespace
     }
 
     /// Returns if the cluster is a line boundary.


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: None.

Stores `Whitespace` on `ClusterInfo`, moving us towards storing more of the derived facts and hopefully soon dropping `source_char: char`. Nico also mentioned to me `Whitespace::from_char` got flagged as a potential hotspot.

Once that `char` is actually gone, we'll want to move the `ClusterInfo` fields onto `Character`, but for now that struct is a useful place for this.

# Performance

This is a small, but measurable, line breaking performance improvement.

```
Line Breaking - arabic 4 paragraph, narrow              [   9.0 us ...   8.8 us ]      -2.21%*
Line Breaking - arabic 4 paragraph, wider               [   6.8 us ...   6.6 us ]      -2.66%*
Line Breaking - arabic 4 paragraph, unwrapped           [   6.2 us ...   6.1 us ]      -0.37%
Line Breaking - latin 4 paragraph, narrow               [   7.3 us ...   6.9 us ]      -5.59%*
Line Breaking - latin 4 paragraph, wider                [   5.2 us ...   5.1 us ]      -2.38%*
Line Breaking - latin 4 paragraph, unwrapped            [   4.5 us ...   4.3 us ]      -3.56%*
Line Breaking - japanese 4 paragraph, narrow            [   5.2 us ...   5.1 us ]      -0.05%
Line Breaking - japanese 4 paragraph, wider             [   4.1 us ...   4.1 us ]      -1.16%*
Line Breaking - japanese 4 paragraph, unwrapped         [   3.8 us ...   3.8 us ]      -0.98%
Line Breaking - arabic 4 paragraph, wrapped + spacing   [   7.8 us ...   7.4 us ]      -5.36%*
Line Breaking - latin 4 paragraph, wrapped + spacing    [   5.9 us ...   5.6 us ]      -4.18%*
Line Breaking - japanese 4 paragraph, wrapped + spacing [   4.6 us ...   4.4 us ]      -4.18%*
```

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**
