### PR TITLE
perf: Accumulate character offsets in `shape_segment`

### DIFF
--- a/parley_engine/src/shape/shaped_text.rs
+++ b/parley_engine/src/shape/shaped_text.rs
@@ -227,6 +227,12 @@ impl ShapedText {
         glyph_buffer: &harfrust::GlyphBuffer,
         normalized_coords: &[harfrust::NormalizedCoord],
     ) {
+        debug_assert_eq!(
+            range.char_range.len(),
+            text[range.byte_range.clone()].chars().count(),
+            "The claimed character range and the text's covered byte range should agree"
+        );
+
         let glyph_infos = glyph_buffer.glyph_infos();
         if glyph_infos.is_empty() {
             return;

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -236,6 +236,9 @@ fn shape_segment(
     };
     let mut current_font = Some(next_font);
 
+    // The character offset prefix sum.
+    let mut char_start = char_range.start;
+
     // Main segmentation loop (based on swash shape_clusters) - only within current item
     while let Some(font) = current_font.take() {
         // Collect all clusters for this font segment
@@ -374,13 +377,13 @@ fn shape_segment(
                 .point_size(Some(options.font_size)),
         );
 
-        let char_start = char_range.start + item_text[..segment_start_offset].chars().count();
         let segment_char_count = segment_text.chars().count();
         let range = TextRange {
             byte_range: (item.range.byte_range.start + segment_start_offset)
                 ..(item.range.byte_range.start + segment_end_offset),
             char_range: char_start..char_start + segment_char_count,
         };
+        char_start += segment_char_count;
         shaped_text.push_run(
             text,
             range,

--- a/parley_engine/src/shape/shaper.rs
+++ b/parley_engine/src/shape/shaper.rs
@@ -236,7 +236,7 @@ fn shape_segment(
     };
     let mut current_font = Some(next_font);
 
-    // The character offset prefix sum.
+    // The character offset of the current font run's start, accumulated per run.
     let mut char_start = char_range.start;
 
     // Main segmentation loop (based on swash shape_clusters) - only within current item


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Spotted by an LLM, review.

Previously, we were `.count()`ing the prefix over and over, which is quadratic (roughly runs * item lengh).

# Performance

This especially impacts Arabic, as it currently has a ton of runs (each space character selects Roboto!) and large items.

Measured using https://github.com/linebender/parley/pull/798, https://github.com/linebender/parley/pull/799, https://github.com/linebender/parley/pull/800.

```
Default Style - arabic 20 characters               [   9.3 us ...   9.1 us ]      -1.72%*
Default Style - latin 20 characters                [   4.4 us ...   4.4 us ]      +0.96%
Default Style - japanese 20 characters             [   7.9 us ...   7.8 us ]      -0.81%
Default Style - arabic 400 characters              [ 204.6 us ... 198.3 us ]      -3.07%*
Default Style - latin 400 characters               [  63.8 us ...  63.8 us ]      -0.10%
Default Style - japanese 400 characters            [ 137.3 us ... 136.5 us ]      -0.56%
Default Style - arabic 8000 characters             [   5.5 ms ...   4.6 ms ]     -15.20%*
Default Style - latin 8000 characters              [   1.4 ms ...   1.4 ms ]      -0.02%
Default Style - japanese 8000 characters           [   3.0 ms ...   2.9 ms ]      -0.56%
Styled - arabic 20 characters                      [  10.4 us ...  10.3 us ]      -0.54%
Styled - latin 20 characters                       [   5.6 us ...   5.7 us ]      +1.11%*
Styled - japanese 20 characters                    [   8.4 us ...   8.4 us ]      -0.40%
Styled - arabic 400 characters                     [ 226.2 us ... 219.0 us ]      -3.16%*
Styled - latin 400 characters                      [  82.1 us ...  82.5 us ]      +0.50%
Styled - japanese 400 characters                   [ 150.6 us ... 148.7 us ]      -1.24%*
Styled - arabic 8000 characters                    [   6.0 ms ...   5.1 ms ]     -14.92%*
Styled - latin 8000 characters                     [   1.8 ms ...   1.8 ms ]      -4.27%*
Styled - japanese 8000 characters                  [   3.3 ms ...   3.2 ms ]      -0.91%
...
Page Full - arabic 8000 characters                 [   5.1 ms ...   4.6 ms ]      -9.54%*
Page Full - latin 8000 characters                  [   1.5 ms ...   1.5 ms ]      +0.44%
Page Full - japanese 8000 characters               [   3.2 ms ...   3.2 ms ]      -0.25%
Page Build - arabic 8000 characters                [   4.8 ms ...   4.3 ms ]     -10.45%*
Page Build - latin 8000 characters                 [   1.3 ms ...   1.3 ms ]      -1.53%*
Page Build - japanese 8000 characters              [   2.9 ms ...   2.9 ms ]      -1.15%*
```

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**