### PR TITLE
Improve the sampling of text in the benchmarks

### DIFF
--- a/parley_bench/src/benches.rs
+++ b/parley_bench/src/benches.rs
@@ -97,8 +97,8 @@ pub fn repeated_justification() -> [Benchmark; 1] {
 
     let sample = get_samples()
         .iter()
-        .find(|sample| sample.name == "latin" && sample.modification == "4 paragraph")
-        .expect("the Latin four-paragraph benchmark sample should exist");
+        .find(|sample| sample.name == "latin" && sample.modification == "8000 characters")
+        .expect("the Latin 8000-character benchmark sample should exist");
 
     [benchmark_fn(
         format!(
@@ -169,7 +169,7 @@ pub fn line_breaking() -> Vec<Benchmark> {
     let samples = || {
         get_samples()
             .iter()
-            .filter(|sample| sample.modification == "4 paragraph")
+            .filter(|sample| sample.modification == "8000 characters")
     };
 
     let mut benchmarks = Vec::new();
@@ -295,8 +295,9 @@ pub fn styled() -> Vec<Benchmark> {
 ///
 /// The cases fall into three groups:
 ///
-/// - Four paragraphs of Latin with a single style, without line wrapping, giving four shaped runs.
-/// - Four paragraphs of Latin with a style alternating every few characters, without line wrapping.
+/// - 8000 characters of Latin with a single style, without line wrapping, giving one shaped run per
+///   paragraph.
+/// - 8000 characters of Latin with a style alternating every few characters, without line wrapping.
 ///   Glyph runs break wherever the style changes; some properties, such as bold, also split the
 ///   shaped run. This benches both cases.
 /// - Mixed styling of each script with line wrapping. This covers script, bidi and font fallback
@@ -304,8 +305,8 @@ pub fn styled() -> Vec<Benchmark> {
 pub fn iterate_glyph_runs() -> Vec<Benchmark> {
     let latin = get_samples()
         .iter()
-        .find(|sample| sample.name == "latin" && sample.modification == "4 paragraph")
-        .expect("the Latin four-paragraph benchmark sample should exist");
+        .find(|sample| sample.name == "latin" && sample.modification == "8000 characters")
+        .expect("the Latin 8000-character benchmark sample should exist");
 
     let mut benchmarks = vec![benchmark_fn(
         format!(
@@ -342,7 +343,7 @@ pub fn iterate_glyph_runs() -> Vec<Benchmark> {
 
     for sample in get_samples()
         .iter()
-        .filter(|sample| sample.modification == "4 paragraph")
+        .filter(|sample| sample.modification == "8000 characters")
     {
         benchmarks.push(benchmark_fn(
             format!(
@@ -464,7 +465,6 @@ fn build_unwrapped_layout<'a>(
 pub fn long_line() -> Vec<Benchmark> {
     const DISPLAY_SCALE: f32 = 1.0;
     const QUANTIZE: bool = true;
-    const REPEAT: usize = 4;
 
     fn layout_long_line(text: &str, max_advance: Option<f32>, alignment: Alignment) {
         with_contexts(|font_cx, layout_cx| {
@@ -483,15 +483,9 @@ pub fn long_line() -> Vec<Benchmark> {
 
     samples
         .iter()
-        .filter(|sample| sample.modification == "4 paragraph")
+        .filter(|sample| sample.modification == "8000 characters")
         .flat_map(|sample| {
-            let text: &'static str = Box::leak(
-                sample
-                    .text
-                    .replace('\n', " ")
-                    .repeat(REPEAT)
-                    .into_boxed_str(),
-            );
+            let text: &'static str = Box::leak(sample.text.replace('\n', " ").into_boxed_str());
             [
                 benchmark_fn(format!("Long Line - {}", sample.name), move |b| {
                     b.iter(move || layout_long_line(text, None, Alignment::Start))

--- a/parley_bench/src/lib.rs
+++ b/parley_bench/src/lib.rs
@@ -105,6 +105,27 @@ pub struct Sample {
 
 static SAMPLES: OnceLock<Vec<Sample>> = OnceLock::new();
 
+/// Take `chars` characters of `text`.
+///
+/// A paragraph that crosses the budget is truncated. Paragraphs are joined by a single `\n`.
+fn take_chars(text: &str, chars: usize) -> String {
+    let mut out = String::new();
+    let mut remaining = chars;
+    for paragraph in text.split("\n\n").map(str::trim).filter(|p| !p.is_empty()) {
+        if remaining == 0 {
+            break;
+        }
+        if !out.is_empty() {
+            out.push('\n');
+            remaining -= 1;
+        }
+        let taken = paragraph.chars().take(remaining).collect::<String>();
+        remaining -= taken.chars().count();
+        out.push_str(&taken);
+    }
+    out
+}
+
 /// Returns a list of samples to be used for benchmarking.
 pub fn get_samples() -> &'static [Sample] {
     let samples = parley_dev::TextSamples::new();
@@ -114,65 +135,47 @@ pub fn get_samples() -> &'static [Sample] {
             Sample {
                 name: samples.arabic.name,
                 modification: "20 characters",
-                text: samples.arabic.text.chars().take(20).collect(),
+                text: take_chars(samples.arabic.text, 20),
             },
             Sample {
                 name: samples.latin.name,
                 modification: "20 characters",
-                text: samples.latin.text.chars().take(20).collect(),
+                text: take_chars(samples.latin.text, 20),
             },
             Sample {
                 name: samples.japanese.name,
                 modification: "20 characters",
-                text: samples.japanese.text.chars().take(20).collect(),
+                text: take_chars(samples.japanese.text, 20),
             },
             Sample {
                 name: samples.arabic.name,
-                modification: "1 paragraph",
-                text: samples.arabic.text.lines().next().unwrap().to_string(),
+                modification: "400 characters",
+                text: take_chars(samples.arabic.text, 400),
             },
             Sample {
                 name: samples.latin.name,
-                modification: "1 paragraph",
-                text: samples.latin.text.lines().next().unwrap().to_string(),
+                modification: "400 characters",
+                text: take_chars(samples.latin.text, 400),
             },
             Sample {
                 name: samples.japanese.name,
-                modification: "1 paragraph",
-                text: samples.japanese.text.lines().next().unwrap().to_string(),
+                modification: "400 characters",
+                text: take_chars(samples.japanese.text, 400),
             },
             Sample {
                 name: samples.arabic.name,
-                modification: "4 paragraph",
-                text: samples
-                    .arabic
-                    .text
-                    .lines()
-                    .take(4)
-                    .collect::<Vec<_>>()
-                    .join("\n"),
+                modification: "8000 characters",
+                text: take_chars(samples.arabic.text, 8000),
             },
             Sample {
                 name: samples.latin.name,
-                modification: "4 paragraph",
-                text: samples
-                    .latin
-                    .text
-                    .lines()
-                    .take(4)
-                    .collect::<Vec<_>>()
-                    .join("\n"),
+                modification: "8000 characters",
+                text: take_chars(samples.latin.text, 8000),
             },
             Sample {
                 name: samples.japanese.name,
-                modification: "4 paragraph",
-                text: samples
-                    .japanese
-                    .text
-                    .lines()
-                    .take(4)
-                    .collect::<Vec<_>>()
-                    .join("\n"),
+                modification: "8000 characters",
+                text: take_chars(samples.japanese.text, 8000),
             },
         ]
     })


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Review.

This PR proposes to change the sampling of text for our benchmarks from "paragraphs" to a given number of characters: I think we can expect workload costs for the various cases we're benching to be related especially to the number of characters, making the timings more easily interpretable.

This fixes a few problems that our current sampling of paragraphs has.

First, note that while we currently take "paragraphs," the source `.txt` files are wrapped with newlines, and e.g. the "4 paragraph" case is actually just taking a few lines. (There's an orthogonal issue here that I've opened another PR for: #799.)

Second, the actual paragraphs are separated by `\n\n`, meaning some lines of the samples are/could be simply empty.

Third, if the problems above were fixed, the timings between workload size and between scripts would both be quite incomparable still, as the various paragraphs have significantly different lengths.

This now samples 20, 400, and 8000 characters. The consistent jump of 20x between the cases should be helpful in determining whether timings are linear in the number of characters or not.

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**
