### PR TITLE
Don't create a line break opportunity at an out-of-flow inline box

### DIFF
--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -669,10 +669,19 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                                 inline_box.height - baseline,
                             )
                         }
+                        // Out-of-flow boxes are not in-flow content: unlike an atomic inline they
+                        // neither contribute to the line's extents nor introduce a line break
+                        // opportunity, so they are appended to the line and otherwise skipped.
                         // Negative infinity extents are a no-op when maxed into the line's
                         // extents, so out-of-flow boxes truly contribute nothing.
                         InlineBoxKind::OutOfFlow => {
-                            (0.0, 0.0, f32::NEG_INFINITY, f32::NEG_INFINITY)
+                            self.state.append_inline_box_to_line(
+                                self.state.line.x,
+                                f32::NEG_INFINITY,
+                                f32::NEG_INFINITY,
+                                self.layout.data.quantize,
+                            );
+                            continue;
                         }
                         // If the box is a `CustomOutOfFlow` box then we yield control flow back to the caller.
                         // It is then the caller's responsibility to handle placement of the box.

--- a/parley_tests/tests/out_of_flow_boxes.rs
+++ b/parley_tests/tests/out_of_flow_boxes.rs
@@ -76,3 +76,43 @@ fn out_of_flow_box_has_no_effect_on_layout() {
     });
     assert!(found_oof);
 }
+
+/// An out-of-flow box is not in-flow content, so it must not introduce a line break
+/// opportunity: a word containing one still overflows rather than being split.
+#[test]
+fn out_of_flow_box_is_not_a_line_break_opportunity() {
+    let mut env = TestEnv::new(test_name!(), None);
+
+    let text = "unbreakable";
+
+    let line_ranges = |layout: &Layout<ColorBrush>| -> Vec<_> {
+        layout.lines().map(|line| line.text_range()).collect()
+    };
+
+    let mut layout_ref = env.ranged_builder(text).build(text);
+    layout_ref.break_all_lines(Some(20.0));
+    assert_eq!(layout_ref.len(), 1);
+
+    // A box anywhere in the word, including at either edge, leaves the line breaking unchanged.
+    for index in [0, 5, text.len()] {
+        let mut builder = env.ranged_builder(text);
+        builder.push_inline_box(InlineBox {
+            id: 42,
+            kind: InlineBoxKind::OutOfFlow,
+            index,
+            width: 9999.0,
+            height: 9999.0,
+            baseline: None,
+        });
+        let mut layout = builder.build(text);
+        layout.break_all_lines(Some(20.0));
+
+        assert_eq!(layout.width(), layout_ref.width(), "index {index}");
+        assert_eq!(layout.height(), layout_ref.height(), "index {index}");
+        assert_eq!(
+            line_ranges(&layout),
+            line_ranges(&layout_ref),
+            "index {index}"
+        );
+    }
+}


### PR DESCRIPTION
LLM Contributions: Generated 

This is a correctness fix. An out-of-flow box is not in-flow content, so unlike an in-flow InlineBox it introduces no line break opportunity.

**Changelog**

> ### Changed
>
> - OutOfFlow inline boxes no longer produce line-break opportunities
