### PR TITLE
Expose Layout::clear

### DIFF
--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -214,6 +214,13 @@ impl<B: Brush> LayoutData<B> {
         self.width = 0.;
         self.full_width = 0.;
         self.height = 0.;
+        self.layout_max_advance = 0.0;
+        self.indent_amount = 0.0;
+        self.indent_options = IndentOptions::default();
+        #[cfg(feature = "accesskit")]
+        {
+            self.alignment = None;
+        }
         self.styles.clear();
         self.inline_boxes.clear();
         self.shaped_text.clear();

--- a/parley/src/layout/layout.rs
+++ b/parley/src/layout/layout.rs
@@ -48,11 +48,10 @@ impl<B: Brush> Layout<B> {
         Self::default()
     }
 
-    /// Clears the layout.
+    /// Clears the layout while retaining capacity.
     ///
-    /// When using a pool of [`Layout`] to reduce allocations for text layout,
-    /// [`Layout::clear`] is useful to ensure that no [`Layout`] maintains a strong reference
-    /// to an underlying font, which would prevent that fonts freeing.
+    /// This clears underlying strong references to fonts, which would otherwise
+    /// prevent those fonts from being freed until dropping or reusing this layout.
     pub fn clear(&mut self) {
         self.data.clear();
     }

--- a/parley/src/layout/layout.rs
+++ b/parley/src/layout/layout.rs
@@ -48,6 +48,22 @@ impl<B: Brush> Layout<B> {
         Self::default()
     }
 
+    /// Clears the layout.
+    ///
+    /// When using a pool of [`Layout`] to reduce allocations for text layout,
+    /// [`Layout::clear`] is useful to ensure that no [`Layout`] maintains a strong reference
+    /// to an underlying font, which would prevent that fonts freeing.
+    pub fn clear(&mut self) {
+        self.data.clear();
+        self.data.layout_max_advance = 0.0;
+        self.data.indent_amount = 0.0;
+        self.data.indent_options = IndentOptions::default();
+        #[cfg(feature = "accesskit")]
+        {
+            self.data.alignment = None;
+        }
+    }
+
     /// Returns the scale factor provided when creating the layout.
     pub fn scale(&self) -> f32 {
         self.data.scale

--- a/parley/src/layout/layout.rs
+++ b/parley/src/layout/layout.rs
@@ -55,13 +55,6 @@ impl<B: Brush> Layout<B> {
     /// to an underlying font, which would prevent that fonts freeing.
     pub fn clear(&mut self) {
         self.data.clear();
-        self.data.layout_max_advance = 0.0;
-        self.data.indent_amount = 0.0;
-        self.data.indent_options = IndentOptions::default();
-        #[cfg(feature = "accesskit")]
-        {
-            self.data.alignment = None;
-        }
     }
 
     /// Returns the scale factor provided when creating the layout.

--- a/parley/src/tests/mod.rs
+++ b/parley/src/tests/mod.rs
@@ -3,4 +3,5 @@
 
 mod test_analysis;
 mod test_builders;
+mod test_layout;
 mod utils;

--- a/parley/src/tests/test_builders.rs
+++ b/parley/src/tests/test_builders.rs
@@ -3,72 +3,21 @@
 
 //! Test that the various builders produce the same results.
 
-use std::{borrow::Cow, path::PathBuf, sync::Arc, vec, vec::Vec};
+use std::{vec, vec::Vec};
 
-use fontique::{Collection, CollectionOptions, FontStyle, FontWeight, FontWidth, SourceCache};
-use parlance::FontFamilyName;
-use peniko::{Blob, color::palette};
+use fontique::{FontStyle, FontWeight, FontWidth};
+use peniko::color::palette;
 
-use super::utils::{ColorBrush, asserts::assert_eq_layout_data};
+use super::utils::{
+    ColorBrush,
+    asserts::assert_eq_layout_data,
+    fonts::{FONT_FAMILY_LIST, create_font_context},
+};
 use crate::{
     BaseDirection, BreakReason, FontContext, FontFamily, FontFeatures, FontVariations, Layout,
     LayoutContext, LineHeight, OverflowWrap, RangedBuilder, StyleProperty, StyleRunBuilder,
     TextStyle, TextWrapMode, TreeBuilder, WordBreak,
 };
-
-// TODO: `FONT_FAMILY_LIST`, `load_fonts`, and `create_font_context` are
-// duplicated between this crate and `parley_test`. We can't move the builder
-// tests into `parley_test` because they use private APIs, but should eventually
-// figure out some way to reduce the duplication.
-const FONT_FAMILY_LIST: &[FontFamilyName<'_>] = &[
-    FontFamilyName::Named(Cow::Borrowed("Roboto")),
-    FontFamilyName::Named(Cow::Borrowed("Noto Kufi Arabic")),
-];
-
-pub(crate) fn load_fonts(
-    collection: &mut Collection,
-    font_dirs: impl Iterator<Item = PathBuf>,
-) -> std::io::Result<()> {
-    for dir in font_dirs {
-        let paths = std::fs::read_dir(dir)?;
-        for entry in paths {
-            let entry = entry?;
-            if !entry.metadata()?.is_file() {
-                continue;
-            }
-            let path = entry.path();
-            if path
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .is_none_or(|ext| !["ttf", "otf", "ttc", "otc"].contains(&ext))
-            {
-                continue;
-            }
-            let font_data = std::fs::read(&path)?;
-            collection.register_fonts(Blob::new(Arc::new(font_data)), None);
-        }
-    }
-    Ok(())
-}
-
-fn create_font_context() -> FontContext {
-    let mut collection = Collection::new(CollectionOptions {
-        shared: false,
-        system_fonts: false,
-    });
-    load_fonts(&mut collection, parley_dev::font_dirs()).unwrap();
-    for font in FONT_FAMILY_LIST {
-        if let FontFamilyName::Named(font_name) = font {
-            collection
-                .family_id(font_name)
-                .unwrap_or_else(|| panic!("{font_name} font not found"));
-        }
-    }
-    FontContext {
-        collection,
-        source_cache: SourceCache::default(),
-    }
-}
 
 /// Set of options for [`build_layout_with_ranged`].
 struct RangedOptions<'a> {

--- a/parley/src/tests/test_layout.rs
+++ b/parley/src/tests/test_layout.rs
@@ -1,0 +1,30 @@
+// Copyright 2026 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use super::utils::{
+    ColorBrush,
+    fonts::{FONT_FAMILY_LIST, create_font_context},
+};
+use crate::{Alignment, AlignmentOptions, FontFamily, IndentOptions, Layout, LayoutContext};
+
+#[test]
+fn clear_resets_to_new() {
+    let mut fcx = create_font_context();
+    let mut lcx: LayoutContext<ColorBrush> = LayoutContext::new();
+
+    static TEXT: &str = "Some text that will wrap across several lines.";
+
+    let mut builder = lcx.ranged_builder(&mut fcx, TEXT, 1., false);
+    builder.push_default(FontFamily::from(FONT_FAMILY_LIST));
+    let mut layout = builder.build(TEXT);
+    layout.set_text_indent(10., IndentOptions::default());
+    layout.break_all_lines(Some(50.));
+    layout.align(Alignment::Center, AlignmentOptions::default());
+    assert!(layout.lines().len() > 1);
+    assert!(layout.width() > 0.);
+    assert!(layout.height() > 0.);
+
+    layout.clear();
+
+    assert_eq!(layout.data, Layout::new().data);
+}

--- a/parley/src/tests/utils/fonts.rs
+++ b/parley/src/tests/utils/fonts.rs
@@ -1,0 +1,64 @@
+// Copyright 2026 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::{borrow::Cow, path::PathBuf, sync::Arc};
+
+use fontique::{Collection, CollectionOptions, SourceCache};
+use parlance::FontFamilyName;
+use peniko::Blob;
+
+use crate::FontContext;
+
+// TODO: `FONT_FAMILY_LIST`, `load_fonts`, and `create_font_context` are
+// duplicated between this crate and `parley_test`. We can't move the in-crate
+// tests into `parley_test` because they use private APIs, but should eventually
+// figure out some way to reduce the duplication.
+pub(crate) const FONT_FAMILY_LIST: &[FontFamilyName<'_>] = &[
+    FontFamilyName::Named(Cow::Borrowed("Roboto")),
+    FontFamilyName::Named(Cow::Borrowed("Noto Kufi Arabic")),
+];
+
+pub(crate) fn load_fonts(
+    collection: &mut Collection,
+    font_dirs: impl Iterator<Item = PathBuf>,
+) -> std::io::Result<()> {
+    for dir in font_dirs {
+        let paths = std::fs::read_dir(dir)?;
+        for entry in paths {
+            let entry = entry?;
+            if !entry.metadata()?.is_file() {
+                continue;
+            }
+            let path = entry.path();
+            if path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_none_or(|ext| !["ttf", "otf", "ttc", "otc"].contains(&ext))
+            {
+                continue;
+            }
+            let font_data = std::fs::read(&path)?;
+            collection.register_fonts(Blob::new(Arc::new(font_data)), None);
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn create_font_context() -> FontContext {
+    let mut collection = Collection::new(CollectionOptions {
+        shared: false,
+        system_fonts: false,
+    });
+    load_fonts(&mut collection, parley_dev::font_dirs()).unwrap();
+    for font in FONT_FAMILY_LIST {
+        if let FontFamilyName::Named(font_name) = font {
+            collection
+                .family_id(font_name)
+                .unwrap_or_else(|| panic!("{font_name} font not found"));
+        }
+    }
+    FontContext {
+        collection,
+        source_cache: SourceCache::default(),
+    }
+}

--- a/parley/src/tests/utils/mod.rs
+++ b/parley/src/tests/utils/mod.rs
@@ -4,6 +4,7 @@
 use peniko::Color;
 
 pub(crate) mod asserts;
+pub(crate) mod fonts;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct ColorBrush {


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Claude Opus 5.

## Intent

We use a pool of [`Layout`] and I've found that, even after uninstalling a font, a `Layout` can retain the font in memory because it holds a strong reference to the underlying font data.

I would like to add a clear function to `Layout` so that I can be sure that, after uninstalling a font, its memory isn't going to be kept around due to some `Layout` holding onto it in our pool.

## Notes

- I created a new `parley/src/tests/test_layout.rs` file to house the test. I wanted to use a private API to enable equality comparison against `Layout::data`. I noticed `PartialEq` being implemented for `LayoutData` and `Brush` but not `Layout`, so I assumed that the omission was intentional?
- Anyway, to facilitate the test, I had to move a helper to a location that could be shared.

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog**

> ### Added
> 
> - `Layout::clear` API to clear the contents of a layout. This is useful to ensure that all references are freed of an uninstalled font.
