### PR TITLE
Add shared helper for atom hanging advance calculation

### DIFF
--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -3,7 +3,7 @@
 
 use crate::inline_box::InlineBox;
 use crate::layout::spacing::{EffectiveSpacing, Justification, Spacing};
-use crate::layout::whitespace::whitespace_can_hang;
+use crate::layout::whitespace::{atom_hanging_advance, whitespace_can_hang};
 use crate::layout::{ContentWidths, LineMetrics, Style};
 use crate::resolve::ResolvedStyle;
 use crate::style::Brush;
@@ -378,38 +378,10 @@ impl<B: Brush> LayoutData<B> {
                                 running_hanging_whitespace = 0.0;
                             }
                         } else {
-                            // The atom may hang partially: e.g., a prepend character followed by a
-                            // space is a single atom (as it's a grapheme), but may consist of
-                            // multiple shaped clusters, of which the spaces can hang. Only the
-                            // atom's spacing at its logical end hangs along with the clusters.
-                            let gaps = spacing.gaps(&atom);
-                            let (gap_start, gap_end) = if is_rtl {
-                                (gaps.after, gaps.before)
-                            } else {
-                                (gaps.before, gaps.after)
-                            };
-                            let mut last_cluster = true;
-                            let mut all_hang = true;
-                            let mut hanging = 0.0;
-                            for cluster in atom.shaped_clusters().iter().rev() {
-                                let cluster_hangs =
-                                    slice.characters_in(cluster.chars_range()).iter().all(|c| {
-                                        whitespace_can_hang(c.info.whitespace())
-                                            && self.styles[c.style_index as usize].text_wrap_mode
-                                                == TextWrapMode::Wrap
-                                    });
-                                if !cluster_hangs {
-                                    all_hang = false;
-                                    break;
-                                }
-                                if last_cluster {
-                                    hanging += gap_end;
-                                    last_cluster = false;
-                                }
-                                hanging += cluster.advance;
-                            }
+                            let (hanging, all_hang) =
+                                atom_hanging_advance(slice, &atom, &self.styles, spacing, is_rtl);
                             if all_hang {
-                                running_hanging_whitespace += hanging + gap_start;
+                                running_hanging_whitespace += hanging;
                             } else {
                                 running_hanging_whitespace = hanging;
                             }

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -12,7 +12,7 @@ use parlance::BidiLevel;
 
 use crate::layout::data::count_graphemes;
 use crate::layout::spacing::{EffectiveSpacing, Justification, is_word_separator};
-use crate::layout::whitespace::whitespace_can_hang;
+use crate::layout::whitespace::{atom_hanging_advance, whitespace_can_hang};
 use crate::layout::{
     BreakReason, Layout, LayoutData, LayoutItem, LayoutItemKind, LineData, LineItemData,
     LineMetrics, Run,
@@ -1241,59 +1241,19 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                     // (we are iterating backwards so trailing whitespace comes first).
                     for atom in slice.atoms_end().rev() {
                         if hanging {
-                            // An atom can hang partially: e.g., a prepend character followed by a
-                            // space is a single atom (as it's a grapheme), but may consist of
-                            // multiple shaped clusters. We can hang the advance of the space's
-                            // shaped cluster. In case of such partial hanging, if the atom has any
-                            // additional spacing (e.g., through word spacing), only the logically
-                            // last spacing is hung.
-                            let mut last_cluster = true;
-                            let (gap_start, gap_end) = {
-                                let gaps = effective_spacing.gaps(&atom);
-                                if line_item.is_rtl() {
-                                    (gaps.after, gaps.before)
-                                } else {
-                                    (gaps.before, gaps.after)
-                                }
-                            };
-                            for (cluster, cluster_idx) in atom
-                                .shaped_clusters()
-                                .iter()
-                                .zip(atom.shaped_clusters_range())
-                                .rev()
-                            {
-                                let cluster_hangs =
-                                    slice.characters_in(cluster.chars_range()).iter().all(|c| {
-                                        let whitespace = c.info.whitespace();
-                                        // Note non-breaking spaces don't hang: CSS Text 4 § 4.3.2
-                                        // hangs only spaces, tabs, segment breaks, and "other space
-                                        // separators." Of those "other space separators," we
-                                        // currently hang only the ideographic space.
-                                        //
-                                        // Note whitespace only hangs with `TextWrapMode::Wrap`,
-                                        // following CSS Text 4 § 4.3.2.
-                                        whitespace_can_hang(whitespace)
-                                            && self.layout.data.styles[c.style_index as usize]
-                                                .text_wrap_mode
-                                                == TextWrapMode::Wrap
-                                    });
-                                if !cluster_hangs {
-                                    hanging = false;
-                                    break;
-                                }
-                                if last_cluster {
-                                    hanging_whitespace_advance += gap_end;
-                                    last_cluster = false;
-                                }
-                                hanging_whitespace_advance += cluster.advance;
-                                justification_end_cluster = cluster_idx;
-                            }
-
-                            if hanging {
-                                hanging_whitespace_advance += gap_start;
-                            } else {
-                                justification_end_cluster = atom.shaped_clusters_range().start;
-                            }
+                            let (atom_hanging, all_hang) = atom_hanging_advance(
+                                slice,
+                                &atom,
+                                &self.layout.data.styles,
+                                effective_spacing,
+                                line_item.is_rtl(),
+                            );
+                            hanging_whitespace_advance += atom_hanging;
+                            // Justification can't stretch within an atom, so it stops at the start
+                            // of the last atom that hangs, whether in its entirety or only
+                            // partially.
+                            justification_end_cluster = atom.shaped_clusters_range().start;
+                            hanging = all_hang;
                         } else if is_word_separator(atom.characters()[0].info.whitespace()) {
                             num_justification_opportunities += 1;
                         }

--- a/parley/src/layout/whitespace.rs
+++ b/parley/src/layout/whitespace.rs
@@ -4,6 +4,12 @@
 //! Some whitespace-related utilities.
 
 use parley_engine::shape::Whitespace;
+use parley_engine::{Atom, ShapedSlice};
+
+use crate::TextWrapMode;
+use crate::layout::Style;
+use crate::layout::spacing::EffectiveSpacing;
+use crate::style::Brush;
 
 /// Whether this is whitespace that is allowed to hang past the line.
 ///
@@ -21,4 +27,58 @@ pub(crate) const fn whitespace_can_hang(whitespace: Whitespace) -> bool {
         whitespace,
         Whitespace::Space | Whitespace::IdeographicSpace | Whitespace::Tab | Whitespace::Newline
     )
+}
+
+/// The advance of the logically trailing clusters of `atom` that can hang past the line's end, and
+/// whether that is the atom in its entirety.
+///
+/// An atom can hang partially: e.g., a prepend character followed by a space is a single atom (as
+/// it's a grapheme), but may consist of multiple shaped clusters, of which the spaces can hang.
+/// The atom's spacing at its logical end hangs along with the clusters, and if the atom hangs in
+/// its entirety does its spacing at its logical start hang as well.
+#[inline(always)]
+pub(crate) fn atom_hanging_advance<B: Brush>(
+    slice: ShapedSlice<'_>,
+    atom: &Atom<'_>,
+    styles: &[Style<B>],
+    spacing: EffectiveSpacing,
+    is_rtl: bool,
+) -> (f32, bool) {
+    let gaps = spacing.gaps(atom);
+    let (gap_start, gap_end) = if is_rtl {
+        (gaps.after, gaps.before)
+    } else {
+        (gaps.before, gaps.after)
+    };
+    let mut last_cluster = true;
+    let mut all_hang = true;
+    let mut hanging = 0.;
+    for cluster in atom.shaped_clusters().iter().rev() {
+        let cluster_hangs = slice
+            .characters_in(cluster.chars_range())
+            .iter()
+            .all(|character| {
+                // Note whitespace only hangs with `TextWrapMode::Wrap`, following
+                // CSS Text 4 § 4.3.2.
+                whitespace_can_hang(character.info.whitespace())
+                    && styles[character.style_index as usize].text_wrap_mode == TextWrapMode::Wrap
+            });
+        if !cluster_hangs {
+            all_hang = false;
+            break;
+        }
+        if last_cluster {
+            hanging += gap_end;
+            last_cluster = false;
+        }
+        hanging += cluster.advance;
+    }
+
+    let hanging = if all_hang {
+        hanging + gap_start
+    } else {
+        hanging
+    };
+
+    (hanging, all_hang)
 }


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Extracted this from #789.

This creates a shared helper of the hanging atom advance calculation (currently effectively duplicated between line breaking and `calculate_content_widths`).

# Performance

Neutral, measured using #798, #799, #800.

```
Line Breaking - arabic 8000 characters, narrow              [ 157.0 us ... 157.8 us ]      +0.53%
Line Breaking - arabic 8000 characters, wider               [ 132.9 us ... 133.7 us ]      +0.54%
Line Breaking - arabic 8000 characters, unwrapped           [ 119.1 us ... 118.4 us ]      -0.55%
Line Breaking - latin 8000 characters, narrow               [ 112.1 us ... 112.2 us ]      +0.06%
Line Breaking - latin 8000 characters, wider                [  73.7 us ...  74.0 us ]      +0.40%
Line Breaking - latin 8000 characters, unwrapped            [  56.3 us ...  55.3 us ]      -1.73%*
Line Breaking - japanese 8000 characters, narrow            [ 172.1 us ... 172.4 us ]      +0.22%
Line Breaking - japanese 8000 characters, wider             [ 140.9 us ... 144.7 us ]      +2.72%*
Line Breaking - japanese 8000 characters, unwrapped         [ 127.1 us ... 129.0 us ]      +1.45%*
Line Breaking - arabic 8000 characters, wrapped + spacing   [ 144.9 us ... 146.0 us ]      +0.78%
Line Breaking - latin 8000 characters, wrapped + spacing    [  95.1 us ...  93.9 us ]      -1.30%*
Line Breaking - japanese 8000 characters, wrapped + spacing [ 153.5 us ... 157.1 us ]      +2.40%*
Page Break - arabic 8000 characters                         [ 122.2 us ... 123.1 us ]      +0.72%
Page Break - latin 8000 characters                          [  61.2 us ...  60.5 us ]      -1.19%*
Page Break - japanese 8000 characters                       [ 131.0 us ... 133.0 us ]      +1.54%*
```

```
Content Widths - arabic 20 characters, uniform     [  51.9 ns ...  52.0 ns ]      +0.23%
Content Widths - latin 20 characters, uniform      [  51.8 ns ...  46.9 ns ]      -9.45%*
Content Widths - japanese 20 characters, uniform   [  53.3 ns ...  53.1 ns ]      -0.52%
Content Widths - arabic 400 characters, uniform    [   1.0 us ...   1.0 us ]      -0.55%
Content Widths - latin 400 characters, uniform     [ 881.4 ns ... 882.0 ns ]      +0.07%
Content Widths - japanese 400 characters, uniform  [   1.0 us ...   1.0 us ]      -0.41%
Content Widths - arabic 8000 characters, uniform   [  27.7 us ...  28.8 us ]      +3.84%*
Content Widths - latin 8000 characters, uniform    [  27.6 us ...  27.6 us ]      +0.14%
Content Widths - japanese 8000 characters, uniform [  26.3 us ...  26.6 us ]      +1.11%*
Content Widths - arabic 20 characters, mixed       [  54.7 ns ...  54.4 ns ]      -0.56%
Content Widths - latin 20 characters, mixed        [  49.9 ns ...  49.9 ns ]      +0.05%
Content Widths - japanese 20 characters, mixed     [  54.4 ns ...  54.4 ns ]      -0.03%
Content Widths - arabic 400 characters, mixed      [   1.1 us ...   1.1 us ]      -0.69%
Content Widths - latin 400 characters, mixed       [ 903.8 ns ... 904.9 ns ]      +0.12%
Content Widths - japanese 400 characters, mixed    [   1.1 us ...   1.0 us ]      -0.73%
Content Widths - arabic 8000 characters, mixed     [  29.6 us ...  30.5 us ]      +3.28%*
Content Widths - latin 8000 characters, mixed      [  26.0 us ...  26.4 us ]      +1.25%*
Content Widths - japanese 8000 characters, mixed   [  30.0 us ...  29.8 us ]      -0.50%
Page Content Widths - arabic 8000 characters       [  28.1 us ...  28.8 us ]      +2.75%*
Page Content Widths - latin 8000 characters        [  27.6 us ...  27.6 us ]      +0.27%
Page Content Widths - japanese 8000 characters     [  28.5 us ...  28.4 us ]      -0.54%
```

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**