### PR TITLE
Make `parley::Layout::Cluster` character-addressed

### DIFF
--- a/parley/src/editing/cursor.rs
+++ b/parley/src/editing/cursor.rs
@@ -4,7 +4,7 @@
 use crate::BoundingBox;
 use crate::layout::{Affinity, BreakReason, Cluster, ClusterSide, Layout, Line};
 #[cfg(feature = "accesskit")]
-use crate::layout::{ClusterPath, LayoutAccessibility};
+use crate::layout::{LayoutAccessibility, accessibility::run_start_path};
 use crate::style::Brush;
 
 #[cfg(feature = "accesskit")]
@@ -76,7 +76,9 @@ impl Cursor {
         let span_path = layout_access.span_paths_by_access_id.get(&pos.node)?;
         let run = span_path.run(layout)?;
         let index = run
-            .get(span_path.logical_index() + pos.character_index)
+            .clusters()
+            .skip_while(|cluster| cluster.path().char_index < span_path.char_index)
+            .nth(pos.character_index)
             .map(|cluster| cluster.text_range().start)
             .unwrap_or(layout.data.text_len);
         Some(Self::from_byte_index(layout, index, Affinity::Downstream))
@@ -409,10 +411,12 @@ impl Cursor {
         if layout.data.text_len == 0 {
             // If the text is empty, just return the first node with a
             // character index of 0.
+            let span_path = run_start_path(&layout.get(0)?.item(0)?.run()?);
+            let position = layout_access
+                .span_positions_by_cluster_path
+                .get(&span_path)?;
             return Some(TextPosition {
-                node: *layout_access
-                    .access_ids_by_span_path
-                    .get(&ClusterPath::new(0, 0, 0))?,
+                node: layout_access.span_id(position.span_index)?,
                 character_index: 0,
             });
         }
@@ -421,15 +425,15 @@ impl Cursor {
         // character index.
         let (offset, path) = self
             .downstream_cluster(layout)
-            .map(|cluster| (0, cluster.path))
+            .map(|cluster| (0, cluster.path()))
             .or_else(|| {
                 self.upstream_cluster(layout)
-                    .map(|cluster| (1, cluster.path))
+                    .map(|cluster| (1, cluster.path()))
             })?;
         // If we're at the end of the layout and the layout ends with a newline
         // then make sure we use the "phantom" run at the end so that
         // AccessKit has correct visual geometry for the cursor.
-        let (span_path, character_index) = if self.index == layout.data.text_len
+        let (span_index, character_index) = if self.index == layout.data.text_len
             && layout
                 .data
                 .shaped_text
@@ -438,17 +442,20 @@ impl Cursor {
                 .map(|character| character.info.whitespace() == Whitespace::Newline)
                 .unwrap_or_default()
         {
-            (ClusterPath::new(path.line_index + 1, 0, 0), 0)
+            let run = layout.get(path.line_index() + 1)?.item(0)?.run()?;
+            let position = layout_access
+                .span_positions_by_cluster_path
+                .get(&run_start_path(&run))?;
+            (position.span_index, 0)
         } else {
-            let span_path = layout_access.span_paths_by_cluster_path.get(&path).unwrap();
-            (
-                *span_path,
-                path.logical_index() - span_path.logical_index() + offset,
-            )
+            let position = layout_access
+                .span_positions_by_cluster_path
+                .get(&path)
+                .unwrap();
+            (position.span_index, position.character_index + offset)
         };
-        let id = layout_access.access_ids_by_span_path.get(&span_path)?;
         Some(TextPosition {
-            node: *id,
+            node: layout_access.span_id(span_index)?,
             character_index,
         })
     }

--- a/parley/src/layout/accessibility.rs
+++ b/parley/src/layout/accessibility.rs
@@ -7,7 +7,7 @@ use alloc::{
 };
 
 use accesskit::{Node, NodeId, Role, TextAlign, TextDirection, TreeUpdate};
-use hashbrown::{HashMap, HashSet};
+use hashbrown::HashMap;
 use skrifa::{
     FontRef,
     raw::{TableProvider, types::NameId},
@@ -58,44 +58,58 @@ pub struct LayoutAccessibility {
     // We define a span as a sequence of clusters, in logical order, that all
     // have an identical style. For each span we create an AccessKit node
     // with the `TextRun` role, and these nodes are in logical order.
-    // The following two fields maintain a two-way mapping between spans
-    // and AccessKit node IDs, where each span is identified by the path to
-    // its first cluster, or a span path for short. These maps are maintained by
-    // `LayoutAccess::build_nodes`, which ensures that removed spans are removed
-    // from the maps on the next accessibility pass.
-    pub(crate) access_ids_by_span_path: HashMap<ClusterPath, NodeId>,
+    //
+    // The following two fields maintain a mapping between spans and AccessKit
+    // node IDs. Each span is identified by its index in the logical order of
+    // spans. The nth span is given the nth ID from the following list, which
+    // is kept across accessibility passes.
+    span_ids: Vec<NodeId>,
+    // Map from node ID to the path of the span's first cluster.
     pub(crate) span_paths_by_access_id: HashMap<NodeId, ClusterPath>,
-    // Map from cluster path to span path. This allows `Cursor::to_access_position`
-    // to complete in O(1), rather than worst-case O(n) where n is the length
-    // of the run. It also means that the logic for when to start a new span,
-    // including the limitation on the number of characters per span,
-    // only needs to live in `LayoutAccess::build_nodes`.
-    pub(crate) span_paths_by_cluster_path: HashMap<ClusterPath, ClusterPath>,
+    // Map from cluster path to the cluster's position within its span. This
+    // allows `Cursor::to_access_position` to complete in O(1), rather than
+    // worst-case O(n) where n is the length of the run. It also means that the
+    // logic for when to start a new span, including the limitation on the
+    // number of characters per span, only needs to live in
+    // `LayoutAccess::build_nodes`.
+    pub(crate) span_positions_by_cluster_path: HashMap<ClusterPath, SpanPosition>,
+}
+
+/// The position of a cluster within its accessibility span.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct SpanPosition {
+    /// The index of the span in logical order.
+    pub(crate) span_index: usize,
+    /// The index of the cluster within the span's characters.
+    pub(crate) character_index: usize,
 }
 
 impl LayoutAccessibility {
+    /// Returns the node ID of the span with the given logical index.
+    pub(crate) fn span_id(&self, span_index: usize) -> Option<NodeId> {
+        self.span_ids.get(span_index).copied()
+    }
+
     fn span_id_and_node<B: Brush>(
         &mut self,
         next_node_id: &mut impl FnMut() -> NodeId,
-        ids: &mut HashSet<NodeId>,
+        span_index: usize,
         run: &Run<'_, B>,
         span_path: ClusterPath,
     ) -> (NodeId, Node) {
-        // If we encountered this same span path in the previous
+        // If we encountered this same span index in the previous
         // accessibility pass, reuse the same AccessKit ID. Otherwise,
         // allocate a new one. This enables stable node IDs when merely
         // updating the content of existing spans.
-        let id = self
-            .access_ids_by_span_path
-            .get(&span_path)
-            .copied()
-            .unwrap_or_else(|| {
+        let id = match self.span_ids.get(span_index) {
+            Some(id) => *id,
+            None => {
                 let id = (*next_node_id)();
-                self.access_ids_by_span_path.insert(span_path, id);
-                self.span_paths_by_access_id.insert(id, span_path);
+                self.span_ids.push(id);
                 id
-            });
-        ids.insert(id);
+            }
+        };
+        self.span_paths_by_access_id.insert(id, span_path);
         let mut node = Node::new(Role::TextRun);
         node.set_text_direction(if run.is_rtl() {
             TextDirection::RightToLeft
@@ -160,13 +174,15 @@ impl LayoutAccessibility {
         y_offset: f64,
         set_brush_properties: impl Fn(&mut Node, &Style<B>),
     ) {
-        self.span_paths_by_cluster_path.clear();
-        // Build a set of node IDs for the runs encountered in this pass.
-        let mut ids = HashSet::<NodeId>::new();
+        self.span_paths_by_access_id.clear();
+        self.span_positions_by_cluster_path.clear();
+        // The number of spans started so far, which is also the logical index
+        // of the next span to start.
+        let mut spans_started = 0;
         // Reuse scratch space for storing a sorted list of runs.
         let mut runs = Vec::new();
 
-        for (line_index, line) in layout.lines().enumerate() {
+        for line in layout.lines() {
             let metrics = line.metrics();
             // Defer adding each run node until we reach either the next run
             // or the end of the line. That way, we can set relations between
@@ -189,9 +205,21 @@ impl LayoutAccessibility {
             runs.sort_by_key(|(r, _)| r.text_range().start);
 
             for (run, run_offset) in runs.drain(..) {
-                let mut span_path = ClusterPath::new(line_index as u32, run.index() as u32, 0);
+                let mut span_path = run_start_path(&run);
                 let (mut id, mut node) =
-                    self.span_id_and_node(&mut next_node_id, &mut ids, &run, span_path);
+                    self.span_id_and_node(&mut next_node_id, spans_started, &run, span_path);
+                spans_started += 1;
+                if run.is_empty() {
+                    // For empty runs, record the run's start so that a cursor in it can still be
+                    // addressed.
+                    self.span_positions_by_cluster_path.insert(
+                        span_path,
+                        SpanPosition {
+                            span_index: spans_started - 1,
+                            character_index: 0,
+                        },
+                    );
+                }
 
                 if let Some((last_id, mut last_node)) = last_node.take() {
                     link_spans(last_id, &mut last_node, id, &mut node);
@@ -240,10 +268,11 @@ impl LayoutAccessibility {
                                 span_path = cluster.path();
                                 let (new_id, mut new_node) = self.span_id_and_node(
                                     &mut next_node_id,
-                                    &mut ids,
+                                    spans_started,
                                     &run,
                                     span_path,
                                 );
+                                spans_started += 1;
                                 link_spans(old_id, &mut old_node, new_id, &mut new_node);
                                 add_span(update, parent_node, old_id, old_node);
                                 (new_id, new_node)
@@ -265,12 +294,19 @@ impl LayoutAccessibility {
                     if cluster.is_word_boundary() && !cluster.is_space_or_nbsp() {
                         word_starts.push(character_lengths.len() as _);
                     }
+                    let character_index = character_lengths.len();
                     character_lengths.push(cluster_text.len() as _);
                     character_positions.push(span_advance);
                     character_widths.push(cluster.advance());
                     span_advance += cluster.advance();
-                    self.span_paths_by_cluster_path
-                        .insert(cluster.path(), span_path);
+                    self.span_positions_by_cluster_path.insert(
+                        cluster.path(),
+                        SpanPosition {
+                            // The current span is the last one started.
+                            span_index: spans_started - 1,
+                            character_index,
+                        },
+                    );
                 }
 
                 finish_span(
@@ -294,14 +330,14 @@ impl LayoutAccessibility {
                 add_span(update, parent_node, id, node);
             }
         }
-
-        // Remove mappings for spans that no longer exist.
-        self.span_paths_by_access_id.retain(|access_id, span_path| {
-            let keep = ids.contains(access_id);
-            if !keep {
-                self.access_ids_by_span_path.remove(span_path);
-            }
-            keep
-        });
     }
+}
+
+/// The path of `run`'s first cluster, used as the path of its first accessibility span.
+pub(crate) fn run_start_path<B: Brush>(run: &Run<'_, B>) -> ClusterPath {
+    ClusterPath::new(
+        run.line_index,
+        run.index,
+        run.line_slice().char_range().start,
+    )
 }

--- a/parley/src/layout/cluster.rs
+++ b/parley/src/layout/cluster.rs
@@ -22,7 +22,6 @@ use parley_engine::{Atom, Glyph, Grapheme, shape::Whitespace};
 ///
 /// [uax-grapheme]: https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries
 pub struct Cluster<'a, B: Brush> {
-    pub(crate) path: ClusterPath,
     pub(crate) run: Run<'a, B>,
     /// The atom containing this grapheme.
     pub(crate) atom: Atom<'a>,
@@ -52,19 +51,10 @@ pub enum ClusterSide {
 impl<'a, B: Brush> Cluster<'a, B> {
     /// Returns the cluster for the given layout and byte index.
     pub fn from_byte_index(layout: &'a Layout<B>, byte_index: usize) -> Option<Self> {
-        if let Some((_, line)) = layout.line_for_byte_index(byte_index) {
-            for run in line.runs() {
-                if !run.text_range().contains(&byte_index) {
-                    continue;
-                }
-                for cluster in run.clusters() {
-                    if cluster.text_range().contains(&byte_index) {
-                        return Some(cluster);
-                    }
-                }
-            }
-        }
-        None
+        let (_, line) = layout.line_for_byte_index(byte_index)?;
+        line.runs()
+            .filter(|run| run.text_range().contains(&byte_index))
+            .find_map(|run| run.cluster_at_text_byte(byte_index))
     }
 
     /// Returns the cluster and side which is at the specified position in the given layout. If no cluster is
@@ -90,9 +80,9 @@ impl<'a, B: Brush> Cluster<'a, B> {
         y: f32,
         exact: bool,
     ) -> Option<(Self, ClusterSide)> {
-        let mut path = ClusterPath::default();
-        if let Some((line_index, line)) = layout.line_for_offset(y) {
-            path.line_index = line_index as u32;
+        let mut line_index = 0;
+        if let Some((index, line)) = layout.line_for_offset(y) {
+            line_index = index;
             let mut offset = line.metrics().offset + line.metrics().inline_min_coord;
             let last_run_index = line.len().saturating_sub(1);
             for item in line.items_nonpositioned() {
@@ -100,17 +90,12 @@ impl<'a, B: Brush> Cluster<'a, B> {
                     LineItem::Run(run) => {
                         let is_last_run = run.index as usize == last_run_index;
                         let run_advance = run.advance();
-                        path.run_index = run.index;
-                        path.logical_index = 0;
                         if x > offset + run_advance && (exact || !is_last_run) {
                             offset += run_advance;
                             continue;
                         }
-                        let last_cluster_index = run.cluster_range().len().saturating_sub(1);
-                        for (visual_index, cluster) in run.visual_clusters().enumerate() {
-                            let is_last_cluster = is_last_run && visual_index == last_cluster_index;
-                            path.logical_index =
-                                run.visual_to_logical(visual_index).unwrap_or_default() as u32;
+                        for cluster in run.visual_clusters() {
+                            let is_last_cluster = is_last_run && cluster.is_visual_last_in_run();
                             let cluster_advance = cluster.advance();
                             let edge = offset;
                             offset += cluster_advance;
@@ -135,7 +120,9 @@ impl<'a, B: Brush> Cluster<'a, B> {
             }
         }
         if y <= 0.0 && !exact {
-            Some((path.cluster(layout)?, ClusterSide::Left))
+            // Fall back to the first cluster of the line's first run.
+            let cluster = layout.get(line_index)?.item(0)?.run()?.clusters().next()?;
+            Some((cluster, ClusterSide::Left))
         } else {
             None
         }
@@ -151,10 +138,13 @@ impl<'a, B: Brush> Cluster<'a, B> {
         self.run
     }
 
-    /// Returns the path that contains the set of indices to reach the cluster
-    /// from a layout.
+    /// Returns the path to reach the cluster from a layout.
     pub fn path(&self) -> ClusterPath {
-        self.path
+        ClusterPath::new(
+            self.run.line_index,
+            self.run.index,
+            self.grapheme.char_range().start,
+        )
     }
 
     /// The first (logical) character of this cluster.
@@ -257,16 +247,35 @@ impl<'a, B: Brush> Cluster<'a, B> {
             .flatten()
     }
 
+    /// Whether this is the visually first cluster of its run.
+    fn is_visual_first_in_run(&self) -> bool {
+        let chars = self.run.line_slice().char_range();
+        if self.is_rtl() {
+            self.grapheme.char_range().end == chars.end
+        } else {
+            self.grapheme.char_range().start == chars.start
+        }
+    }
+
+    /// Whether this is the visually last cluster of its run.
+    fn is_visual_last_in_run(&self) -> bool {
+        let chars = self.run.line_slice().char_range();
+        if self.is_rtl() {
+            self.grapheme.char_range().start == chars.start
+        } else {
+            self.grapheme.char_range().end == chars.end
+        }
+    }
+
     /// Returns `true` if this cluster is at the beginning of a line.
     pub fn is_start_of_line(&self) -> bool {
-        self.path.run_index == 0 && self.run.logical_to_visual(self.path.logical_index()) == Some(0)
+        self.run.index == 0 && self.is_visual_first_in_run()
     }
 
     /// Returns `true` if this cluster is at the end of a line.
     pub fn is_end_of_line(&self) -> bool {
-        self.line().len().saturating_sub(1) == self.path.run_index()
-            && self.run.logical_to_visual(self.path.logical_index())
-                == Some(self.run.cluster_range().len().saturating_sub(1))
+        self.line().len().saturating_sub(1) == self.run.index as usize
+            && self.is_visual_last_in_run()
     }
 
     /// If the cluster as at the end of the line, returns the reason
@@ -279,16 +288,23 @@ impl<'a, B: Brush> Cluster<'a, B> {
         }
     }
 
+    /// The cluster logically following this one within the same run, if any.
+    fn next_in_run(&self) -> Option<Self> {
+        self.run
+            .cluster_containing_char(self.grapheme.char_range().end)
+    }
+
+    /// The cluster logically preceding this one within the same run, if any.
+    fn previous_in_run(&self) -> Option<Self> {
+        self.run
+            .cluster_containing_char(self.grapheme.char_range().start.checked_sub(1)?)
+    }
+
     /// Returns the cluster that follows this one in logical order.
     pub fn next_logical(&self) -> Option<Self> {
-        if self.path.logical_index() + 1 < self.run.cluster_range().len() {
+        if let Some(next) = self.next_in_run() {
             // Fast path: next cluster is in the same run
-            ClusterPath {
-                line_index: self.path.line_index,
-                run_index: self.path.run_index,
-                logical_index: self.path.logical_index + 1,
-            }
-            .cluster(self.run.layout)
+            Some(next)
         } else {
             let index = self.text_range().end;
             if index >= self.run.layout.data.text_len {
@@ -301,14 +317,9 @@ impl<'a, B: Brush> Cluster<'a, B> {
 
     /// Returns the cluster that precedes this one in logical order.
     pub fn previous_logical(&self) -> Option<Self> {
-        if self.path.logical_index > 0 {
+        if let Some(previous) = self.previous_in_run() {
             // Fast path: previous cluster is in the same run
-            ClusterPath {
-                line_index: self.path.line_index,
-                run_index: self.path.run_index,
-                logical_index: self.path.logical_index - 1,
-            }
-            .cluster(self.run.layout)
+            Some(previous)
         } else {
             Self::from_byte_index(self.run.layout, self.text_range().start.checked_sub(1)?)
         }
@@ -316,28 +327,28 @@ impl<'a, B: Brush> Cluster<'a, B> {
 
     /// Returns the cluster that follows this one in visual order.
     pub fn next_visual(&self) -> Option<Self> {
-        let layout = self.run.layout;
-        let run = self.run;
-        let visual_index = run.logical_to_visual(self.path.logical_index())?;
-        if let Some(cluster_index) = run.visual_to_logical(visual_index + 1) {
-            // Fast path: next visual cluster is in the same run
-            run.get(cluster_index)
+        // Fast path: next visual cluster is in the same run
+        let next = if self.is_rtl() {
+            self.previous_in_run()
+        } else {
+            self.next_in_run()
+        };
+        if let Some(next) = next {
+            Some(next)
         } else {
             // We just want to find the first line/run following this one that
             // contains any cluster.
-            let mut run_index = self.path.run_index() + 1;
-            for line_index in self.path.line_index()..layout.len() {
+            let layout = self.run.layout;
+            let mut run_index = self.run.index as usize + 1;
+            for line_index in self.run.line_index as usize..layout.len() {
                 let line = layout.get(line_index)?;
                 for run_index in run_index..line.len() {
-                    if let Some(run) = line.item(run_index).and_then(|item| item.run())
-                        && !run.cluster_range().is_empty()
+                    if let Some(cluster) = line
+                        .item(run_index)
+                        .and_then(|item| item.run())
+                        .and_then(|run| run.visual_clusters().next())
                     {
-                        return ClusterPath {
-                            line_index: line_index as u32,
-                            run_index: run_index as u32,
-                            logical_index: run.visual_to_logical(0)? as u32,
-                        }
-                        .cluster(layout);
+                        return Some(cluster);
                     }
                 }
                 // Restart at first run on next line
@@ -349,37 +360,28 @@ impl<'a, B: Brush> Cluster<'a, B> {
 
     /// Returns the cluster that precedes this one in visual order.
     pub fn previous_visual(&self) -> Option<Self> {
-        let visual_index = self.run.logical_to_visual(self.path.logical_index())?;
-        if let Some(cluster_index) = visual_index
-            .checked_sub(1)
-            .and_then(|visual_index| self.run.visual_to_logical(visual_index))
-        {
-            // Fast path: previous visual cluster is in the same run
-            ClusterPath {
-                line_index: self.path.line_index,
-                run_index: self.path.run_index,
-                logical_index: cluster_index as u32,
-            }
-            .cluster(self.run.layout)
+        // Fast path: previous visual cluster is in the same run
+        let previous = if self.is_rtl() {
+            self.next_in_run()
         } else {
-            // We just want to find the first line/run preceding this one that
-            // contains any cluster.
+            self.previous_in_run()
+        };
+        if let Some(previous) = previous {
+            Some(previous)
+        } else {
+            // To find the first line/run preceding this one that contains any cluster.
             let layout = self.run.layout;
-            let mut run_index = Some(self.path.run_index());
-            for line_index in (0..=self.path.line_index()).rev() {
+            let mut run_index = Some(self.run.index as usize);
+            for line_index in (0..=self.run.line_index as usize).rev() {
                 let line = layout.get(line_index)?;
                 let first_run = run_index.unwrap_or(line.len());
                 for run_index in (0..first_run).rev() {
-                    if let Some(run) = line.item(run_index).and_then(|item| item.run()) {
-                        let range = run.cluster_range();
-                        if !range.is_empty() {
-                            return ClusterPath {
-                                line_index: line_index as u32,
-                                run_index: run_index as u32,
-                                logical_index: run.visual_to_logical(range.len() - 1)? as u32,
-                            }
-                            .cluster(layout);
-                        }
+                    if let Some(cluster) = line
+                        .item(run_index)
+                        .and_then(|item| item.run())
+                        .and_then(|run| run.visual_clusters_rev().next())
+                    {
+                        return Some(cluster);
                     }
                 }
                 run_index = None;
@@ -441,17 +443,21 @@ impl<'a, B: Brush> Cluster<'a, B> {
     /// This cost of this function is roughly linear in the number of clusters
     /// on the containing line.
     pub fn visual_offset(&self) -> Option<f32> {
-        let line = self.path.line(self.run.layout)?;
+        let line = self.line();
         let mut offset = line.metrics().offset;
-        for run_index in 0..=self.path.run_index() {
+        for run_index in 0..=self.run.index as usize {
             let item = line.item(run_index)?;
             match item {
                 LineItem::Run(run) => {
-                    if run_index != self.path.run_index() {
+                    if run_index != self.run.index as usize {
                         offset += run.advance();
                     } else {
-                        let visual_index = run.logical_to_visual(self.path.logical_index())?;
-                        for cluster in run.visual_clusters().take(visual_index) {
+                        for cluster in run.visual_clusters() {
+                            if cluster.grapheme.char_range().start
+                                == self.grapheme.char_range().start
+                            {
+                                break;
+                            }
                             offset += cluster.advance();
                         }
                     }
@@ -496,15 +502,16 @@ impl Affinity {
 pub struct ClusterPath {
     pub(crate) line_index: u32,
     pub(crate) run_index: u32,
-    pub(crate) logical_index: u32,
+    /// The cluster's first (logical) character index.
+    pub(crate) char_index: u32,
 }
 
 impl ClusterPath {
-    pub(crate) fn new(line_index: u32, run_index: u32, logical_index: u32) -> Self {
+    pub(crate) fn new(line_index: u32, run_index: u32, char_index: u32) -> Self {
         Self {
             line_index,
             run_index,
-            logical_index,
+            char_index,
         }
     }
 
@@ -519,11 +526,6 @@ impl ClusterPath {
         self.run_index as usize
     }
 
-    /// Returns the logical index of the cluster within the owning run.
-    pub fn logical_index(&self) -> usize {
-        self.logical_index as usize
-    }
-
     /// Returns the line for this path and the specified layout.
     pub fn line<'a, B: Brush>(&self, layout: &'a Layout<B>) -> Option<Line<'a, B>> {
         layout.get(self.line_index())
@@ -536,7 +538,7 @@ impl ClusterPath {
 
     /// Returns the cluster for this path and the specified layout.
     pub fn cluster<'a, B: Brush>(&self, layout: &'a Layout<B>) -> Option<Cluster<'a, B>> {
-        self.run(layout)?.get(self.logical_index())
+        self.run(layout)?.cluster_containing_char(self.char_index)
     }
 }
 

--- a/parley/src/layout/data.rs
+++ b/parley/src/layout/data.rs
@@ -13,7 +13,7 @@ use core::ops::Range;
 use alloc::vec::Vec;
 use parlance::BidiLevel;
 use parley_engine::shape::Whitespace;
-use parley_engine::{Boundary, ShapedSlice, ShapedText};
+use parley_engine::{Boundary, ShapedText};
 
 /// `HarfRust`-based run data
 #[derive(Clone, Debug, PartialEq)]
@@ -90,31 +90,13 @@ pub(crate) struct LineItemData {
     ///
     /// The bounds are atom-aligned.
     pub(crate) shaped_cluster_range: Range<u32>,
-    /// This run's grapheme clusters on this line, as a range of grapheme indices relative to the
-    /// owning [`parley_engine::ShapedRun`].
-    pub(crate) grapheme_range: Range<usize>,
 }
 
 impl LineItemData {
-    pub(crate) fn is_text_run(&self) -> bool {
-        self.kind == LayoutItemKind::TextRun
-    }
-
     #[inline(always)]
     pub(crate) fn is_rtl(&self) -> bool {
         self.bidi_level.is_rtl()
     }
-}
-
-/// The number of graphemes in `slice`.
-///
-/// This is `O(n)` in the slice's characters.
-pub(crate) fn count_graphemes(slice: ShapedSlice<'_>) -> usize {
-    slice
-        .characters_in(slice.char_range())
-        .iter()
-        .filter(|character| character.grapheme_start)
-        .count()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/parley/src/layout/line_break.rs
+++ b/parley/src/layout/line_break.rs
@@ -10,7 +10,6 @@ use alloc::vec::Vec;
 use core_maths::CoreFloat;
 use parlance::BidiLevel;
 
-use crate::layout::data::count_graphemes;
 use crate::layout::spacing::{EffectiveSpacing, Justification, is_word_separator};
 use crate::layout::whitespace::{atom_hanging_advance, whitespace_can_hang};
 use crate::layout::{
@@ -1174,7 +1173,6 @@ impl<'a, B: Brush> BreakLines<'a, B> {
         {
             line.text_range = 0..0;
             line.shaped_cluster_range = 0..0;
-            line.grapheme_range = 0..0;
         }
     }
 
@@ -1249,8 +1247,6 @@ impl<'a, B: Brush> BreakLines<'a, B> {
             {
                 let run_index = self.lines.line_items.len();
                 let cluster = run.shaped_clusters_range.end;
-                let grapheme =
-                    count_graphemes(self.layout.data.shaped_text.run_slice(index as u32));
                 let text = run.range.byte_range.end;
                 self.lines.line_items.push(LineItemData {
                     kind: LayoutItemKind::TextRun,
@@ -1258,7 +1254,6 @@ impl<'a, B: Brush> BreakLines<'a, B> {
                     bidi_level: BidiLevel::new(0),
                     advance: 0.,
                     shaped_cluster_range: cluster..cluster,
-                    grapheme_range: grapheme..grapheme,
                     text_range: text..text,
                 });
                 line.item_range = run_index..run_index + 1;
@@ -1393,7 +1388,6 @@ fn commit_line<B: Brush>(
 
                     // These properties are ignored for inline boxes. So we just put a dummy value.
                     shaped_cluster_range: 0..0,
-                    grapheme_range: 0..0,
                     text_range: 0..0,
                 });
 
@@ -1422,38 +1416,15 @@ fn commit_line<B: Brush>(
                 last_item_kind = item.kind;
                 committed_text_run = true;
 
-                // Map the cluster range to source-text and grapheme ranges. Line boundaries are
-                // always aligned to `Atom`s, i.e., line bounds are always grapheme bounds.
-                //
-                // Because counting graphemes is `O(n)`, and for runs that are split across lines we
-                // would recount the prefix every time, we first check whether this line continues
-                // the run committed to the previous line. In that case, use its grapheme range end
-                // as our start.
-                //
-                // Perhaps this can be improved...
+                // Map the cluster range to the source-text range. Line boundaries are always
+                // aligned to `Atom`s, i.e., line bounds are always grapheme bounds.
                 let slice = shaped_text.run_slice(item.index as u32);
-                let grapheme_start =
-                    lines
-                        .line_items
-                        .iter()
-                        .rev()
-                        .find(|prev| prev.is_text_run())
-                        .filter(|prev| {
-                            prev.index == item.index
-                                && prev.shaped_cluster_range.end == cluster_range.start
-                        })
-                        .map(|prev| prev.grapheme_range.end)
-                        .unwrap_or_else(|| {
-                            count_graphemes(slice.narrow(
-                                shaped_run.shaped_clusters_range.start..cluster_range.start,
-                            ))
-                        });
-                let (item_text_range, grapheme_range) = if cluster_range.is_empty() {
+                let item_text_range = if cluster_range.is_empty() {
                     let char_pos = shaped_clusters[cluster_range.start as usize]
                         .chars_range()
                         .start;
                     let text_pos = slice.text_byte_at(char_pos);
-                    (text_pos..text_pos, grapheme_start..grapheme_start)
+                    text_pos..text_pos
                 } else {
                     let char_range = shaped_clusters[cluster_range.start as usize]
                         .chars_range()
@@ -1461,9 +1432,7 @@ fn commit_line<B: Brush>(
                         ..shaped_clusters[cluster_range.end as usize - 1]
                             .chars_range()
                             .end;
-                    let text_range = slice.text_byte_range(char_range.clone());
-                    let grapheme_len = count_graphemes(slice.narrow(cluster_range.clone()));
-                    (text_range, grapheme_start..grapheme_start + grapheme_len)
+                    slice.text_byte_range(char_range)
                 };
 
                 // Compute the text range for the line
@@ -1486,7 +1455,6 @@ fn commit_line<B: Brush>(
                     bidi_level: shaped_run.bidi_level,
                     advance,
                     shaped_cluster_range: cluster_range,
-                    grapheme_range,
                     text_range: item_text_range,
                 });
             }

--- a/parley/src/layout/mod.rs
+++ b/parley/src/layout/mod.rs
@@ -4,7 +4,7 @@
 //! Layout types.
 
 #[cfg(feature = "accesskit")]
-mod accessibility;
+pub(crate) mod accessibility;
 mod alignment;
 mod cluster;
 mod line;

--- a/parley/src/layout/run.rs
+++ b/parley/src/layout/run.rs
@@ -1,8 +1,8 @@
 // Copyright 2021 the Parley Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::layout::cluster::{Cluster, ClusterPath};
-use crate::layout::data::{LineItemData, RunData, count_graphemes};
+use crate::layout::cluster::Cluster;
+use crate::layout::data::{LineItemData, RunData};
 use crate::layout::layout::Layout;
 use crate::layout::spacing::{EffectiveSpacing, Gaps, Justification};
 use crate::style::Brush;
@@ -165,23 +165,33 @@ impl<'a, B: Brush> Run<'a, B> {
     /// The indices are grapheme cluster indices, relative to the shaped run this [`Run`] belongs
     /// to: for a run scoped to a line, this is the sub-range of the shaped run's clusters that fall
     /// on that line; otherwise it covers all of the shaped run's clusters.
+    ///
+    /// Note this counts the shaped run's clusters, so the cost is linear in the shaped run's
+    /// length.
     pub fn cluster_range(&self) -> Range<usize> {
-        self.line_data
-            .map(|d| d.grapheme_range.clone())
-            .unwrap_or_else(|| 0..count_graphemes(self.full_slice()))
+        let start = match self.line_data {
+            Some(line_data) => count_graphemes(self.full_slice().narrow(
+                self.shaped.shaped_clusters_range.start..line_data.shaped_cluster_range.start,
+            )),
+            None => 0,
+        };
+        start..start + self.len()
     }
 
     /// Returns the number of clusters in the run.
+    ///
+    /// Note this counts the run's clusters, so the cost is linear in the run's length. To check
+    /// whether the run has any clusters, use [`Self::is_empty`].
     pub fn len(&self) -> usize {
-        self.cluster_range().len()
+        count_graphemes(self.line_slice())
     }
 
     /// Returns `true` if the run is empty.
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.line_slice().shaped_clusters_range().is_empty()
     }
 
-    /// Returns the cluster at the specified index.
+    /// Returns the cluster at the specified logical index.
     ///
     /// Note this walks the run's clusters, so the cost is `O(index)`.
     pub fn get(&self, index: usize) -> Option<Cluster<'a, B>> {
@@ -193,41 +203,47 @@ impl<'a, B: Brush> Run<'a, B> {
         Clusters::new(*self, false)
     }
 
-    /// Returns the visual cluster index for the specified logical cluster index.
-    pub fn logical_to_visual(&self, logical_index: usize) -> Option<usize> {
-        let num_clusters = self.len();
-        if logical_index >= num_clusters {
-            return None;
-        }
-
-        let visual_index = if self.is_rtl() {
-            num_clusters - 1 - logical_index
-        } else {
-            logical_index
-        };
-
-        Some(visual_index)
-    }
-
-    /// Returns the logical cluster index for the specified visual cluster index.
-    pub fn visual_to_logical(&self, visual_index: usize) -> Option<usize> {
-        let num_clusters = self.len();
-        if visual_index >= num_clusters {
-            return None;
-        }
-
-        let logical_index = if self.is_rtl() {
-            num_clusters - 1 - visual_index
-        } else {
-            visual_index
-        };
-
-        Some(logical_index)
-    }
-
     /// Returns an iterator over the clusters in visual order.
     pub fn visual_clusters(&self) -> impl Iterator<Item = Cluster<'a, B>> + Clone + use<'a, B> {
         Clusters::new(*self, self.is_rtl())
+    }
+
+    /// Returns an iterator over the clusters in reverse visual order.
+    pub(crate) fn visual_clusters_rev(
+        &self,
+    ) -> impl Iterator<Item = Cluster<'a, B>> + Clone + use<'a, B> {
+        Clusters::new(*self, !self.is_rtl())
+    }
+
+    /// The cluster containing the character at `char_index`.
+    ///
+    /// Returns `None` if `char_index` is not within this run.
+    pub(crate) fn cluster_containing_char(&self, char_index: u32) -> Option<Cluster<'a, B>> {
+        let atom = self.line_slice().atom_at_char(char_index)?;
+        let grapheme = atom
+            .graphemes_start()
+            .find(|grapheme| grapheme.char_range().contains(&char_index))?;
+        Some(Cluster {
+            run: *self,
+            atom,
+            grapheme,
+        })
+    }
+
+    /// The cluster containing the source text byte at `text_byte`.
+    ///
+    /// Returns `None` if `text_byte` is not within this run.
+    pub(crate) fn cluster_at_text_byte(&self, text_byte: usize) -> Option<Cluster<'a, B>> {
+        let slice = self.line_slice();
+        let atom = slice.atom_at_text_byte(u32::try_from(text_byte).ok()?)?;
+        let grapheme = atom
+            .graphemes_start()
+            .find(|grapheme| slice.text_byte_range(grapheme.char_range()).end > text_byte)?;
+        Some(Cluster {
+            run: *self,
+            atom,
+            grapheme,
+        })
     }
 
     /// An iterator over the glyphs in `shaped_clusters` in visual left-to-right order.
@@ -356,9 +372,6 @@ struct Clusters<'a, B: Brush> {
     graphemes: Graphemes<'a>,
     /// The atom containing the most recently yielded grapheme; `None` before the first grapheme.
     atom: Option<Atom<'a>>,
-    /// In forward iteration, the logical index of the cluster yielded next; in reverse
-    /// iteration, one past that index.
-    logical_index: usize,
     /// Whether iteration is in reverse logical order.
     rev: bool,
 }
@@ -379,7 +392,6 @@ impl<'a, B: Brush> Clusters<'a, B> {
                 slice.graphemes_start()
             },
             atom: None,
-            logical_index: if rev { run.len() } else { 0 },
             rev,
         }
     }
@@ -392,7 +404,6 @@ impl<B: Brush> Clone for Clusters<'_, B> {
             atoms: self.atoms,
             graphemes: self.graphemes,
             atom: self.atom,
-            logical_index: self.logical_index,
             rev: self.rev,
         }
     }
@@ -401,7 +412,6 @@ impl<B: Brush> Clone for Clusters<'_, B> {
 impl<'a, B: Brush> Iterator for Clusters<'a, B> {
     type Item = Cluster<'a, B>;
 
-    #[expect(clippy::cast_possible_truncation, reason = "deferred")]
     fn next(&mut self) -> Option<Self::Item> {
         let grapheme = if self.rev {
             self.graphemes.prev()?
@@ -423,19 +433,21 @@ impl<'a, B: Brush> Iterator for Clusters<'a, B> {
         let atom = self.atom.expect(
             "The first call to `next` should always be an atom edge, so this should always be set at this point.",
         );
-        let logical_index = if self.rev {
-            self.logical_index -= 1;
-            self.logical_index
-        } else {
-            let index = self.logical_index;
-            self.logical_index += 1;
-            index
-        };
         Some(Cluster {
-            path: ClusterPath::new(self.run.line_index, self.run.index, logical_index as u32),
             run: self.run,
             atom,
             grapheme,
         })
     }
+}
+
+/// The number of graphemes in `slice`.
+///
+/// This is `O(n)` in the slice's characters.
+fn count_graphemes(slice: ShapedSlice<'_>) -> usize {
+    slice
+        .characters()
+        .iter()
+        .filter(|character| character.grapheme_start)
+        .count()
 }

--- a/parley_tests/tests/cursor.rs
+++ b/parley_tests/tests/cursor.rs
@@ -6,11 +6,13 @@
 // TODO: these should use the create_font_context helper to avoid introducing
 // accidental dependencies on system fonts
 
+use core::{iter::successors, ops::Range};
+
 use crate::{
     test_name,
-    util::{CursorTest, TestEnv, env::create_font_context},
+    util::{ColorBrush, CursorTest, TestEnv, env::create_font_context},
 };
-use parley::{Affinity, Cursor, LayoutContext, Selection};
+use parley::{Affinity, Cluster, ClusterPath, Cursor, LayoutContext, Selection};
 
 #[test]
 fn cursor_previous_visual() {
@@ -65,4 +67,88 @@ fn cursor_ligature_selection() {
     let clusters = focus.logical_clusters(&layout);
 
     assert_eq!(clusters[0].as_ref().map(|c| c.text_range()), Some(1..2));
+}
+
+/// Check consistency of cluster paths, navigation, and lookups.
+fn check_cluster_navigation(text: &str, max_advance: Option<f32>) {
+    let mut env = TestEnv::new(test_name!(), None);
+    let mut layout = env.ranged_builder(text).build(text);
+    layout.break_all_lines(max_advance);
+
+    fn key(cluster: &Cluster<'_, ColorBrush>) -> (ClusterPath, Range<usize>) {
+        (cluster.path(), cluster.text_range())
+    }
+
+    /// Checks that stepping from the first of `expected` visits exactly `expected`, in order.
+    fn walk<'a>(
+        expected: &[Cluster<'a, ColorBrush>],
+        step: impl FnMut(&Cluster<'a, ColorBrush>) -> Option<Cluster<'a, ColorBrush>>,
+        name: &str,
+    ) {
+        let walked = successors(expected.first().cloned(), step);
+        let walked: Vec<_> = walked.map(|cluster| key(&cluster)).collect();
+        let expected: Vec<_> = expected.iter().map(key).collect();
+        assert_eq!(walked, expected, "{name}");
+    }
+
+    // Every cluster in the layout, in logical and in visual order.
+    let mut logical = Vec::new();
+    let mut visual = Vec::new();
+    for line in layout.lines() {
+        let on_line: Vec<_> = line.runs().flat_map(|run| run.visual_clusters()).collect();
+        for (i, cluster) in on_line.iter().enumerate() {
+            assert_eq!(cluster.is_start_of_line(), i == 0, "line start");
+            assert_eq!(cluster.is_end_of_line(), i + 1 == on_line.len(), "line end");
+        }
+        for run in line.runs() {
+            let run_logical_clusters: Vec<_> = run.clusters().collect();
+            for cluster in &run_logical_clusters {
+                let expected = key(cluster);
+                let by_path = cluster.path().cluster(&layout);
+                assert_eq!(
+                    by_path.as_ref().map(key).unwrap(),
+                    expected,
+                    "path round trip"
+                );
+                for byte in cluster.text_range() {
+                    let by_byte = Cluster::from_byte_index(&layout, byte);
+                    assert_eq!(by_byte.as_ref().map(key).unwrap(), expected, "byte {byte}");
+                }
+            }
+            let run_visual_clusters: Vec<_> = run.visual_clusters().collect();
+            let mut expected: Vec<_> = run_logical_clusters.iter().map(key).collect();
+            if run.is_rtl() {
+                expected.reverse();
+            }
+            assert_eq!(
+                run_visual_clusters.iter().map(key).collect::<Vec<_>>(),
+                expected
+            );
+            logical.extend(run_logical_clusters);
+            visual.extend(run_visual_clusters);
+        }
+    }
+    logical.sort_by_key(|cluster| cluster.text_range().start);
+
+    walk(&logical, Cluster::next_logical, "forward logical");
+    walk(&visual, Cluster::next_visual, "forward visual");
+    logical.reverse();
+    visual.reverse();
+    walk(&logical, Cluster::previous_logical, "backward logical");
+    walk(&visual, Cluster::previous_visual, "backward visual");
+}
+
+#[test]
+fn cluster_navigation_mixed_directions_and_ligatures() {
+    check_cluster_navigation("Hello Ligature: fi, Arabic: حداً", Some(60.0));
+}
+
+#[test]
+fn cluster_navigation_hard_breaks_and_trailing_newline() {
+    check_cluster_navigation("AAA \nااااا\nfi\n", None);
+}
+
+#[test]
+fn cluster_navigation_multi_character_graphemes() {
+    check_cluster_navigation("e\u{0301}x 🇳🇱 a\r\nb", None);
 }

--- a/parley_tests/tests/cursor.rs
+++ b/parley_tests/tests/cursor.rs
@@ -116,14 +116,6 @@ fn check_cluster_navigation(text: &str, max_advance: Option<f32>) {
                 }
             }
             let run_visual_clusters: Vec<_> = run.visual_clusters().collect();
-            let mut expected: Vec<_> = run_logical_clusters.iter().map(key).collect();
-            if run.is_rtl() {
-                expected.reverse();
-            }
-            assert_eq!(
-                run_visual_clusters.iter().map(key).collect::<Vec<_>>(),
-                expected
-            );
             logical.extend(run_logical_clusters);
             visual.extend(run_visual_clusters);
         }


### PR DESCRIPTION
<!-- Please ensure that you have reviewed our LLM ("AI") policy at https://linebender.org/wiki/llm-policy/.

If you did not use any LLM tools, please replace `Unspecified` with `None`. -->
LLM Contributions: Investigation, initial implementation, review.

First: note this `Cluster` is effectively a grapheme, but with some caveats (see also
https://github.com/linebender/parley/pull/715/changes#r3693621362 for some prior discussion on its name).

`parley` currently addresses `Cluster` by line index, run index, and finally cluster/grapheme index within the run. That grapheme index is a bit troublesome, as grapheme positions are generally not needed unless a layout is actually queried, so it's not quite a first-class indexing mechanism. Currently, querying is quadratic in many places because of this.

This proposes replacing the cluster/grapheme index with the grapheme's starting character index. That stops us from needing to count graphemes in quite a few places. Note that we *could* store some grapheme map to get a similar speed-up, but that could itself become troublesome once we support graphemes spanning runs (i.e., one source grapheme may be in two or more runs, which isn't that trivial to map). Character indices don't have that problem, and don't require additional state. Most other places in the code use character indices already.

I've made a little bit of effort to ensure the AccessKit `NodeId`s remain stable under character insertion/deletion etc., but I've not gone too deep on that as the intention is to move that code out of `parley`: https://github.com/linebender/parley/pull/716.

# Performance

```
$ cargo bench --bench main -- compare ../target/benchmarks/main -t 4. --filter "*Break*"

Line Breaking - arabic 8000 characters, narrow              [ 150.9 us ... 134.9 us ]     -10.61%*
Line Breaking - arabic 8000 characters, wider               [ 111.3 us ...  91.0 us ]     -18.24%*
Line Breaking - arabic 8000 characters, unwrapped           [  94.1 us ...  75.9 us ]     -19.33%*
Line Breaking - latin 8000 characters, narrow               [ 106.6 us ... 100.8 us ]      -5.42%*
Line Breaking - latin 8000 characters, wider                [  60.4 us ...  57.7 us ]      -4.37%*
Line Breaking - latin 8000 characters, unwrapped            [  46.3 us ...  43.6 us ]      -5.73%*
Line Breaking - japanese 8000 characters, narrow            [ 151.8 us ... 134.1 us ]     -11.69%*
Line Breaking - japanese 8000 characters, wider             [ 113.4 us ...  95.9 us ]     -15.37%*
Line Breaking - japanese 8000 characters, unwrapped         [ 101.3 us ...  84.9 us ]     -16.25%*
Line Breaking - arabic 8000 characters, wrapped + spacing   [ 123.9 us ... 106.6 us ]     -13.92%*
Line Breaking - latin 8000 characters, wrapped + spacing    [  78.1 us ...  74.7 us ]      -4.42%*
Line Breaking - japanese 8000 characters, wrapped + spacing [ 125.6 us ... 110.6 us ]     -11.96%*
Page Break - arabic 8000 characters                         [  99.8 us ...  78.5 us ]     -21.31%*
Page Break - latin 8000 characters                          [  49.0 us ...  46.9 us ]      -4.12%*
Page Break - japanese 8000 characters                       [ 105.8 us ...  88.5 us ]     -16.35%*
```

```
$ cargo bench --bench main -- compare ../target/benchmarks/main -t 4. --filter "*Query*"

Query Cursor - arabic 8000 characters, next visual               [  47.7 us ...  35.7 us ]     -25.21%*
Query Cursor - latin 8000 characters, next visual                [ 333.7 us ...  42.0 us ]     -87.41%*
Query Cursor - japanese 8000 characters, next visual             [  64.6 us ...  37.3 us ]     -42.23%*
Query Cursor - arabic 8000 characters, line down + up            [  59.4 us ...  61.2 us ]      +3.07%*
Query Cursor - latin 8000 characters, line down + up             [ 325.1 us ... 234.6 us ]     -27.82%*
Query Cursor - japanese 8000 characters, line down + up          [  64.5 us ...  59.0 us ]      -8.47%*
Query Cursor - latin 8000 characters, line down + up, long lines [   3.1 ms ...   2.1 ms ]     -31.91%*
Query Cursor - latin 8000 characters, from byte index            [   7.3 us ... 795.0 ns ]     -89.04%*
```

<!--
If our users need to know about this change, please describe that in the quote block below.
What you write here will be edited by us later - it doesn't need to be perfect.
If this change doesn't need a changelog entry, please replace the next line with `**Changelog: None**`.
-->
**Changelog**

> ## Parley
> ### Changed
>
> - Breaking change: `ClusterPath::logical_index` was removed. You can resolve the path to a `Cluster` using `ClusterPath::cluster`. `ClusterPath` still provides the line and run indices, but should otherwise be treated as an opaque handle.
> - Breaking change: `Run::{logical_to_visual, visual_to_logical}` were removed. Use `Run::visual_clusters` or `Cluster::{next, previous}_visual` instead.
