### PR TITLE
Don't let hanging whitespace end the line early, and fix hanging-whitespace content widths

### DIFF
--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -349,8 +349,8 @@ impl<B: Brush> LayoutData<B> {
                             // Newlines hang, so whitespace before them keeps hanging.
                             min_width =
                                 min_width.max(running_min_width - running_hanging_whitespace);
-                            max_width =
-                                max_width.max(running_max_width - running_hanging_whitespace);
+                            // A max-content line never wraps, so nothing can hang off it.
+                            max_width = max_width.max(running_max_width);
                             running_min_width = 0.0;
                             running_max_width = 0.0;
                             running_hanging_whitespace = 0.0;
@@ -365,7 +365,7 @@ impl<B: Brush> LayoutData<B> {
                         running_min_width += advance;
                         running_max_width += advance;
 
-                        if !can_hang {
+                        if !can_hang || text_wrap_mode != TextWrapMode::Wrap {
                             running_hanging_whitespace = 0.0;
                         } else if characters.len() == 1 {
                             // Fast path for the common-case that the atom is a single character,
@@ -436,7 +436,7 @@ impl<B: Brush> LayoutData<B> {
         }
 
         min_width = min_width.max(running_min_width - running_hanging_whitespace);
-        max_width = max_width.max(running_max_width - running_hanging_whitespace);
+        max_width = max_width.max(running_max_width);
 
         ContentWidths {
             min: min_width,

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -862,7 +862,11 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                         else {
                             // Case: the atom is a space character (and wrapping is enabled)
                             //
-                            // We hang any overflowing whitespace and then line-break.
+                            // We hang overflowing whitespace and continue scanning rather than
+                            // breaking immediately: hanging whitespace does not end the line on
+                            // its own. A following forced break (e.g. a newline) terminates the
+                            // line normally, while following non-whitespace content that doesn't
+                            // fit breaks at the opportunity marked after the hanging whitespace.
                             if is_space && style.text_wrap_mode == TextWrapMode::Wrap {
                                 if max_height_exceeded {
                                     return self.max_height_break_data(line_height);
@@ -874,11 +878,7 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                                     line_height,
                                     self.layout.data.quantize,
                                 );
-                                return self.start_new_line(
-                                    BreakReason::Regular,
-                                    max_advance,
-                                    line_indent,
-                                );
+                                self.state.mark_line_break_opportunity();
                             }
                             // Case: we have previously encountered a REGULAR line-breaking opportunity in the current line
                             //


### PR DESCRIPTION
LLM Contributions: Generated with Fable 5.1 Low.

A few hanging whitespace fixups. Followups for https://github.com/linebender/parley/pull/785 needed to mitigate Blitz WPT test regressions.
