### PR TITLE
Add larger "document scale" benchmarks for each pipeline phase

### DIFF
--- a/parley_bench/benches/main.rs
+++ b/parley_bench/benches/main.rs
@@ -6,8 +6,8 @@
 use tango_bench::tango_benchmarks;
 
 use parley_bench::benches::{
-    content_widths, defaults, iterate_glyph_runs, line_breaking, long_line, repeated_justification,
-    spacing, styled,
+    content_widths, defaults, document, iterate_glyph_runs, line_breaking, long_line,
+    repeated_justification, spacing, styled,
 };
 use parley_bench::fontique_benches::system_fonts_init;
 
@@ -16,6 +16,7 @@ tango_benchmarks!(
     styled(),
     iterate_glyph_runs(),
     content_widths(),
+    document(),
     spacing(),
     repeated_justification(),
     line_breaking(),

--- a/parley_bench/src/benches.rs
+++ b/parley_bench/src/benches.rs
@@ -5,7 +5,7 @@
 //!
 //! This module provides benchmarks for text layout and rendering.
 
-use crate::{ColorBrush, FONT_FAMILY_LIST, get_samples, with_contexts};
+use crate::{ColorBrush, FONT_FAMILY_LIST, get_documents, get_samples, with_contexts};
 use parley::{
     Alignment, AlignmentOptions, FontFamily, FontStyle, FontWeight, Layout, PositionedLayoutItem,
     StyleProperty,
@@ -504,4 +504,75 @@ pub fn long_line() -> Vec<Benchmark> {
             ]
         })
         .collect()
+}
+
+/// Benchmarks for document-scale inputs, exercising each layout pipeline phase
+/// separately.
+///
+/// The other groups cover short excerpts (at most four paragraphs) and mostly
+/// run the whole pipeline end-to-end. These use the full text samples
+/// (~12–120KB) plus a ~250KB Latin document, at a page-like 800px wrap width —
+/// the scale at which per-phase costs in build, line breaking, content widths,
+/// and glyph iteration diverge.
+pub fn document() -> Vec<Benchmark> {
+    const MAX_ADVANCE: f32 = 800.0;
+
+    let mut benchmarks = Vec::new();
+
+    for sample in get_documents() {
+        benchmarks.push(benchmark_fn(
+            format!("Document Build - {} {}", sample.name, sample.modification),
+            move |b| {
+                let text = &sample.text;
+                b.iter(move || black_box(build_layout(text, [])))
+            },
+        ));
+    }
+
+    for sample in get_documents() {
+        benchmarks.push(benchmark_fn(
+            format!(
+                "Document Break + Align - {} {}",
+                sample.name, sample.modification
+            ),
+            move |b| {
+                let mut layout = build_layout(&sample.text, []);
+                b.iter(move || {
+                    layout.break_all_lines(Some(MAX_ADVANCE));
+                    layout.align(Alignment::Start, AlignmentOptions::default());
+                    black_box(layout.lines().count())
+                })
+            },
+        ));
+    }
+
+    for sample in get_documents() {
+        benchmarks.push(benchmark_fn(
+            format!(
+                "Document Content Widths - {} {}",
+                sample.name, sample.modification
+            ),
+            move |b| {
+                let layout = build_layout(&sample.text, []);
+                b.iter(move || black_box(layout.calculate_content_widths()))
+            },
+        ));
+    }
+
+    for sample in get_documents() {
+        benchmarks.push(benchmark_fn(
+            format!(
+                "Document Glyph Iteration - {} {}",
+                sample.name, sample.modification
+            ),
+            move |b| {
+                let mut layout = build_layout(&sample.text, []);
+                layout.break_all_lines(Some(MAX_ADVANCE));
+                layout.align(Alignment::Start, AlignmentOptions::default());
+                b.iter(move || black_box(walk_items(&layout)))
+            },
+        ));
+    }
+
+    benchmarks
 }

--- a/parley_bench/src/lib.rs
+++ b/parley_bench/src/lib.rs
@@ -177,3 +177,45 @@ pub fn get_samples() -> &'static [Sample] {
         ]
     })
 }
+
+static DOCUMENTS: OnceLock<Vec<Sample>> = OnceLock::new();
+
+/// Returns large, document-scale samples for benchmarking.
+///
+/// Each sample is the full text of the built-in sample file, plus a large
+/// Latin document built by repeating the Latin sample — ~250KB, the scale of a
+/// long article page, where per-phase layout costs become measurable.
+pub fn get_documents() -> &'static [Sample] {
+    let samples = parley_dev::TextSamples::new();
+
+    DOCUMENTS.get_or_init(|| {
+        let mut large_latin = String::with_capacity(samples.latin.text.len() * 21);
+        while large_latin.len() < 250_000 {
+            large_latin.push_str(samples.latin.text);
+            large_latin.push('\n');
+        }
+
+        vec![
+            Sample {
+                name: samples.arabic.name,
+                modification: "full text",
+                text: samples.arabic.text.to_string(),
+            },
+            Sample {
+                name: samples.latin.name,
+                modification: "full text",
+                text: samples.latin.text.to_string(),
+            },
+            Sample {
+                name: samples.japanese.name,
+                modification: "full text",
+                text: samples.japanese.text.to_string(),
+            },
+            Sample {
+                name: samples.latin.name,
+                modification: "~250KB",
+                text: large_latin,
+            },
+        ]
+    })
+}


### PR DESCRIPTION
LLM Contributions: Generated with Fable 5.1 Low

Add a `document` benchmark group measuring build, break+align, content widths, and glyph iteration separately on the full-length text samples (~12–120KB) plus a ~250KB Latin document: the scale where the per-phase costs that the micro-bench axis comparisons exercise become measurable. Existing benchmark groups only cover excerpts of up to four paragraphs.

These are the benchmarks used for the historical sweep (see: https://xi.zulipchat.com/#narrow/channel/205635-parley/topic/Parley.20perf.200.2E11.20vs.20main.20.282026-09-08.29). So they're known to actually cover some of the perf issues that we care about.

**Changelog**: None
