### PR TITLE
Benchmark layout cursor queries

### DIFF
--- a/parley_bench/benches/main.rs
+++ b/parley_bench/benches/main.rs
@@ -10,7 +10,7 @@ use parley_bench::benches::{
     repeated_justification, spacing, styled,
 };
 use parley_bench::fontique_benches::system_fonts_init;
-use parley_bench::query_benches::caret_navigation;
+use parley_bench::query_benches::cursor;
 
 tango_benchmarks!(
     defaults(),
@@ -22,6 +22,6 @@ tango_benchmarks!(
     line_breaking(),
     long_line(),
     page(),
-    caret_navigation(),
+    cursor(),
     system_fonts_init()
 );

--- a/parley_bench/benches/main.rs
+++ b/parley_bench/benches/main.rs
@@ -10,6 +10,7 @@ use parley_bench::benches::{
     repeated_justification, spacing, styled,
 };
 use parley_bench::fontique_benches::system_fonts_init;
+use parley_bench::query_benches::caret_navigation;
 
 tango_benchmarks!(
     defaults(),
@@ -21,5 +22,6 @@ tango_benchmarks!(
     line_breaking(),
     long_line(),
     page(),
+    caret_navigation(),
     system_fonts_init()
 );

--- a/parley_bench/src/benches.rs
+++ b/parley_bench/src/benches.rs
@@ -424,7 +424,7 @@ pub fn content_widths() -> Vec<Benchmark> {
 /// Build `text` into a layout. Each style of `styles` is applied to its given byte range.
 ///
 /// This doesn't break the layout into lines.
-fn build_layout<'a>(
+pub(crate) fn build_layout<'a>(
     text: &str,
     styles: impl IntoIterator<Item = (StyleProperty<'a, ColorBrush>, Range<usize>)>,
 ) -> Layout<ColorBrush> {

--- a/parley_bench/src/lib.rs
+++ b/parley_bench/src/lib.rs
@@ -19,6 +19,7 @@ use parley::{
 
 pub mod benches;
 pub mod fontique_benches;
+pub mod query_benches;
 
 /// A color brush.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]

--- a/parley_bench/src/query_benches.rs
+++ b/parley_bench/src/query_benches.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Benchmarks for queries against finished [`Layout`]s, like caret placement.
+//! Benchmarks for queries against finished [`Layout`]s, like cursor movement.
 
 use crate::benches::build_layout;
 use crate::{ColorBrush, get_samples};
@@ -50,7 +50,7 @@ fn spread_cursors(layout: &Layout<ColorBrush>, text: &str, count: usize) -> Vec<
 fn walk_lines(layout: &Layout<ColorBrush>, starts: &[Cursor], lines: usize) -> usize {
     let mut indices = 0;
     for start in starts {
-        // Uses a [`Selection`], as that retains the caret's horizontal position across lines.
+        // Uses a [`Selection`], as that retains the cursor's horizontal position across lines.
         let mut selection = Selection::from(*start);
         for _ in 0..lines {
             selection = selection.next_line(layout, false);
@@ -63,8 +63,8 @@ fn walk_lines(layout: &Layout<ColorBrush>, starts: &[Cursor], lines: usize) -> u
     indices
 }
 
-/// Benchmark caret movement.
-pub fn caret_navigation() -> Vec<Benchmark> {
+/// Benchmark cursor building and movement.
+pub fn cursor() -> Vec<Benchmark> {
     /// The number of start positions to operate from.
     const STARTS: usize = 16;
     /// The number of clusters moved over per start position.
@@ -80,7 +80,7 @@ pub fn caret_navigation() -> Vec<Benchmark> {
     {
         benchmarks.push(benchmark_fn(
             format!(
-                "Query Caret - {} {}, next visual",
+                "Query Cursor - {} {}, next visual",
                 sample.name, sample.modification
             ),
             move |b| {
@@ -107,7 +107,7 @@ pub fn caret_navigation() -> Vec<Benchmark> {
     {
         benchmarks.push(benchmark_fn(
             format!(
-                "Query Caret - {} {}, line down + up",
+                "Query Cursor - {} {}, line down + up",
                 sample.name, sample.modification
             ),
             move |b| {
@@ -126,10 +126,10 @@ pub fn caret_navigation() -> Vec<Benchmark> {
         .find(|sample| sample.name == "latin" && sample.modification == "8000 characters")
         .expect("the Latin 8000-character benchmark sample should exist");
 
-    // With longer lines, finding the caret's horizontal position walks more clusters per move.
+    // With longer lines, finding the cursor's horizontal position walks more clusters per move.
     benchmarks.push(benchmark_fn(
         format!(
-            "Query Caret - {} {}, line down + up, long lines",
+            "Query Cursor - {} {}, line down + up, long lines",
             latin.name, latin.modification
         ),
         move |b| {
@@ -141,7 +141,7 @@ pub fn caret_navigation() -> Vec<Benchmark> {
 
     benchmarks.push(benchmark_fn(
         format!(
-            "Query Caret - {} {}, from byte index",
+            "Query Cursor - {} {}, from byte index",
             latin.name, latin.modification
         ),
         move |b| {

--- a/parley_bench/src/query_benches.rs
+++ b/parley_bench/src/query_benches.rs
@@ -44,27 +44,7 @@ fn spread_cursors(layout: &Layout<ColorBrush>, text: &str, count: usize) -> Vec<
         .collect()
 }
 
-/// Move each cursor of `starts` `steps` times using `step`.
-///
-/// Returns a value derived from what the cursors landed on, to `black_box`.
-fn walk_cursors(
-    layout: &Layout<ColorBrush>,
-    starts: &[Cursor],
-    steps: usize,
-    step: impl Fn(&Cursor, &Layout<ColorBrush>) -> Cursor,
-) -> usize {
-    let mut indices = 0;
-    for start in starts {
-        let mut cursor = *start;
-        for _ in 0..steps {
-            cursor = step(&cursor, layout);
-        }
-        indices += cursor.index();
-    }
-    indices
-}
-
-/// Move each cursor of `starts` down `lines` number of lines down and back up again.
+/// Move each cursor of `starts` down `lines` number of lines and back up again.
 ///
 /// Returns a value derived from what the cursors landed on, to `black_box`.
 fn walk_lines(layout: &Layout<ColorBrush>, starts: &[Cursor], lines: usize) -> usize {
@@ -107,12 +87,15 @@ pub fn caret_navigation() -> Vec<Benchmark> {
                 let layout = build_and_break(&sample.text, Some(MAX_ADVANCE));
                 let starts = spread_cursors(&layout, &sample.text, STARTS);
                 b.iter(move || {
-                    black_box(walk_cursors(
-                        &layout,
-                        &starts,
-                        CLUSTER_STEPS,
-                        |cursor, layout| cursor.next_visual(layout),
-                    ))
+                    let mut indices = 0;
+                    for &start in &starts {
+                        let mut cursor = start;
+                        for _ in 0..CLUSTER_STEPS {
+                            cursor = cursor.next_visual(&layout);
+                        }
+                        indices += cursor.index();
+                    }
+                    black_box(indices)
                 })
             },
         ));

--- a/parley_bench/src/query_benches.rs
+++ b/parley_bench/src/query_benches.rs
@@ -1,0 +1,179 @@
+// Copyright 2026 the Parley Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Benchmarks for queries against finished [`Layout`]s, like caret placement.
+
+use crate::benches::build_layout;
+use crate::{ColorBrush, get_samples};
+use parley::{Affinity, Alignment, AlignmentOptions, Cursor, Layout, Selection};
+use std::hint::black_box;
+use tango_bench::{Benchmark, benchmark_fn};
+
+/// The width to wrap at: around 90 characters of 16px Roboto per line.
+const MAX_ADVANCE: f32 = 720.;
+
+/// A width to wrap at that gives much longer lines than [`MAX_ADVANCE`], while still leaving some
+/// lines to move between.
+const WIDE_MAX_ADVANCE: f32 = 10. * MAX_ADVANCE;
+
+fn build_and_break(text: &str, max_advance: Option<f32>) -> Layout<ColorBrush> {
+    let mut layout = build_layout(text, []);
+    layout.break_all_lines(max_advance);
+    layout.align(Alignment::Start, AlignmentOptions::default());
+    layout
+}
+
+/// Byte indices spread evenly through `text`, snapped to character boundaries.
+fn spread_byte_indices(text: &str, count: usize) -> Vec<usize> {
+    (0..count)
+        .map(|position| {
+            let mut index = text.len() * position / count;
+            while !text.is_char_boundary(index) {
+                index -= 1;
+            }
+            index
+        })
+        .collect()
+}
+
+/// Cursors at the [spread byte indices](spread_byte_indices) of `text`.
+fn spread_cursors(layout: &Layout<ColorBrush>, text: &str, count: usize) -> Vec<Cursor> {
+    spread_byte_indices(text, count)
+        .into_iter()
+        .map(|index| Cursor::from_byte_index(layout, index, Affinity::Downstream))
+        .collect()
+}
+
+/// Move each cursor of `starts` `steps` times using `step`.
+///
+/// Returns a value derived from what the cursors landed on, to `black_box`.
+fn walk_cursors(
+    layout: &Layout<ColorBrush>,
+    starts: &[Cursor],
+    steps: usize,
+    step: impl Fn(&Cursor, &Layout<ColorBrush>) -> Cursor,
+) -> usize {
+    let mut indices = 0;
+    for start in starts {
+        let mut cursor = *start;
+        for _ in 0..steps {
+            cursor = step(&cursor, layout);
+        }
+        indices += cursor.index();
+    }
+    indices
+}
+
+/// Move each cursor of `starts` down `lines` number of lines down and back up again.
+///
+/// Returns a value derived from what the cursors landed on, to `black_box`.
+fn walk_lines(layout: &Layout<ColorBrush>, starts: &[Cursor], lines: usize) -> usize {
+    let mut indices = 0;
+    for start in starts {
+        // Uses a [`Selection`], as that retains the caret's horizontal position across lines.
+        let mut selection = Selection::from(*start);
+        for _ in 0..lines {
+            selection = selection.next_line(layout, false);
+        }
+        for _ in 0..lines {
+            selection = selection.previous_line(layout, false);
+        }
+        indices += selection.focus().index();
+    }
+    indices
+}
+
+/// Benchmark caret movement.
+pub fn caret_navigation() -> Vec<Benchmark> {
+    /// The number of start positions to operate from.
+    const STARTS: usize = 16;
+    /// The number of clusters moved over per start position.
+    const CLUSTER_STEPS: usize = 16;
+    /// The number of lines moved down, and back up, per start position.
+    const LINE_STEPS: usize = 4;
+
+    let mut benchmarks = Vec::new();
+
+    for sample in get_samples()
+        .iter()
+        .filter(|sample| sample.modification == "8000 characters")
+    {
+        benchmarks.push(benchmark_fn(
+            format!(
+                "Query Caret - {} {}, next visual",
+                sample.name, sample.modification
+            ),
+            move |b| {
+                let layout = build_and_break(&sample.text, Some(MAX_ADVANCE));
+                let starts = spread_cursors(&layout, &sample.text, STARTS);
+                b.iter(move || {
+                    black_box(walk_cursors(
+                        &layout,
+                        &starts,
+                        CLUSTER_STEPS,
+                        |cursor, layout| cursor.next_visual(layout),
+                    ))
+                })
+            },
+        ));
+    }
+
+    for sample in get_samples()
+        .iter()
+        .filter(|sample| sample.modification == "8000 characters")
+    {
+        benchmarks.push(benchmark_fn(
+            format!(
+                "Query Caret - {} {}, line down + up",
+                sample.name, sample.modification
+            ),
+            move |b| {
+                let layout = build_and_break(&sample.text, Some(MAX_ADVANCE));
+                let starts = spread_cursors(&layout, &sample.text, STARTS);
+                b.iter(move || black_box(walk_lines(&layout, &starts, LINE_STEPS)))
+            },
+        ));
+    }
+
+    // Two more cases, one of which tests the same as above but with a slightly bigger input, and
+    // the other shouldn't be too script-sensitive: let's just test with Latin to attempt keeping
+    // the number of cases somewhat in check...
+    let latin = get_samples()
+        .iter()
+        .find(|sample| sample.name == "latin" && sample.modification == "8000 characters")
+        .expect("the Latin 8000-character benchmark sample should exist");
+
+    // With longer lines, finding the caret's horizontal position walks more clusters per move.
+    benchmarks.push(benchmark_fn(
+        format!(
+            "Query Caret - {} {}, line down + up, long lines",
+            latin.name, latin.modification
+        ),
+        move |b| {
+            let layout = build_and_break(&latin.text, Some(WIDE_MAX_ADVANCE));
+            let starts = spread_cursors(&layout, &latin.text, STARTS);
+            b.iter(move || black_box(walk_lines(&layout, &starts, LINE_STEPS)))
+        },
+    ));
+
+    benchmarks.push(benchmark_fn(
+        format!(
+            "Query Caret - {} {}, from byte index",
+            latin.name, latin.modification
+        ),
+        move |b| {
+            let layout = build_and_break(&latin.text, Some(MAX_ADVANCE));
+            let indices = spread_byte_indices(&latin.text, STARTS);
+            b.iter(move || {
+                let mut cursors = 0;
+                for &index in &indices {
+                    cursors +=
+                        Cursor::from_byte_index(&layout, index, Affinity::Downstream).index();
+                }
+                black_box(cursors);
+            })
+        },
+    ));
+
+    benchmarks
+}


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Initial implementation, review.

This adds some benchmarks for `Cursor` navigation. (I'm working on `parley::layout::Cluster` improvements which should impact query and line breaking performance.)

We may want some more benchmarks (like selection geometry or hit-testing), so I started this in a new module to scope the possible future shared helpers.

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog: None**